### PR TITLE
Document proof surfaces in Lean source

### DIFF
--- a/BtcVerified/BitVM/BitCommitment.lean
+++ b/BtcVerified/BitVM/BitCommitment.lean
@@ -1,57 +1,98 @@
-namespace BtcVerified.BitVM.BitCommitment
+/-!
+  # Abstract BitVM bit commitments
 
-/--
-  A bit-level commitment primitive for the BitVM verification track.
+  This module models the smallest useful commitment primitive for the BitVM
+  verification track. The hash function is intentionally abstract: the point of
+  this leaf is not to verify SHA-256 or any concrete compression function, but
+  to state the protocol-level shape that any collision-resistant commitment
+  hash must satisfy.
 
-  This file intentionally keeps the hash function abstract. The first useful
-  proof surface is the protocol shape: opening one commitment to both bits is
-  exactly a collision/equivocation witness for the commitment hash.
+  A commitment is produced by hashing a bit together with a nonce. An
+  equivocation is a single commitment with two valid openings to distinct bits.
+  The checked proof spine is:
+
+  * distinct opened bits imply distinct openings;
+  * an equivocation therefore gives two distinct openings with the same digest,
+    i.e. a collision;
+  * if collisions are impossible, every pair of valid openings for a commitment
+    must open to the same bit.
+
+  This is deliberately tiny, but it fixes the vocabulary for later BitVM proof
+  packets: openings, equivocation, collision resistance, and binding.
 -/
 
+namespace BtcVerified.BitVM.BitCommitment
+
+/-- The committed payload is a bit. -/
 inductive Bit where
   | zero
   | one
   deriving DecidableEq, Repr
 
+/-- An opening reveals both the committed bit and the nonce used to commit it. -/
 structure Opening (Nonce : Type) where
   bit : Bit
   nonce : Nonce
 
+/--
+  If two openings reveal different bits, then the openings themselves are
+  different. This is the small structural fact that turns equivocation into a
+  collision witness.
+-/
 theorem diff_bits_diff_openings {Nonce: Type}
   (left right : Opening Nonce)
   (hdiff : left.bit ≠ right.bit) : left ≠ right := by
     exact mt (congrArg Opening.bit) hdiff
 
+/-- A commitment is just a digest value at this abstraction level. -/
 abbrev Commitment (Digest : Type) := Digest
 
+/-- Commits to a bit by hashing the bit together with a nonce. -/
 def commit (hash : Bit → Nonce → Digest) (bit : Bit) (nonce : Nonce) : Commitment Digest :=
   hash bit nonce
 
+/-- An opening verifies when recomputing the commitment yields the same digest. -/
 def verifies (hash : Bit → Nonce → Digest) (c : Commitment Digest)
     (opening : Opening Nonce) : Prop :=
   commit hash opening.bit opening.nonce = c
 
+/-- The opening used to create a commitment verifies for that commitment. -/
 theorem commit_verifies_identity
     (hash : Bit → Nonce → Digest) (bit : Bit) (nonce : Nonce) :
     verifies hash (commit hash bit nonce) ⟨bit, nonce⟩ := by
   rfl
 
+/-- A valid opening packages an opening together with its verification proof. -/
 structure ValidOpening (hash : Bit → Nonce → Digest) (c : Commitment Digest) where
   opening : Opening Nonce
   valid: verifies hash c opening
 
+/--
+  Equivocation means one commitment has two valid openings whose revealed bits
+  are distinct.
+-/
 structure Equivocation (hash : Bit → Nonce → Digest) where
   commitment : Commitment Digest
   left : ValidOpening hash commitment
   right : ValidOpening hash commitment
   bits_distinct : left.opening.bit ≠ right.opening.bit
 
+/--
+  A collision is two distinct openings that produce the same commitment digest
+  under the abstract hash.
+-/
 structure Collision (hash : Bit → Nonce → Digest) where
   left : Opening Nonce
   right : Opening Nonce
   distinct : left ≠ right
   same_digest : commit hash left.bit left.nonce = commit hash right.bit right.nonce
 
+/--
+  Extracts the concrete collision witness contained in an equivocation.
+
+  The two openings are distinct because they reveal different bits, and their
+  digests are equal because both verify against the same commitment.
+-/
 def collisionFromEquivocation
     (hash : Bit → Nonce → Digest)
     (equivocation : Equivocation hash) :
@@ -62,18 +103,30 @@ def collisionFromEquivocation
     exact diff_bits
     rw [left.valid, right.valid]
 
+/-- Every equivocation gives evidence that a collision exists. -/
 theorem equivocation_implies_collision
     (hash : Bit → Nonce → Digest)
     (equivocation : Equivocation hash) :
     Nonempty (Collision hash) := by
   exact ⟨collisionFromEquivocation hash equivocation⟩
 
+/-- Collision resistance says there are no collision witnesses for this hash. -/
 def CollisionResistant (hash : Bit → Nonce → Digest) : Prop := Collision hash → False
 
+/--
+  Binding says that any two valid openings for the same commitment must reveal
+  the same bit.
+-/
 def Binding (hash : Bit → Nonce → Digest) : Prop :=
   ∀ (c : Commitment Digest) (left right : ValidOpening hash c),
     left.opening.bit = right.opening.bit
 
+/--
+  Collision resistance implies binding for this abstract commitment scheme.
+
+  If two valid openings for one commitment revealed different bits, they would
+  form an equivocation, hence a collision. Collision resistance rules that out.
+-/
 theorem collision_resistant_hashes_are_binding
     (hash : Bit → Nonce → Digest)
     (hcr : CollisionResistant hash) :

--- a/BtcVerified/CompactSize.lean
+++ b/BtcVerified/CompactSize.lean
@@ -2,60 +2,95 @@ import Std.Tactic.BVDecide
 import Mathlib.Tactic.SplitIfs
 import Mathlib.Tactic.ApplyAt
 import Batteries.Tactic.Init
-/-
-  CompactSize (Bitcoin varint) encoder/decoder with roundtrip correctness
-  and canonicality.
+/-!
+  # Bitcoin CompactSize encoding
 
-  Encoding rules:
-    n < 253      → [n]
-    n < 2^16     → [0xFD, lo, hi]
-    n < 2^32     → [0xFE, b0, b1, b2, b3]
-    n < 2^64     → [0xFF, b0, b1, b2, b3, b4, b5, b6, b7]
+  This module formalizes Bitcoin's CompactSize variable-length integer
+  encoding over `UInt64`. CompactSize appears throughout Bitcoin
+  serialization, so this is a small but useful first leaf in a larger verified
+  Bitcoin protocol library.
 
-  Multi-byte fields are little-endian. A value must be encoded in the
-  shortest applicable form; non-canonical encodings (e.g. [0xFD, 0x01, 0x00]
-  for the value 1) are rejected by the decoder.
+  The encoder chooses one of four canonical forms:
+
+  * `n < 253`: one byte, `[n]`
+  * `n < 2^16`: marker `0xFD` followed by a little-endian `UInt16`
+  * `n < 2^32`: marker `0xFE` followed by a little-endian `UInt32`
+  * otherwise: marker `0xFF` followed by a little-endian `UInt64`
+
+  The decoder rejects non-canonical encodings, so values must appear in the
+  shortest applicable form. The main checked claims are:
+
+  * `decode_encode`: encoding and then decoding returns the original value,
+    preserving any following bytes as the unconsumed tail.
+  * `encode_length_le`: every canonical CompactSize encoding is at most
+    nine bytes.
+  * `decode_canonical`: every accepted byte string has a consumed prefix equal
+    to `encode n`, which rules out accepted non-canonical encodings.
 -/
 
 namespace BtcVerified.CompactSize
 
+/-- Encodes a `UInt16` in the two little-endian bytes used by CompactSize. -/
 def encode_u16_le (n : UInt16) : List UInt8 := [n.toUInt8, (n >>> 8).toUInt8]
+
+/-- Decodes two little-endian bytes into a `UInt16`. -/
 def decode_u16_le (b0 b1 : UInt8) : UInt16 := (b1.toUInt16 <<< 8) + b0.toUInt16
 
+/-- Decoding two bytes and encoding the result returns the original bytes. -/
 theorem encode_decode_u16_le (b0 b1 : UInt8) : encode_u16_le (decode_u16_le b0 b1) = [b0, b1] := by
   simp [encode_u16_le, decode_u16_le]
   bv_decide
+
+/-- Encoding and decoding a `UInt16` little-endian word returns the word. -/
 theorem decode_encode_u16_le (w : UInt16) :
     decode_u16_le w.toUInt8 (w >>> 8).toUInt8 = w := by
   simp [decode_u16_le]
   bv_decide
 
+/-- Encodes a `UInt32` as two little-endian `UInt16` chunks. -/
 def encode_u32_le (n : UInt32) : List UInt8 :=
   encode_u16_le n.toUInt16 ++ encode_u16_le (n >>> 16).toUInt16
+
+/-- Decodes two little-endian `UInt16` chunks into a `UInt32`. -/
 def decode_u32_le (w0 w1 : UInt16) : UInt32 := (w1.toUInt32 <<< 16) + w0.toUInt32
 
+/-- Decoding two chunks and encoding the result returns the original chunks. -/
 theorem encode_decode_u32_le (w0 w1 : UInt16) :
     encode_u32_le (decode_u32_le w0 w1) = encode_u16_le w0 ++ encode_u16_le w1 := by
   simp [encode_u32_le, decode_u32_le, encode_u16_le]
   bv_decide
+
+/-- Encoding and decoding a `UInt32` little-endian word returns the word. -/
 theorem decode_encode_u32_le (d : UInt32) :
     decode_u32_le d.toUInt16 (d >>> 16).toUInt16 = d := by
   simp [decode_u32_le]
   bv_decide
 
+/-- Encodes a `UInt64` as two little-endian `UInt32` chunks. -/
 def encode_u64_le (n : UInt64) : List UInt8 :=
   encode_u32_le n.toUInt32 ++ encode_u32_le (n >>> 32).toUInt32
+
+/-- Decodes two little-endian `UInt32` chunks into a `UInt64`. -/
 def decode_u64_le (d0 d1 : UInt32) : UInt64 := (d1.toUInt64 <<< 32) + d0.toUInt64
 
+/-- Decoding two chunks and encoding the result returns the original chunks. -/
 theorem encode_decode_u64_le (d0 d1 : UInt32) :
     encode_u64_le (decode_u64_le d0 d1) = encode_u32_le d0 ++ encode_u32_le d1 := by
   simp [decode_u64_le, encode_u64_le, encode_u32_le, encode_u16_le]
   bv_decide
+
+/-- Encoding and decoding a `UInt64` little-endian word returns the word. -/
 theorem decode_encode_u64_le (q : UInt64) :
     decode_u64_le q.toUInt32 (q >>> 32).toUInt32 = q := by
   simp [decode_u64_le]
   bv_decide
 
+/--
+  Canonically encodes a `UInt64` as Bitcoin CompactSize bytes.
+
+  The branch conditions implement the shortest-form rule: marker bytes are used
+  only when the value cannot fit in a shorter CompactSize form.
+-/
 def encode (n : UInt64) : List UInt8 :=
   if n < 253 then
     [n.toUInt8]
@@ -66,6 +101,12 @@ def encode (n : UInt64) : List UInt8 :=
   else
     0xFF :: encode_u64_le n
 
+/--
+  Decodes a CompactSize value from the front of a byte list.
+
+  On success, the result contains the decoded value and the unconsumed tail.
+  Non-canonical forms and incomplete inputs return `none`.
+-/
 def decode (bs : List UInt8) : Option (UInt64 × List UInt8) :=
   match bs with
   | [] => none
@@ -135,7 +176,12 @@ private theorem not_toUInt32_lt_two_pow_16 {n : UInt64}
     have h64 := UInt32.toUInt64_lt.mpr h
     simpa [toUInt32_toUInt64_eq_of_lt h32] using h64)
 
-/-- Every canonical encoding followed by arbitrary tail decodes back. -/
+/--
+  Round-trip correctness for canonical encodings.
+
+  Encoding `n` and appending arbitrary trailing bytes always decodes back to
+  `n`, leaving exactly those trailing bytes as the unconsumed tail.
+-/
 theorem decode_encode (n : UInt64) (xs : List UInt8) : decode (encode n ++ xs) = some (n, xs) := by
   have u8_u32_trans_expand : ∀ (x : UInt32), x.toUInt8 = x.toUInt16.toUInt8 := by bv_decide
   have u8_u64_trans_expand : ∀ (x : UInt64), x.toUInt8 = x.toUInt32.toUInt16.toUInt8 := by bv_decide
@@ -172,16 +218,18 @@ theorem decode_encode (n : UInt64) (xs : List UInt8) : decode (encode n ++ xs) =
     repeat rw [decode_encode_u64_le]
     exact ⟨UInt64.not_lt.mp h3, rfl⟩
 
-/-- Encoded forms fit in at most 9 bytes. -/
+/-- CompactSize encodings are bounded by the one marker byte plus eight data bytes. -/
 theorem encode_length_le (n : UInt64) :
     (encode n).length ≤ 9 := by
   unfold encode
   split_ifs <;> simp [encode_u16_le, encode_u32_le, encode_u64_le]
 
 /--
-  Canonicality: if the decoder accepts `bs`, the consumed prefix is exactly
-  the encoder's output for the returned value. Equivalently, non-canonical
-  encodings are rejected.
+  Canonicality of accepted parses.
+
+  If `decode` accepts `bs` as value `n` with tail `rest`, then `bs` is exactly
+  the canonical encoding of `n` followed by `rest`. Equivalently, every
+  accepted consumed prefix is the shortest CompactSize representation.
 -/
 theorem decode_canonical (bs : List UInt8) (n : UInt64) (rest : List UInt8) :
     decode bs = some (n, rest) →


### PR DESCRIPTION
## Summary
- Adds source-native documentation to the CompactSize proof leaf.
- Adds source-native documentation to the BitVM bit commitment proof leaf.
- Keeps documentation inside Lean source; no separate notes or docs infrastructure.

## Test
- lake build