### PR TITLE
Add transaction ids and the merkle commitment

### DIFF
--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -3,6 +3,7 @@ import BtcVerified.Serialize.Codec
 import BtcVerified.Serialize.WidthCast
 import BtcVerified.Serialize.CountedList
 import BtcVerified.Serialize.CompactSize
+import BtcVerified.Crypto.Collision
 import BtcVerified.Crypto.Hash256
 import BtcVerified.Crypto.Sha256
 import BtcVerified.Crypto.Merkle

--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -13,6 +13,7 @@ import BtcVerified.Transaction.WitnessStack
 import BtcVerified.Transaction.SegwitInput
 import BtcVerified.Transaction.TxBody
 import BtcVerified.Transaction.Tx
+import BtcVerified.Transaction.Txid
 import BtcVerified.Block.BlockHeader
 import BtcVerified.Block.Block
 import BtcVerified.BitVM.BitCommitment

--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -5,6 +5,7 @@ import BtcVerified.Serialize.CountedList
 import BtcVerified.Serialize.CompactSize
 import BtcVerified.Crypto.Hash256
 import BtcVerified.Crypto.Sha256
+import BtcVerified.Crypto.Merkle
 import BtcVerified.Script.Script
 import BtcVerified.Transaction.OutPoint
 import BtcVerified.Transaction.TxIn
@@ -16,4 +17,5 @@ import BtcVerified.Transaction.Tx
 import BtcVerified.Transaction.Txid
 import BtcVerified.Block.BlockHeader
 import BtcVerified.Block.Block
+import BtcVerified.Block.Commitment
 import BtcVerified.BitVM.BitCommitment

--- a/BtcVerified/Block/BlockHeader.lean
+++ b/BtcVerified/Block/BlockHeader.lean
@@ -64,6 +64,6 @@ instance instCodecBlockHeader : Codec BlockHeader :=
 /-- A block header encodes to exactly 80 bytes: the fixed size of the
 proof-of-work preimage. -/
 theorem BlockHeader.encode_length (h : BlockHeader) : (Codec.encode h).length = 80 := by
-  simp [Codec.encode, List.length_append, encodeBitVecLE_length]
+  simp [Codec.encode, List.length_append, encodeBitVecLE_length, Hash256.length_val]
 
 end BtcVerified

--- a/BtcVerified/Block/Commitment.lean
+++ b/BtcVerified/Block/Commitment.lean
@@ -1,0 +1,38 @@
+import BtcVerified.Block.Block
+import BtcVerified.Transaction.Txid
+import BtcVerified.Crypto.Merkle
+/-!
+  # The block's merkle commitment
+
+  The validity condition tying a block's header to its body: the transaction
+  ids form a canonical list whose merkle root is the header's `merkleRoot`.
+  Root equality alone is not enough — the padding ambiguity (CVE-2012-2459)
+  lets a non-canonical list share a canonical list's root — so consensus
+  demands canonicality of the list itself. Core enforces the same pair of
+  facts in `CheckBlock` via the duplicate scan fused into its root
+  computation; the two formulations agree on transaction-valid blocks
+  (`BtcVerified.Merkle`'s module header has the analysis).
+
+  The SegWit witness commitment — the wtxid merkle root committed in the
+  coinbase — is the next leaf, not this one.
+
+  Checked claims:
+
+  * `Block.merkleCommits` is decidable, so real blocks are checked against it
+    in the golden vectors and the `lake test` fixture.
+-/
+
+namespace BtcVerified
+
+/-- The merkle commitment a consensus-valid block satisfies: its transaction
+ids form a canonical list whose merkle root is the header's. With
+`Merkle.root_inj_of_canonical`, two such blocks sharing a header agree on
+their txid lists — or exhibit a concrete double-SHA-256 collision. -/
+def Block.merkleCommits (b : Block) : Prop :=
+  Merkle.Canonical (b.txs.val.map Tx.txid)
+    ∧ Merkle.computeRoot (b.txs.val.map Tx.txid) = b.header.merkleRoot
+
+instance : DecidablePred Block.merkleCommits := fun _ =>
+  inferInstanceAs (Decidable (_ ∧ _))
+
+end BtcVerified

--- a/BtcVerified/Crypto/Collision.lean
+++ b/BtcVerified/Crypto/Collision.lean
@@ -60,4 +60,19 @@ theorem CollisionResistant.comp {α β γ : Type*} {f : α → β} {g : β → �
     CollisionResistant (g ∘ f) :=
   fun hc => (Collision.comp hc).elim hf hg
 
+/-- A collision in the inner function lifts to a collision in the composite:
+the colliding inputs already agree under `f`, hence under `g ∘ f`. -/
+theorem Collision.comp_inner {α β γ : Type*} {f : α → β} {g : β → γ}
+    (hc : Collision f) : Collision (g ∘ f) := by
+  match hc with
+  | ⟨a, b, hab, h⟩ => exact ⟨a, b, hab, congrArg g h⟩
+
+/-- The partial dual of `CollisionResistant.comp`: resistance of `g ∘ f` forces
+resistance of the *inner* `f` (a collision in `f` would lift to one in the
+composite). It does **not** force resistance of the outer `g` — `g` may collide
+on values outside the range of `f`, where no composite input reaches. -/
+theorem CollisionResistant.of_comp {α β γ : Type*} {f : α → β} {g : β → γ}
+    (h : CollisionResistant (g ∘ f)) : CollisionResistant f :=
+  fun hc => h hc.comp_inner
+
 end BtcVerified

--- a/BtcVerified/Crypto/Collision.lean
+++ b/BtcVerified/Crypto/Collision.lean
@@ -1,0 +1,63 @@
+import Mathlib.Logic.Basic
+/-!
+  # Collisions and collision resistance of a function
+
+  The collision vocabulary, stated over an arbitrary function rather than any
+  particular hash. A collision is two distinct inputs with the same image;
+  collision resistance is the absence of one. Both are interesting independent
+  of which function appears — `sha256d`, a merkle node combiner, an abstract
+  commitment hash — so they live here once and specialize where needed.
+
+  Collision resistance is never an axiom over a concrete function (it is
+  provably false there by pigeonhole). It enters as a *hypothesis*, and from it
+  injectivity follows: a collision-resistant function is injective on the nose.
+  Composition is the other load-bearing fact — a collision in `g ∘ f` is a
+  collision in `f` or in `g` — which is exactly what carries collision
+  resistance through Bitcoin's double hashing.
+
+  Checked claims:
+
+  * `CollisionResistant.injective`: a collision-resistant function is injective.
+  * `Collision.comp`: a collision in `g ∘ f` yields a collision in `f` or `g`.
+  * `CollisionResistant.comp`: collision resistance of `f` and `g` gives
+    collision resistance of `g ∘ f`.
+-/
+
+namespace BtcVerified
+
+/-- A collision in `h`: two distinct inputs sharing an image. -/
+def Collision {α β : Type*} (h : α → β) : Prop := ∃ a b : α, a ≠ b ∧ h a = h b
+
+/-- `h` is collision-resistant when it has no collision. For a concrete function
+this is a hypothesis a caller supplies, never an axiom — it is provably false
+for any function out of an infinite domain into a finite one. -/
+def CollisionResistant {α β : Type*} (h : α → β) : Prop := ¬ Collision h
+
+/-- A collision-resistant function is injective: equal images force equal
+inputs. This is the bridge that turns the `… ∨ Collision` disjunct of the
+hashing faithfulness theorems into outright injectivity under a resistance
+hypothesis. -/
+theorem CollisionResistant.injective {α β : Type*} {h : α → β}
+    (hcr : CollisionResistant h) {a b : α} (hab : h a = h b) : a = b := by
+  by_cases hne : a = b
+  · exact hne
+  · exact absurd ⟨a, b, hne, hab⟩ hcr
+
+/-- A collision in `g ∘ f` is a collision in `f` (its inputs already collide
+under `f`) or in `g` (their distinct `f`-images collide under `g`). -/
+theorem Collision.comp {α β γ : Type*} {f : α → β} {g : β → γ}
+    (hc : Collision (g ∘ f)) : Collision f ∨ Collision g := by
+  match hc with
+  | ⟨a, b, hab, h⟩ =>
+    by_cases hf : f a = f b
+    · exact Or.inl ⟨a, b, hab, hf⟩
+    · exact Or.inr ⟨f a, f b, hf, h⟩
+
+/-- Collision resistance composes: if `f` and `g` are each collision-resistant,
+so is `g ∘ f`. -/
+theorem CollisionResistant.comp {α β γ : Type*} {f : α → β} {g : β → γ}
+    (hf : CollisionResistant f) (hg : CollisionResistant g) :
+    CollisionResistant (g ∘ f) :=
+  fun hc => (Collision.comp hc).elim hf hg
+
+end BtcVerified

--- a/BtcVerified/Crypto/Hash256.lean
+++ b/BtcVerified/Crypto/Hash256.lean
@@ -1,15 +1,51 @@
+import BtcVerified.Serialize.Codec
 /-!
   # The 256-bit hash type
 
   Txids, block hashes, and merkle nodes are all 256-bit digests; this fixes
-  the one type they share. Hashing itself stays abstract at this layer —
-  nothing here computes SHA-256, and nothing downstream may assume more about
-  a `Hash256` than its width.
+  the one type they share, together with the one rule for reading digest
+  bytes as a value: little-endian, so the displayed (big-endian) hex is the
+  digest bytes reversed — the interpretation Bitcoin's consensus arithmetic
+  uses everywhere.
+
+  Checked claims:
+
+  * `Hash256.ofBytesLE_encode` / `Hash256.encode_ofBytesLE`: on full 32-byte
+    digests, reading and the little-endian encoding are mutually inverse, so
+    `ofBytesLE` loses nothing on the inputs hashing produces.
 -/
 
 namespace BtcVerified
 
+open BtcVerified.Serialize
+
 /-- A 256-bit hash: txid, block hash, or merkle node. -/
 abbrev Hash256 := BitVec 256
+
+/-- Read a 256-bit hash off the front of a byte string, low byte first — the
+value Bitcoin's consensus arithmetic assigns to digest bytes (the displayed
+hex is these bytes reversed). Returns 0 when fewer than 32 bytes are
+supplied; every use site feeds a full digest, where `encode_ofBytesLE` makes
+the reading lossless. -/
+def Hash256.ofBytesLE (bs : List UInt8) : Hash256 :=
+  ((decodeBitVecLE 32 bs).map Prod.fst).getD 0
+
+/-- Reading back the 32-byte little-endian encoding of a hash returns the
+hash. -/
+theorem Hash256.ofBytesLE_encode (h : Hash256) :
+    Hash256.ofBytesLE (encodeBitVecLE 32 h) = h := by
+  have hd := decodeBitVecLE_encodeBitVecLE 32 h []
+  rw [List.append_nil] at hd
+  simp [Hash256.ofBytesLE, hd]
+
+/-- A 32-byte string is exactly the little-endian encoding of the hash read
+from it — `ofBytesLE` is injective on full digests. -/
+theorem Hash256.encode_ofBytesLE {bs : List UInt8} (hlen : bs.length = 32) :
+    encodeBitVecLE 32 (Hash256.ofBytesLE bs) = bs := by
+  obtain ⟨v, hv⟩ := decodeBitVecLE_of_le_length 32 bs (by omega)
+  rw [List.drop_eq_nil_of_le (by omega)] at hv
+  have hcanon := decodeBitVecLE_canonical 32 bs v [] hv
+  rw [List.append_nil] at hcanon
+  rw [hcanon, Hash256.ofBytesLE_encode]
 
 end BtcVerified

--- a/BtcVerified/Crypto/Hash256.lean
+++ b/BtcVerified/Crypto/Hash256.lean
@@ -2,50 +2,73 @@ import BtcVerified.Serialize.Codec
 /-!
   # The 256-bit hash type
 
-  Txids, block hashes, and merkle nodes are all 256-bit digests; this fixes
-  the one type they share, together with the one rule for reading digest
-  bytes as a value: little-endian, so the displayed (big-endian) hex is the
-  digest bytes reversed — the interpretation Bitcoin's consensus arithmetic
-  uses everywhere.
+  Txids, block hashes, and merkle nodes are all 256-bit digests; this fixes the
+  one type they share — as the 32 raw digest bytes, in the order SHA-256 emits
+  them, which is also the order they take on the wire. A digest is an identifier
+  you concatenate and compare for equality, never a number you do arithmetic on,
+  so the natural representation is bytes, not `BitVec 256`. The numeric reading
+  (and the only place endianness matters) is deferred to where a digest meets a
+  *target* in the proof-of-work check.
+
+  The familiar big-endian display hex is these bytes reversed; that reversal is
+  a display convention only, with no role in hashing or the wire codec — so it
+  lives in test helpers, not here. On the wire a hash is exactly its 32 bytes,
+  so its codec writes them as-is, with no little-endian step.
 
   Checked claims:
 
-  * `Hash256.ofBytesLE_encode` / `Hash256.encode_ofBytesLE`: on full 32-byte
-    digests, reading and the little-endian encoding are mutually inverse, so
-    `ofBytesLE` loses nothing on the inputs hashing produces.
+  * `instCodecHash256`: the hash codec round-trips and is canonical — 32 raw
+    bytes off the front.
 -/
 
 namespace BtcVerified
 
 open BtcVerified.Serialize
 
-/-- A 256-bit hash: txid, block hash, or merkle node. -/
-abbrev Hash256 := BitVec 256
+/-- A 256-bit hash — txid, block hash, or merkle node — as its 32 raw digest
+bytes (SHA-256 emission order, i.e. wire order; the display hex is reversed). -/
+abbrev Hash256 := { bytes : List UInt8 // bytes.length = 32 }
 
-/-- Read a 256-bit hash off the front of a byte string, low byte first — the
-value Bitcoin's consensus arithmetic assigns to digest bytes (the displayed
-hex is these bytes reversed). Returns 0 when fewer than 32 bytes are
-supplied; every use site feeds a full digest, where `encode_ofBytesLE` makes
-the reading lossless. -/
-def Hash256.ofBytesLE (bs : List UInt8) : Hash256 :=
-  ((decodeBitVecLE 32 bs).map Prod.fst).getD 0
+/-- The 32 raw digest bytes of a hash. -/
+@[reducible] def Hash256.bytes (h : Hash256) : List UInt8 := h.1
 
-/-- Reading back the 32-byte little-endian encoding of a hash returns the
-hash. -/
-theorem Hash256.ofBytesLE_encode (h : Hash256) :
-    Hash256.ofBytesLE (encodeBitVecLE 32 h) = h := by
-  have hd := decodeBitVecLE_encodeBitVecLE 32 h []
-  rw [List.append_nil] at hd
-  simp [Hash256.ofBytesLE, hd]
+/-- Build a hash from 32 raw bytes, when the length is right. -/
+def Hash256.ofBytes? (bs : List UInt8) : Option Hash256 :=
+  if h : bs.length = 32 then some ⟨bs, h⟩ else none
 
-/-- A 32-byte string is exactly the little-endian encoding of the hash read
-from it — `ofBytesLE` is injective on full digests. -/
-theorem Hash256.encode_ofBytesLE {bs : List UInt8} (hlen : bs.length = 32) :
-    encodeBitVecLE 32 (Hash256.ofBytesLE bs) = bs := by
-  obtain ⟨v, hv⟩ := decodeBitVecLE_of_le_length 32 bs (by omega)
-  rw [List.drop_eq_nil_of_le (by omega)] at hv
-  have hcanon := decodeBitVecLE_canonical 32 bs v [] hv
-  rw [List.append_nil] at hcanon
-  rw [hcanon, Hash256.ofBytesLE_encode]
+/-- Decode a hash: take 32 raw bytes off the front. -/
+def decodeHash256 (bs : List UInt8) : Option (Hash256 × List UInt8) :=
+  if h : 32 ≤ bs.length then
+    some (⟨bs.take 32, by rw [List.length_take]; omega⟩, bs.drop 32)
+  else none
+
+/-- A hash serializes as its 32 raw bytes, in wire order — no little-endian
+reinterpretation, because the stored bytes already are the wire bytes. -/
+instance instCodecHash256 : Codec Hash256 where
+  encode h := h.1
+  decode := decodeHash256
+  decode_encode h rest := by
+    have hlen : 32 ≤ (h.1 ++ rest).length := by rw [List.length_append, h.2]; omega
+    simp only [decodeHash256, dif_pos hlen, List.take_left' h.2, List.drop_left' h.2]
+  decode_canonical bs h rest hdec := by
+    simp only [decodeHash256] at hdec
+    split at hdec
+    · next hlen =>
+      rw [Option.some.injEq, Prod.mk.injEq] at hdec
+      obtain ⟨hh, hr⟩ := hdec
+      have hval : bs.take 32 = h.1 := congrArg Subtype.val hh
+      rw [← hr, ← hval, List.take_append_drop]
+    · exact absurd hdec (by simp)
+
+/-- A hash is exactly 32 bytes. -/
+@[simp] theorem Hash256.length_val (h : Hash256) : h.1.length = 32 := h.2
+
+/-- A hash encodes to exactly its 32 bytes. -/
+theorem Hash256.encode_length (h : Hash256) : (Codec.encode h).length = 32 := h.2
+
+/-- A natural number as a 256-bit hash, low byte first — distinct numbers give
+distinct hashes, which is all the synthetic test vectors need from it. -/
+instance (n : Nat) : OfNat Hash256 n :=
+  ⟨⟨encodeBitVecLE 32 (BitVec.ofNat (8 * 32) n), encodeBitVecLE_length 32 _⟩⟩
 
 end BtcVerified

--- a/BtcVerified/Crypto/Merkle.lean
+++ b/BtcVerified/Crypto/Merkle.lean
@@ -1,0 +1,551 @@
+import BtcVerified.Crypto.Hash256
+import BtcVerified.Crypto.Sha256
+import Mathlib.Data.Nat.Log
+/-!
+  # Bitcoin's merkle tree
+
+  The merkle root is how a block header commits to its transaction list:
+  leaves are txids, and each node is the double-SHA-256 of its two children's
+  digests. Bitcoin pads an odd level by hashing its last node with itself —
+  and that padding rule makes the construction famously non-injective
+  (CVE-2012-2459): a list that materializes part of its own padding as actual
+  content produces the same root as the shorter list it extends. Core rejects
+  such blocks with a uniform per-level duplicate-pair scan fused into its root
+  computation (its `mutated` flag). Here the concern is factored apart: the
+  root computation is one deterministic cryptographic operation, and
+  *canonicality* is a first-class, decidable property of the leaf list.
+
+  The spec is structural rather than procedural: `Tree` is built top-down by
+  bisection at the enclosing power of two, and procedural duplication is an
+  explicit constructor (`pad`, semantically a node with two equal children)
+  instead of an artifact of iteration order. The bottom-up fold Bitcoin
+  actually computes (`computeRoot`) is proved equal to the spec.
+
+  Canonicality constrains exactly what threatens injectivity and nothing
+  more. Padding only ever duplicates trailing power-of-two-aligned blocks —
+  the right spine — so a cross-length collision requires a trailing block
+  duplicating its left sibling, and `Canonical` forbids precisely that
+  (`Tree.spineCanonical`, root node exempt: a shorter list with the same
+  enclosing width must still split at the root). Core's uniform scan is
+  strictly stronger — it also rejects pair-aligned duplicates that no padding
+  could produce — but the two agree on transaction-valid blocks, where a
+  duplicated leaf means a duplicated txid: a self-double-spend or a collision.
+
+  Collision resistance is never assumed: theorems conclude with
+  `Sha256.Collision` — two concrete colliding byte strings — as a
+  constructed disjunct, and intractability is the consumer's hypothesis.
+
+  Known residual, documented not solved: equal *widths* are a hypothesis of
+  `root_inj_of_canonical`. Across widths, a 64-byte transaction whose
+  serialization equals the concatenation of two digests confuses a leaf with
+  an internal node (the SPV-grade ambiguity the Great Consensus Cleanup
+  proposes to close by forbidding 64-byte transactions). For block validity
+  the transaction count is in hand, so the hypothesis is free.
+
+  Checked claims:
+
+  * `computeRoot_eq_root`: the bottom-up fold computes the structural spec's
+    root.
+  * `root_inj_of_length_eq`: between equal-length lists, the root identifies
+    the list — or two concrete byte strings collide under double-SHA-256.
+  * `root_inj_of_canonical`: between canonical lists of equal enclosing
+    width, the root identifies the list — or a concrete collision. This is
+    the property the canonicality rule exists to restore.
+-/
+
+namespace BtcVerified.Merkle
+
+open BtcVerified.Serialize
+
+/-- A merkle node: the double-SHA-256 of the two children's digests, each
+serialized as its 32 little-endian bytes. -/
+def combine (l r : Hash256) : Hash256 :=
+  Hash256.ofBytesLE (Sha256.sha256d (encodeBitVecLE 32 l ++ encodeBitVecLE 32 r))
+
+/-- Equal merkle nodes have equal children — or their two 64-byte preimages
+collide under double-SHA-256. -/
+theorem combine_inj {l r l' r' : Hash256} (h : combine l r = combine l' r') :
+    (l = l' ∧ r = r') ∨ Sha256.Collision := by
+  by_cases hm : encodeBitVecLE 32 l ++ encodeBitVecLE 32 r
+      = encodeBitVecLE 32 l' ++ encodeBitVecLE 32 r'
+  · obtain ⟨h₁, h₂⟩ := List.append_inj hm (by rw [encodeBitVecLE_length, encodeBitVecLE_length])
+    exact Or.inl ⟨by simpa [Hash256.ofBytesLE_encode] using congrArg Hash256.ofBytesLE h₁,
+      by simpa [Hash256.ofBytesLE_encode] using congrArg Hash256.ofBytesLE h₂⟩
+  · refine Or.inr ⟨_, _, hm, ?_⟩
+    have hl := Hash256.encode_ofBytesLE (Sha256.sha256d_length
+      (encodeBitVecLE 32 l ++ encodeBitVecLE 32 r))
+    have hr := Hash256.encode_ofBytesLE (Sha256.sha256d_length
+      (encodeBitVecLE 32 l' ++ encodeBitVecLE 32 r'))
+    rw [← hl, ← hr]
+    exact congrArg (encodeBitVecLE 32) h
+
+/-! ## The structural spec -/
+
+/-- A Bitcoin merkle tree, with procedural duplication explicit: `pad t` is
+the node Bitcoin forms by hashing `t` with itself when a level runs out of
+content — semantically a `node t t`, kept distinguishable so the structure
+records which duplications the *construction* introduced. -/
+inductive Tree where
+  /-- A leaf: one txid. -/
+  | leaf (h : Hash256)
+  /-- An interior node over two materialized subtrees. -/
+  | node (l r : Tree)
+  /-- A padding node: the right child is a procedural copy of the left. -/
+  | pad (t : Tree)
+  deriving DecidableEq
+
+namespace Tree
+
+/-- The root hash: leaves are their own digest, and both node forms hash two
+children — a `pad` hashes its child with itself. -/
+def root : Tree → Hash256
+  | leaf h => h
+  | node l r => combine l.root r.root
+  | pad t => combine t.root t.root
+
+/-- The leaf sequence with all padding materialized: the `2 ^ k` leaves the
+hashing actually consumes at width `k`. -/
+def virtualLeaves : Tree → List Hash256
+  | leaf h => [h]
+  | node l r => l.virtualLeaves ++ r.virtualLeaves
+  | pad t => t.virtualLeaves ++ t.virtualLeaves
+
+end Tree
+
+/-- Build the width-`2 ^ k` tree over a slice, top-down: bisect while the
+content overflows the left half, pad once it fits. (Empty input degenerates
+to a `0` leaf; a Bitcoin block has at least its coinbase.) -/
+def ofList (xs : List Hash256) : Nat → Tree
+  | 0 => .leaf (xs.headD 0)
+  | k + 1 =>
+    if xs.length ≤ 2 ^ k then .pad (ofList xs k)
+    else .node (ofList (xs.take (2 ^ k)) k) (ofList (xs.drop (2 ^ k)) k)
+
+/-- The merkle tree of a leaf list, built at the enclosing power of two. -/
+def tree (xs : List Hash256) : Tree := ofList xs (Nat.clog 2 xs.length)
+
+/-- The merkle root of a leaf list (the structural spec). -/
+def root (xs : List Hash256) : Hash256 := (tree xs).root
+
+/-! ## The bottom-up computation -/
+
+/-- One level of Bitcoin's bottom-up fold: hash adjacent pairs, hashing an
+unpaired last node with itself. -/
+def foldLevel : List Hash256 → List Hash256
+  | [] => []
+  | [x] => [combine x x]
+  | x :: y :: rest => combine x y :: foldLevel rest
+
+/-- Each fold level halves the node count, rounding up. -/
+theorem foldLevel_length : ∀ xs : List Hash256, (foldLevel xs).length = (xs.length + 1) / 2
+  | [] => by simp [foldLevel]
+  | [_] => by simp [foldLevel]
+  | _ :: _ :: rest => by simp [foldLevel, foldLevel_length rest]; omega
+
+/-- The merkle root as Bitcoin computes it: fold levels bottom-up until one
+node remains. One deterministic cryptographic operation — canonicality of the
+input is `Canonical`'s concern, decided separately. (Core fuses a duplicate
+scan into this same pass under the name `mutated`; see the module header.) -/
+def computeRoot : List Hash256 → Hash256
+  | [] => 0
+  | [x] => x
+  | x :: y :: rest => computeRoot (foldLevel (x :: y :: rest))
+  termination_by xs => xs.length
+  decreasing_by simp [foldLevel_length]; omega
+
+/-- A fold level distributes over an append at an even boundary. -/
+theorem foldLevel_append : ∀ (as bs : List Hash256), as.length % 2 = 0 →
+    foldLevel (as ++ bs) = foldLevel as ++ foldLevel bs
+  | [], _, _ => rfl
+  | [_], _, h => by simp at h
+  | a :: a' :: rest, bs, h => by
+    have hrest : rest.length % 2 = 0 := by simp at h; omega
+    cases bs with
+    | nil => simp [foldLevel]
+    | cons b bs' =>
+      simp only [List.cons_append, foldLevel, foldLevel_append rest (b :: bs') hrest]
+
+/-- One spec level absorbs one fold level: the width-`2 ^ (k + 1)` tree over
+`xs` and the width-`2 ^ k` tree over `foldLevel xs` share a root. -/
+theorem ofList_root_foldLevel :
+    ∀ (k : Nat) (xs : List Hash256), 0 < xs.length → xs.length ≤ 2 ^ (k + 1) →
+      (ofList xs (k + 1)).root = (ofList (foldLevel xs) k).root := by
+  intro k
+  induction k with
+  | zero =>
+    intro xs h0 h2
+    rw [Nat.pow_succ, Nat.pow_zero, Nat.one_mul] at h2
+    cases xs with
+    | nil => simp at h0
+    | cons x xs' =>
+      cases xs' with
+      | nil => simp [ofList, foldLevel, Tree.root]
+      | cons y xs'' =>
+        have hnil : xs'' = [] := by
+          simp only [List.length_cons] at h2
+          exact List.eq_nil_of_length_eq_zero (by omega)
+        subst hnil
+        simp [ofList, foldLevel, Tree.root]
+  | succ k ih =>
+    intro xs h0 h2
+    have hpow : 2 ^ (k + 2) = 2 ^ (k + 1) + 2 ^ (k + 1) := Nat.two_pow_succ (k + 1)
+    have hpow' : 2 ^ (k + 1) = 2 ^ k + 2 ^ k := Nat.two_pow_succ k
+    by_cases hsplit : xs.length ≤ 2 ^ (k + 1)
+    · have hfold : (foldLevel xs).length ≤ 2 ^ k := by
+        rw [foldLevel_length]; omega
+      have hL : ofList xs (k + 1 + 1) = .pad (ofList xs (k + 1)) := by
+        rw [ofList, if_pos hsplit]
+      have hR : ofList (foldLevel xs) (k + 1) = .pad (ofList (foldLevel xs) k) := by
+        rw [ofList, if_pos hfold]
+      rw [hL, hR, Tree.root, Tree.root, ih xs h0 hsplit]
+    · have hsplit' : 2 ^ (k + 1) < xs.length := by omega
+      have htake : (xs.take (2 ^ (k + 1))).length = 2 ^ (k + 1) := by
+        rw [List.length_take]; omega
+      have hsplitFold : foldLevel xs = foldLevel (xs.take (2 ^ (k + 1)))
+          ++ foldLevel (xs.drop (2 ^ (k + 1))) := by
+        rw [← foldLevel_append _ _ (by omega), List.take_append_drop]
+      have hfoldTake : (foldLevel (xs.take (2 ^ (k + 1)))).length = 2 ^ k := by
+        rw [foldLevel_length, htake]; omega
+      have hfoldLen : ¬ (foldLevel xs).length ≤ 2 ^ k := by
+        rw [foldLevel_length]; omega
+      have hL : ofList xs (k + 1 + 1)
+          = .node (ofList (xs.take (2 ^ (k + 1))) (k + 1))
+              (ofList (xs.drop (2 ^ (k + 1))) (k + 1)) := by
+        rw [ofList, if_neg (by omega)]
+      have hR : ofList (foldLevel xs) (k + 1)
+          = .node (ofList ((foldLevel xs).take (2 ^ k)) k)
+              (ofList ((foldLevel xs).drop (2 ^ k)) k) := by
+        rw [ofList, if_neg hfoldLen]
+      have htakeF : (foldLevel xs).take (2 ^ k) = foldLevel (xs.take (2 ^ (k + 1))) := by
+        rw [hsplitFold, List.take_left' hfoldTake]
+      have hdropF : (foldLevel xs).drop (2 ^ k) = foldLevel (xs.drop (2 ^ (k + 1))) := by
+        rw [hsplitFold, List.drop_left' hfoldTake]
+      rw [hL, hR, Tree.root, Tree.root, htakeF, hdropF,
+        ih _ (by rw [List.length_take]; omega) (by omega),
+        ih _ (by rw [List.length_drop]; omega) (by rw [List.length_drop]; omega)]
+
+/-- The bottom-up fold computes the structural spec's root. -/
+theorem computeRoot_eq_root : ∀ xs : List Hash256, computeRoot xs = root xs
+  | [] => by simp [computeRoot, root, tree, Nat.clog_zero_right, ofList, Tree.root]
+  | [x] => by simp [computeRoot, root, tree, Nat.clog_one_right, ofList, Tree.root]
+  | x :: y :: rest => by
+    have hlen : 2 ≤ (x :: y :: rest).length := by simp
+    have hclog : Nat.clog 2 (x :: y :: rest).length
+        = Nat.clog 2 (((x :: y :: rest).length + 1) / 2) + 1 := by
+      rw [Nat.clog_of_two_le (by decide) hlen,
+        show (x :: y :: rest).length + 2 - 1 = (x :: y :: rest).length + 1 by omega]
+    have hfl : (foldLevel (x :: y :: rest)).length = ((x :: y :: rest).length + 1) / 2 :=
+      foldLevel_length _
+    have hrec : computeRoot (x :: y :: rest) = computeRoot (foldLevel (x :: y :: rest)) := by
+      conv_lhs => rw [computeRoot]
+    rw [hrec, computeRoot_eq_root (foldLevel (x :: y :: rest)), root, root, tree, tree,
+      hfl, hclog, ofList_root_foldLevel _ _ (by simp) (by
+        calc (x :: y :: rest).length ≤ 2 ^ Nat.clog 2 (x :: y :: rest).length :=
+              Nat.le_pow_clog (by decide) _
+          _ = 2 ^ (Nat.clog 2 (((x :: y :: rest).length + 1) / 2) + 1) := by rw [← hclog])]
+  termination_by xs => xs.length
+  decreasing_by simp [foldLevel_length]; omega
+
+/-! ## Canonicality -/
+
+/-- The canonicality scan along the right spine: descending through the
+content side of every padding node and the right child of every interior
+node, no interior node may join two subtrees with identical materialized
+leaf sequences — that is exactly the shape a materialized padding suffix
+produces, and (`root_inj_of_canonical`) the only shape that threatens
+injectivity. -/
+def Tree.spineCanonical : Tree → Bool
+  | .leaf _ => true
+  | .pad t => t.spineCanonical
+  | .node l r => l.virtualLeaves != r.virtualLeaves && r.spineCanonical
+
+/-- The canonicality decision procedure for a leaf list: scan the right spine
+of its tree. The root node itself is exempt — a shorter list of the same
+enclosing width must still overflow the left half, so a duplication at the
+root cannot be a materialized padding (it is honest duplicate content, which
+transaction validity, not the merkle layer, rejects). -/
+def canonicalCheck (xs : List Hash256) : Bool :=
+  match tree xs with
+  | .node _ r => r.spineCanonical
+  | _ => true
+
+/-- A canonical leaf list: one whose merkle root is not also the root of a
+shorter list (its trailing blocks never materialize its own padding). The
+proposition the consensus layer demands of a block's txids. -/
+abbrev Canonical (xs : List Hash256) : Prop := canonicalCheck xs = true
+
+/-! ## Injectivity -/
+
+/-- A width-`2 ^ k` tree materializes exactly `2 ^ k` leaves. -/
+theorem length_virtualLeaves_ofList :
+    ∀ (k : Nat) (xs : List Hash256), ((ofList xs k).virtualLeaves).length = 2 ^ k := by
+  intro k
+  induction k with
+  | zero => intro xs; rfl
+  | succ k ih =>
+    intro xs
+    rw [ofList]
+    split
+    · simp [Tree.virtualLeaves, ih, Nat.two_pow_succ]
+    · simp [Tree.virtualLeaves, ih, Nat.two_pow_succ]
+
+/-- A full slice needs no padding: its materialized leaves are itself. -/
+theorem virtualLeaves_ofList_of_length_eq :
+    ∀ (k : Nat) (xs : List Hash256), xs.length = 2 ^ k →
+      (ofList xs k).virtualLeaves = xs := by
+  intro k
+  induction k with
+  | zero =>
+    intro xs hlen
+    obtain ⟨x, rfl⟩ := List.length_eq_one_iff.mp hlen
+    rfl
+  | succ k ih =>
+    intro xs hlen
+    have hpos : 0 < 2 ^ k := Nat.pow_pos (by decide)
+    have hpow := Nat.two_pow_succ k
+    have hlt : ¬ xs.length ≤ 2 ^ k := by omega
+    rw [ofList, if_neg hlt, Tree.virtualLeaves,
+      ih _ (by rw [List.length_take]; omega),
+      ih _ (by rw [List.length_drop]; omega),
+      List.take_append_drop]
+
+/-- The materialized leaves extend the actual list: padding only appends. -/
+theorem virtualLeaves_ofList_append :
+    ∀ (k : Nat) (xs : List Hash256), xs.length ≤ 2 ^ k →
+      ∃ ps, (ofList xs k).virtualLeaves = xs ++ ps := by
+  intro k
+  induction k with
+  | zero =>
+    intro xs hlen
+    match xs, hlen with
+    | [], _ => exact ⟨[0], rfl⟩
+    | [x], _ => exact ⟨[], rfl⟩
+  | succ k ih =>
+    intro xs hlen
+    rw [ofList]
+    split
+    · next hfit =>
+      obtain ⟨ps, hps⟩ := ih xs hfit
+      exact ⟨ps ++ (xs ++ ps), by rw [Tree.virtualLeaves, hps, List.append_assoc]⟩
+    · next hover =>
+      have htake : (xs.take (2 ^ k)).length = 2 ^ k := by rw [List.length_take]; omega
+      obtain ⟨ps, hps⟩ := ih (xs.drop (2 ^ k)) (by rw [List.length_drop]; omega)
+      exact ⟨ps, by
+        rw [Tree.virtualLeaves, virtualLeaves_ofList_of_length_eq k _ htake, hps,
+          ← List.append_assoc, List.take_append_drop]⟩
+
+/-- Equal roots at one width force equal materialized leaf sequences — or a
+concrete double-SHA-256 collision. The hashing direction of injectivity. -/
+theorem virtualLeaves_eq_of_root_eq :
+    ∀ (k : Nat) (xs ys : List Hash256),
+      (ofList xs k).root = (ofList ys k).root →
+      (ofList xs k).virtualLeaves = (ofList ys k).virtualLeaves ∨ Sha256.Collision := by
+  intro k
+  induction k with
+  | zero =>
+    intro xs ys h
+    exact Or.inl (by simpa [ofList, Tree.root, Tree.virtualLeaves] using h)
+  | succ k ih =>
+    intro xs ys h
+    simp only [ofList] at h ⊢
+    by_cases hx : xs.length ≤ 2 ^ k <;> by_cases hy : ys.length ≤ 2 ^ k
+    · rw [if_pos hx, if_pos hy] at h ⊢
+      rw [Tree.root, Tree.root] at h
+      rw [Tree.virtualLeaves, Tree.virtualLeaves]
+      rcases combine_inj h with ⟨ha, _⟩ | c
+      · rcases ih xs ys ha with hvl | c
+        · exact Or.inl (by rw [hvl])
+        · exact Or.inr c
+      · exact Or.inr c
+    · rw [if_pos hx, if_neg hy] at h ⊢
+      rw [Tree.root, Tree.root] at h
+      rw [Tree.virtualLeaves, Tree.virtualLeaves]
+      rcases combine_inj h with ⟨hl, hr⟩ | c
+      · rcases ih xs (ys.take (2 ^ k)) hl with hvl₁ | c
+        · rcases ih xs (ys.drop (2 ^ k)) hr with hvl₂ | c
+          · exact Or.inl (by rw [← hvl₁, ← hvl₂])
+          · exact Or.inr c
+        · exact Or.inr c
+      · exact Or.inr c
+    · rw [if_neg hx, if_pos hy] at h ⊢
+      rw [Tree.root, Tree.root] at h
+      rw [Tree.virtualLeaves, Tree.virtualLeaves]
+      rcases combine_inj h with ⟨hl, hr⟩ | c
+      · rcases ih (xs.take (2 ^ k)) ys hl with hvl₁ | c
+        · rcases ih (xs.drop (2 ^ k)) ys hr with hvl₂ | c
+          · exact Or.inl (by rw [hvl₁, hvl₂])
+          · exact Or.inr c
+        · exact Or.inr c
+      · exact Or.inr c
+    · rw [if_neg hx, if_neg hy] at h ⊢
+      rw [Tree.root, Tree.root] at h
+      rw [Tree.virtualLeaves, Tree.virtualLeaves]
+      rcases combine_inj h with ⟨hl, hr⟩ | c
+      · rcases ih (xs.take (2 ^ k)) (ys.take (2 ^ k)) hl with hvl₁ | c
+        · rcases ih (xs.drop (2 ^ k)) (ys.drop (2 ^ k)) hr with hvl₂ | c
+          · exact Or.inl (by rw [hvl₁, hvl₂])
+          · exact Or.inr c
+        · exact Or.inr c
+      · exact Or.inr c
+
+/-- Equal materialized leaves of canonical-spine trees come from equal actual
+lists: the combinatorial direction of injectivity, no hashing involved. The
+spine conditions kill exactly the materialized-padding case. -/
+theorem eq_of_virtualLeaves_eq :
+    ∀ (k : Nat) (xs ys : List Hash256),
+      0 < xs.length → xs.length ≤ 2 ^ k → 0 < ys.length → ys.length ≤ 2 ^ k →
+      (ofList xs k).spineCanonical = true → (ofList ys k).spineCanonical = true →
+      (ofList xs k).virtualLeaves = (ofList ys k).virtualLeaves → xs = ys := by
+  intro k
+  induction k with
+  | zero =>
+    intro xs ys h0x hx h0y hy _ _ hvl
+    obtain ⟨x, rfl⟩ := List.length_eq_one_iff.mp (by omega : xs.length = 1)
+    obtain ⟨y, rfl⟩ := List.length_eq_one_iff.mp (by omega : ys.length = 1)
+    simpa [ofList, Tree.virtualLeaves] using hvl
+  | succ k ih =>
+    intro xs ys h0x hx h0y hy hcx hcy hvl
+    simp only [ofList] at hcx hcy hvl
+    by_cases hxs : xs.length ≤ 2 ^ k <;> by_cases hys : ys.length ≤ 2 ^ k
+    · -- pad / pad: equal halves, recurse.
+      rw [if_pos hxs] at hcx hvl
+      rw [if_pos hys] at hcy hvl
+      rw [Tree.spineCanonical] at hcx hcy
+      rw [Tree.virtualLeaves, Tree.virtualLeaves] at hvl
+      have hhalf := (List.append_inj hvl (by
+        rw [length_virtualLeaves_ofList, length_virtualLeaves_ofList])).1
+      exact ih xs ys h0x hxs h0y hys hcx hcy hhalf
+    · -- pad / node: the node side's halves are forced equal — its spine
+      -- condition forbids exactly that.
+      rw [if_pos hxs] at hcx hvl
+      rw [if_neg hys] at hcy hvl
+      rw [Tree.virtualLeaves, Tree.virtualLeaves] at hvl
+      simp only [Tree.spineCanonical, Bool.and_eq_true, bne_iff_ne, ne_eq] at hcy
+      have hlen : ((ofList xs k).virtualLeaves).length
+          = ((ofList (ys.take (2 ^ k)) k).virtualLeaves).length := by
+        rw [length_virtualLeaves_ofList, length_virtualLeaves_ofList]
+      obtain ⟨h₁, h₂⟩ := List.append_inj hvl hlen
+      exact absurd (h₁.symm.trans h₂) hcy.1
+    · -- node / pad: symmetric.
+      rw [if_neg hxs] at hcx hvl
+      rw [if_pos hys] at hcy hvl
+      rw [Tree.virtualLeaves, Tree.virtualLeaves] at hvl
+      simp only [Tree.spineCanonical, Bool.and_eq_true, bne_iff_ne, ne_eq] at hcx
+      have hlen : ((ofList (xs.take (2 ^ k)) k).virtualLeaves).length
+          = ((ofList ys k).virtualLeaves).length := by
+        rw [length_virtualLeaves_ofList, length_virtualLeaves_ofList]
+      obtain ⟨h₁, h₂⟩ := List.append_inj hvl hlen
+      exact absurd (h₁.trans h₂.symm) hcx.1
+    · -- node / node: left halves are full slices, right halves recurse.
+      rw [if_neg hxs] at hcx hvl
+      rw [if_neg hys] at hcy hvl
+      rw [Tree.virtualLeaves, Tree.virtualLeaves] at hvl
+      simp only [Tree.spineCanonical, Bool.and_eq_true, bne_iff_ne, ne_eq] at hcx hcy
+      have htx : (xs.take (2 ^ k)).length = 2 ^ k := by rw [List.length_take]; omega
+      have hty : (ys.take (2 ^ k)).length = 2 ^ k := by rw [List.length_take]; omega
+      have hlen : ((ofList (xs.take (2 ^ k)) k).virtualLeaves).length
+          = ((ofList (ys.take (2 ^ k)) k).virtualLeaves).length := by
+        rw [length_virtualLeaves_ofList, length_virtualLeaves_ofList]
+      obtain ⟨h₁, h₂⟩ := List.append_inj hvl hlen
+      have htake : xs.take (2 ^ k) = ys.take (2 ^ k) := by
+        rw [← virtualLeaves_ofList_of_length_eq k _ htx,
+          ← virtualLeaves_ofList_of_length_eq k _ hty, h₁]
+      have hdrop : xs.drop (2 ^ k) = ys.drop (2 ^ k) :=
+        ih _ _ (by rw [List.length_drop]; omega) (by rw [List.length_drop]; omega)
+          (by rw [List.length_drop]; omega) (by rw [List.length_drop]; omega)
+          hcx.2 hcy.2 h₂
+      rw [← List.take_append_drop (2 ^ k) xs, ← List.take_append_drop (2 ^ k) ys,
+        htake, hdrop]
+
+/-! ## The headline theorems -/
+
+/-- Between equal-length lists the merkle root identifies the list — or two
+concrete byte strings collide under double-SHA-256. No canonicality needed:
+padding only appends, so equal lengths leave no room for ambiguity. -/
+theorem root_inj_of_length_eq {xs ys : List Hash256}
+    (hlen : xs.length = ys.length) (hroot : root xs = root ys) :
+    xs = ys ∨ Sha256.Collision := by
+  unfold root tree at hroot
+  rw [← hlen] at hroot
+  rcases virtualLeaves_eq_of_root_eq (Nat.clog 2 xs.length) xs ys hroot with hvl | c
+  · obtain ⟨ps, hps⟩ := virtualLeaves_ofList_append (Nat.clog 2 xs.length) xs
+      (Nat.le_pow_clog (by decide) _)
+    obtain ⟨qs, hqs⟩ := virtualLeaves_ofList_append (Nat.clog 2 xs.length) ys
+      (by rw [← hlen]; exact Nat.le_pow_clog (by decide) _)
+    rw [hps, hqs] at hvl
+    exact Or.inl (List.append_inj hvl hlen).1
+  · exact Or.inr c
+
+/-- Between canonical lists of equal enclosing width the merkle root
+identifies the list — or two concrete byte strings collide under
+double-SHA-256. This is the injectivity the canonicality rule exists to
+restore: without `Canonical`, a list extended by its own materialized padding
+shares its root (CVE-2012-2459). Equal widths exclude the cross-height
+leaf/interior ambiguity (see the module header). -/
+theorem root_inj_of_canonical {xs ys : List Hash256}
+    (hcx : Canonical xs) (hcy : Canonical ys)
+    (h0x : xs ≠ []) (h0y : ys ≠ [])
+    (hk : Nat.clog 2 xs.length = Nat.clog 2 ys.length)
+    (hroot : root xs = root ys) : xs = ys ∨ Sha256.Collision := by
+  have h0x' : 0 < xs.length := List.length_pos_iff.mpr h0x
+  have h0y' : 0 < ys.length := List.length_pos_iff.mpr h0y
+  rcases Nat.eq_zero_or_pos (Nat.clog 2 xs.length) with hk0 | hkpos
+  · -- Width 1: both lists are singletons and the root is the element.
+    have hx1 : xs.length = 1 := by
+      by_contra hne
+      have := Nat.clog_pos (b := 2) (by decide) (n := xs.length) (by omega)
+      omega
+    have hy1 : ys.length = 1 := by
+      by_contra hne
+      have := Nat.clog_pos (b := 2) (by decide) (n := ys.length) (by omega)
+      omega
+    obtain ⟨x, rfl⟩ := List.length_eq_one_iff.mp hx1
+    obtain ⟨y, rfl⟩ := List.length_eq_one_iff.mp hy1
+    rw [root, root, tree, tree, hx1, hy1] at hroot
+    exact Or.inl (by simpa [ofList, Nat.clog, Tree.root] using hroot)
+  · -- Width ≥ 2: by minimality both trees split at the root; the left halves
+    -- are full slices, the right halves carry the spine conditions.
+    obtain ⟨j, hj⟩ : ∃ j, Nat.clog 2 xs.length = j + 1 :=
+      ⟨Nat.clog 2 xs.length - 1, by omega⟩
+    have hxlen : 2 ^ j < xs.length := by
+      have h2 : 2 ≤ xs.length := by
+        by_contra hlt
+        have : Nat.clog 2 xs.length = 0 := Nat.clog_of_right_le_one (by omega) 2
+        omega
+      have := Nat.pow_pred_clog_lt_self (b := 2) (by decide) (x := xs.length) (by omega)
+      rwa [hj, Nat.pred_succ] at this
+    have hylen : 2 ^ j < ys.length := by
+      have h2 : 2 ≤ ys.length := by
+        by_contra hlt
+        have : Nat.clog 2 ys.length = 0 := Nat.clog_of_right_le_one (by omega) 2
+        omega
+      have := Nat.pow_pred_clog_lt_self (b := 2) (by decide) (x := ys.length) (by omega)
+      rwa [← hk, hj, Nat.pred_succ] at this
+    have hxle : xs.length ≤ 2 ^ (j + 1) := hj ▸ Nat.le_pow_clog (by decide) _
+    have hyle : ys.length ≤ 2 ^ (j + 1) := (hk ▸ hj) ▸ Nat.le_pow_clog (by decide) _
+    rw [root, root, tree, tree, hj, ← hk, hj] at hroot
+    rw [Canonical, canonicalCheck, tree, hj] at hcx
+    rw [Canonical, canonicalCheck, tree, ← hk, hj] at hcy
+    simp only [ofList, if_neg (by omega : ¬ xs.length ≤ 2 ^ j),
+      if_neg (by omega : ¬ ys.length ≤ 2 ^ j), Tree.root] at hroot hcx hcy
+    rcases combine_inj hroot with ⟨hl, hr⟩ | c
+    · rcases virtualLeaves_eq_of_root_eq j _ _ hl with hvl₁ | c
+      · have htake : xs.take (2 ^ j) = ys.take (2 ^ j) := by
+          rw [← virtualLeaves_ofList_of_length_eq j (xs.take (2 ^ j))
+              (by rw [List.length_take]; omega),
+            ← virtualLeaves_ofList_of_length_eq j (ys.take (2 ^ j))
+              (by rw [List.length_take]; omega), hvl₁]
+        rcases virtualLeaves_eq_of_root_eq j _ _ hr with hvl₂ | c
+        · have hdrop : xs.drop (2 ^ j) = ys.drop (2 ^ j) :=
+            eq_of_virtualLeaves_eq j _ _
+              (by rw [List.length_drop]; omega) (by rw [List.length_drop]; omega)
+              (by rw [List.length_drop]; omega) (by rw [List.length_drop]; omega)
+              hcx hcy hvl₂
+          exact Or.inl (by
+            rw [← List.take_append_drop (2 ^ j) xs, ← List.take_append_drop (2 ^ j) ys,
+              htake, hdrop])
+        · exact Or.inr c
+      · exact Or.inr c
+    · exact Or.inr c
+
+end BtcVerified.Merkle

--- a/BtcVerified/Crypto/Merkle.lean
+++ b/BtcVerified/Crypto/Merkle.lean
@@ -57,27 +57,21 @@ namespace BtcVerified.Merkle
 
 open BtcVerified.Serialize
 
-/-- A merkle node: the double-SHA-256 of the two children's digests, each
-serialized as its 32 little-endian bytes. -/
+/-- A merkle node: the double-SHA-256 of its two children's raw digest bytes,
+concatenated as-is — exactly what Bitcoin hashes, with no byte reversal. -/
 def combine (l r : Hash256) : Hash256 :=
-  Hash256.ofBytesLE (Sha256.sha256d (encodeBitVecLE 32 l ++ encodeBitVecLE 32 r))
+  ⟨Sha256.sha256d (l.1 ++ r.1), Sha256.sha256d_length _⟩
 
 /-- Equal merkle nodes have equal children — or their two 64-byte preimages
 collide under double-SHA-256. -/
 theorem combine_inj {l r l' r' : Hash256} (h : combine l r = combine l' r') :
     (l = l' ∧ r = r') ∨ Sha256.Collision := by
-  by_cases hm : encodeBitVecLE 32 l ++ encodeBitVecLE 32 r
-      = encodeBitVecLE 32 l' ++ encodeBitVecLE 32 r'
-  · obtain ⟨h₁, h₂⟩ := List.append_inj hm (by rw [encodeBitVecLE_length, encodeBitVecLE_length])
-    exact Or.inl ⟨by simpa [Hash256.ofBytesLE_encode] using congrArg Hash256.ofBytesLE h₁,
-      by simpa [Hash256.ofBytesLE_encode] using congrArg Hash256.ofBytesLE h₂⟩
-  · refine Or.inr ⟨_, _, hm, ?_⟩
-    have hl := Hash256.encode_ofBytesLE (Sha256.sha256d_length
-      (encodeBitVecLE 32 l ++ encodeBitVecLE 32 r))
-    have hr := Hash256.encode_ofBytesLE (Sha256.sha256d_length
-      (encodeBitVecLE 32 l' ++ encodeBitVecLE 32 r'))
-    rw [← hl, ← hr]
-    exact congrArg (encodeBitVecLE 32) h
+  have hd : Sha256.sha256d (l.1 ++ r.1) = Sha256.sha256d (l'.1 ++ r'.1) :=
+    congrArg Subtype.val h
+  by_cases hm : l.1 ++ r.1 = l'.1 ++ r'.1
+  · obtain ⟨h₁, h₂⟩ := List.append_inj hm (by rw [l.2, l'.2])
+    exact Or.inl ⟨Subtype.ext h₁, Subtype.ext h₂⟩
+  · exact Or.inr ⟨_, _, hm, hd⟩
 
 /-! ## The structural spec -/
 

--- a/BtcVerified/Crypto/Sha256.lean
+++ b/BtcVerified/Crypto/Sha256.lean
@@ -1,3 +1,4 @@
+import BtcVerified.Crypto.Collision
 /-!
   # SHA-256 and Bitcoin's double-SHA-256
 
@@ -138,7 +139,14 @@ about hash commitments conclude with this as a constructive disjunct — never
 assuming its absence as an axiom, which would be inconsistent for a concrete
 hash (an infinite domain into 32 bytes has collisions by pigeonhole). The
 *intractability* of producing a witness is the consumer's hypothesis. -/
-def Collision : Prop :=
-  ∃ a b : List UInt8, a ≠ b ∧ sha256d a = sha256d b
+abbrev Collision : Prop := BtcVerified.Collision sha256d
+
+/-- Bitcoin's double hashing inherits collision resistance from `sha256`: a
+`sha256d` collision is a `sha256` collision (in the outer call if the inner
+digests differ, in the inner call otherwise), so resistance of `sha256` gives
+resistance of `sha256d = sha256 ∘ sha256`. -/
+theorem collisionResistant_sha256d (h : CollisionResistant sha256) :
+    CollisionResistant sha256d :=
+  h.comp h
 
 end BtcVerified.Sha256

--- a/BtcVerified/Crypto/Sha256.lean
+++ b/BtcVerified/Crypto/Sha256.lean
@@ -99,8 +99,9 @@ def toWords (bytes : Array UInt8) : Array UInt32 := Id.run do
     ws := ws.push (beWord bytes[4 * i]! bytes[4 * i + 1]! bytes[4 * i + 2]! bytes[4 * i + 3]!)
   return ws
 
-/-- SHA-256 of a byte string: the 32-byte digest. -/
-def sha256 (msg : List UInt8) : List UInt8 := Id.run do
+/-- The final 8-word hash state of SHA-256: pad, split into 16-word blocks,
+and fold each through the compression function. -/
+def sha256State (msg : List UInt8) : Array UInt32 := Id.run do
   let words := toWords (pad msg).toArray
   let mut state := initialHash
   for b in [0:words.size / 16] do
@@ -108,13 +109,36 @@ def sha256 (msg : List UInt8) : List UInt8 := Id.run do
     for j in [0:16] do
       block := block.set! j words[16 * b + j]!
     state := compress state block
-  let mut out : List UInt8 := []
-  for i in [0:8] do
-    out := out ++ wordBytes state[i]!
-  return out
+  return state
+
+/-- The 32-byte digest of an 8-word hash state: each word unpacked big-endian,
+in order. Kept outside the state loop so the digest's byte length is a
+structural fact rather than a property of an imperative fold. -/
+def stateBytes (s : Array UInt32) : List UInt8 :=
+  wordBytes s[0]! ++ wordBytes s[1]! ++ wordBytes s[2]! ++ wordBytes s[3]!
+    ++ wordBytes s[4]! ++ wordBytes s[5]! ++ wordBytes s[6]! ++ wordBytes s[7]!
+
+/-- SHA-256 of a byte string: the 32-byte digest. -/
+def sha256 (msg : List UInt8) : List UInt8 := stateBytes (sha256State msg)
 
 /-- Bitcoin's double-SHA-256: `SHA256(SHA256(msg))`. The hash behind txids,
 block hashes, and merkle nodes. -/
 def sha256d (msg : List UInt8) : List UInt8 := sha256 (sha256 msg)
+
+/-- A SHA-256 digest is exactly 32 bytes. -/
+theorem sha256_length (msg : List UInt8) : (sha256 msg).length = 32 := by
+  simp [sha256, stateBytes, wordBytes]
+
+/-- A double-SHA-256 digest is exactly 32 bytes. -/
+theorem sha256d_length (msg : List UInt8) : (sha256d msg).length = 32 :=
+  sha256_length _
+
+/-- Two distinct byte strings with the same double-SHA-256 digest. Theorems
+about hash commitments conclude with this as a constructive disjunct — never
+assuming its absence as an axiom, which would be inconsistent for a concrete
+hash (an infinite domain into 32 bytes has collisions by pigeonhole). The
+*intractability* of producing a witness is the consumer's hypothesis. -/
+def Collision : Prop :=
+  ∃ a b : List UInt8, a ≠ b ∧ sha256d a = sha256d b
 
 end BtcVerified.Sha256

--- a/BtcVerified/Crypto/Sha256.lean
+++ b/BtcVerified/Crypto/Sha256.lean
@@ -149,4 +149,16 @@ theorem collisionResistant_sha256d (h : CollisionResistant sha256) :
     CollisionResistant sha256d :=
   h.comp h
 
+/-- The converse: a `sha256d` collision forces a `sha256` collision in the inner
+call, so resistance of `sha256d` gives resistance of `sha256`. Together with
+`collisionResistant_sha256d`, the two resistances are equivalent. -/
+theorem collisionResistant_sha256_of_sha256d (h : CollisionResistant sha256d) :
+    CollisionResistant sha256 :=
+  CollisionResistant.of_comp (f := sha256) (g := sha256) h
+
+/-- Collision resistance of `sha256` and of `sha256d` are equivalent. -/
+theorem collisionResistant_sha256_iff_sha256d :
+    CollisionResistant sha256 ↔ CollisionResistant sha256d :=
+  ⟨collisionResistant_sha256d, collisionResistant_sha256_of_sha256d⟩
+
 end BtcVerified.Sha256

--- a/BtcVerified/Serialize/Codec.lean
+++ b/BtcVerified/Serialize/Codec.lean
@@ -230,6 +230,22 @@ theorem decodeBitVecLE_canonical :
         simp only [encodeBitVecLE, List.cons_append, setWidth_append_low,
           setWidth_ushiftRight_append, UInt8.ofBitVec_toBitVec, ihbs]
 
+/-- The little-endian decoder succeeds on any input of at least `n` bytes,
+consuming exactly `n` and leaving the rest as the tail. -/
+theorem decodeBitVecLE_of_le_length :
+    ∀ (n : Nat) (bs : List UInt8), n ≤ bs.length →
+      ∃ v, decodeBitVecLE n bs = some (v, bs.drop n) := by
+  intro n
+  induction n with
+  | zero => exact fun bs _ => ⟨0#0, rfl⟩
+  | succ n ih =>
+    intro bs h
+    cases bs with
+    | nil => simp at h
+    | cons b bs' =>
+      obtain ⟨v, hv⟩ := ih bs' (by simpa using h)
+      exact ⟨v ++ b.toBitVec, by simp [decodeBitVecLE, decodeByte, hv]⟩
+
 /-- A little-endian `BitVec (8 * n)` encoding is exactly `n` bytes long. -/
 theorem encodeBitVecLE_length :
     ∀ (n : Nat) (v : BitVec (8 * n)), (encodeBitVecLE n v).length = n := by

--- a/BtcVerified/Transaction/Txid.lean
+++ b/BtcVerified/Transaction/Txid.lean
@@ -1,0 +1,77 @@
+import BtcVerified.Transaction.Tx
+import BtcVerified.Crypto.Sha256
+import BtcVerified.Crypto.Hash256
+/-!
+  # Transaction ids
+
+  The txid is the double-SHA-256 of the witness-free `TxBody` serialization,
+  read little-endian; the wtxid (BIP141) is the same over the full
+  serialization, witness included. Witness data never affects a txid — that
+  is the non-malleability SegWit exists to provide — and for a legacy
+  transaction the two ids coincide definitionally.
+
+  A hash of an encoding only identifies anything because the encoding is
+  injective — `encode_injective`, a consequence of the codec round-trip law.
+  The faithfulness theorems here are exactly that observation: equal txids
+  mean equal bodies, and equal wtxids mean equal transactions, or in either
+  case there are two concrete byte strings witnessing a double-SHA-256
+  collision (`Sha256.Collision`). The collision appears as a constructed
+  disjunct, never as an assumed-absent axiom.
+
+  Checked claims:
+
+  * `Tx.txid_faithful`: equal txids imply equal witness-free bodies, or a
+    concrete `sha256d` collision.
+  * `Tx.wtxid_faithful`: equal wtxids imply equal transactions (witnesses
+    included), or a concrete `sha256d` collision.
+  * `Tx.wtxid_legacy`: a legacy transaction's wtxid is its txid.
+-/
+
+namespace BtcVerified
+
+open BtcVerified.Serialize
+
+/-- The transaction id: double-SHA-256 of the witness-free `TxBody`
+serialization, read little-endian (the displayed hex is the digest bytes
+reversed). Both constructors hash only the body, so witness data never
+affects a txid. -/
+def Tx.txid (tx : Tx) : Hash256 :=
+  Hash256.ofBytesLE (Sha256.sha256d (Codec.encode tx.body))
+
+/-- The witness transaction id (BIP141): double-SHA-256 of the full
+serialization, witness included for the SegWit form. -/
+def Tx.wtxid (tx : Tx) : Hash256 :=
+  Hash256.ofBytesLE (Sha256.sha256d (Codec.encode tx))
+
+/-- A legacy transaction's wtxid is its txid: its full serialization is its
+body's serialization. -/
+theorem Tx.wtxid_legacy (body : TxBody) (h : body.inputs.val ≠ []) :
+    (Tx.legacy body h).wtxid = (Tx.legacy body h).txid := rfl
+
+/-- Equal hash-of-digest values force the digests themselves equal, because a
+full digest round-trips through its 32-byte encoding. -/
+private theorem digest_eq_of_hash_eq {a b : List UInt8}
+    (h : Hash256.ofBytesLE (Sha256.sha256d a) = Hash256.ofBytesLE (Sha256.sha256d b)) :
+    Sha256.sha256d a = Sha256.sha256d b := by
+  rw [← Hash256.encode_ofBytesLE (Sha256.sha256d_length a),
+    ← Hash256.encode_ofBytesLE (Sha256.sha256d_length b), h]
+
+/-- Equal txids mean equal witness-free bodies — or two concrete byte strings
+witnessing a double-SHA-256 collision. -/
+theorem Tx.txid_faithful {t₁ t₂ : Tx} (h : t₁.txid = t₂.txid) :
+    t₁.body = t₂.body ∨ Sha256.Collision := by
+  by_cases hb : t₁.body = t₂.body
+  · exact Or.inl hb
+  · exact Or.inr ⟨Codec.encode t₁.body, Codec.encode t₂.body,
+      fun he => hb (encode_injective he), digest_eq_of_hash_eq h⟩
+
+/-- Equal wtxids mean equal transactions, witnesses included — or two
+concrete byte strings witnessing a double-SHA-256 collision. -/
+theorem Tx.wtxid_faithful {t₁ t₂ : Tx} (h : t₁.wtxid = t₂.wtxid) :
+    t₁ = t₂ ∨ Sha256.Collision := by
+  by_cases ht : t₁ = t₂
+  · exact Or.inl ht
+  · exact Or.inr ⟨Codec.encode t₁, Codec.encode t₂,
+      fun he => ht (encode_injective he), digest_eq_of_hash_eq h⟩
+
+end BtcVerified

--- a/BtcVerified/Transaction/Txid.lean
+++ b/BtcVerified/Transaction/Txid.lean
@@ -5,7 +5,7 @@ import BtcVerified.Crypto.Hash256
   # Transaction ids
 
   The txid is the double-SHA-256 of the witness-free `TxBody` serialization,
-  read little-endian; the wtxid (BIP141) is the same over the full
+  as its raw 32 digest bytes; the wtxid (BIP141) is the same over the full
   serialization, witness included. Witness data never affects a txid — that
   is the non-malleability SegWit exists to provide — and for a legacy
   transaction the two ids coincide definitionally.
@@ -31,30 +31,22 @@ namespace BtcVerified
 
 open BtcVerified.Serialize
 
-/-- The transaction id: double-SHA-256 of the witness-free `TxBody`
-serialization, read little-endian (the displayed hex is the digest bytes
-reversed). Both constructors hash only the body, so witness data never
-affects a txid. -/
+/-- The transaction id: the double-SHA-256 of the witness-free `TxBody`
+serialization, as its raw 32 digest bytes (the displayed hex is these bytes
+reversed). Both constructors hash only the body, so witness data never affects
+a txid. -/
 def Tx.txid (tx : Tx) : Hash256 :=
-  Hash256.ofBytesLE (Sha256.sha256d (Codec.encode tx.body))
+  ⟨Sha256.sha256d (Codec.encode tx.body), Sha256.sha256d_length _⟩
 
-/-- The witness transaction id (BIP141): double-SHA-256 of the full
+/-- The witness transaction id (BIP141): the double-SHA-256 of the full
 serialization, witness included for the SegWit form. -/
 def Tx.wtxid (tx : Tx) : Hash256 :=
-  Hash256.ofBytesLE (Sha256.sha256d (Codec.encode tx))
+  ⟨Sha256.sha256d (Codec.encode tx), Sha256.sha256d_length _⟩
 
 /-- A legacy transaction's wtxid is its txid: its full serialization is its
 body's serialization. -/
 theorem Tx.wtxid_legacy (body : TxBody) (h : body.inputs.val ≠ []) :
     (Tx.legacy body h).wtxid = (Tx.legacy body h).txid := rfl
-
-/-- Equal hash-of-digest values force the digests themselves equal, because a
-full digest round-trips through its 32-byte encoding. -/
-private theorem digest_eq_of_hash_eq {a b : List UInt8}
-    (h : Hash256.ofBytesLE (Sha256.sha256d a) = Hash256.ofBytesLE (Sha256.sha256d b)) :
-    Sha256.sha256d a = Sha256.sha256d b := by
-  rw [← Hash256.encode_ofBytesLE (Sha256.sha256d_length a),
-    ← Hash256.encode_ofBytesLE (Sha256.sha256d_length b), h]
 
 /-- Equal txids mean equal witness-free bodies — or two concrete byte strings
 witnessing a double-SHA-256 collision. -/
@@ -63,7 +55,7 @@ theorem Tx.txid_faithful {t₁ t₂ : Tx} (h : t₁.txid = t₂.txid) :
   by_cases hb : t₁.body = t₂.body
   · exact Or.inl hb
   · exact Or.inr ⟨Codec.encode t₁.body, Codec.encode t₂.body,
-      fun he => hb (encode_injective he), digest_eq_of_hash_eq h⟩
+      fun he => hb (encode_injective he), congrArg Subtype.val h⟩
 
 /-- Equal wtxids mean equal transactions, witnesses included — or two
 concrete byte strings witnessing a double-SHA-256 collision. -/
@@ -72,6 +64,6 @@ theorem Tx.wtxid_faithful {t₁ t₂ : Tx} (h : t₁.wtxid = t₂.wtxid) :
   by_cases ht : t₁ = t₂
   · exact Or.inl ht
   · exact Or.inr ⟨Codec.encode t₁, Codec.encode t₂,
-      fun he => ht (encode_injective he), digest_eq_of_hash_eq h⟩
+      fun he => ht (encode_injective he), congrArg Subtype.val h⟩
 
 end BtcVerified

--- a/README.md
+++ b/README.md
@@ -193,6 +193,64 @@ concrete function buys instead is computation: a verified decoder plus a
 computable hash is what lets a real block's merkle root or a header's
 proof-of-work be checked, not just asserted.
 
+### `BtcVerified` transaction ids
+
+`Tx.txid` — the double-SHA-256 of the witness-free `TxBody` serialization,
+read little-endian — and `Tx.wtxid` (BIP141), the same over the full
+serialization. Witness data never affects a txid; for a legacy transaction the
+two coincide by `rfl`.
+
+Checked claims:
+
+- `Tx.txid_faithful`: equal txids imply equal witness-free bodies — or two
+  concrete byte strings witnessing a double-SHA-256 collision.
+- `Tx.wtxid_faithful`: equal wtxids imply equal transactions, witnesses
+  included — or a concrete collision.
+- Golden vectors: the first Bitcoin payment's txid, the genesis coinbase txid
+  (which is the genesis merkle root), and the SegWit coinbase's txid with
+  `wtxid ≠ txid`.
+
+Why it matters: a hash of an encoding only identifies anything because the
+encoding is injective — `encode_injective`, from the codec round-trip law. The
+serialization leaves are exactly what make txids meaningful, and the collision
+disjunct is constructed, never assumed away: intractability of producing a
+witness is the consumer's hypothesis, the only form in which collision
+resistance can soundly appear over a concrete hash.
+
+### `BtcVerified.Merkle`
+
+Bitcoin's merkle tree, with the root computation and canonicality factored
+apart. The spec is structural — a tree built top-down by bisection, procedural
+duplication an explicit `pad` constructor rather than an artifact of iteration
+order — and `computeRoot`, the bottom-up fold Bitcoin actually runs, is proved
+equal to it. Canonicality is a first-class decidable property of the leaf
+list, constraining exactly what threatens injectivity: padding only duplicates
+trailing power-of-two-aligned blocks, so only a right-spine duplication can
+materialize a shorter list's padding (CVE-2012-2459). Core's fused `mutated`
+scan is strictly stronger; the two agree on transaction-valid blocks.
+
+Checked claims:
+
+- `computeRoot_eq_root`: the bottom-up fold computes the structural spec.
+- `root_inj_of_length_eq`: between equal-length lists, the root identifies the
+  list — or two concrete byte strings collide under double-SHA-256.
+- `root_inj_of_canonical`: between canonical lists of equal enclosing width,
+  the root identifies the list — or a concrete collision. This is the
+  injectivity the canonicality rule exists to restore.
+- `Block.merkleCommits`: the consensus condition — a canonical txid list whose
+  root is the header's. Checked on the genesis block and block 170 at build
+  time, and on all 1866 transactions of block 481824 under `lake test`, which
+  with the header-hash check pins every transaction byte of the fixture
+  (txids → merkle root → header → proof-of-work hash).
+
+Why it matters: this is the first consensus-validity leaf — the commitment
+that ties a block's body to the header that proof of work covers. The known
+residual is documented rather than papered over: equal enclosing widths are a
+hypothesis because a 64-byte transaction can confuse a leaf with an interior
+node across heights (the ambiguity the Great Consensus Cleanup proposes to
+close); for block validity the transaction count is in hand, so the hypothesis
+is free.
+
 ### `BtcVerified.Script`
 
 The `Script` type: a Bitcoin Script program as it exists on the wire — raw,

--- a/README.md
+++ b/README.md
@@ -195,15 +195,18 @@ proof-of-work be checked, not just asserted.
 
 ### `BtcVerified` transaction ids
 
-`Tx.txid` — the double-SHA-256 of the witness-free `TxBody` serialization,
-read little-endian — and `Tx.wtxid` (BIP141), the same over the full
+`Tx.txid` — the double-SHA-256 of the witness-free `TxBody` serialization, as
+its raw 32 digest bytes — and `Tx.wtxid` (BIP141), the same over the full
 serialization. Witness data never affects a txid; for a legacy transaction the
 two coincide by `rfl`.
 
 Checked claims:
 
 - `Tx.txid_faithful`: equal txids imply equal witness-free bodies — or two
-  concrete byte strings witnessing a double-SHA-256 collision.
+  concrete byte strings witnessing a double-SHA-256 collision. With
+  `CollisionResistant.injective` (the generalized collision vocabulary in
+  `BtcVerified.Collision`), a resistance hypothesis collapses this to outright
+  injectivity.
 - `Tx.wtxid_faithful`: equal wtxids imply equal transactions, witnesses
   included — or a concrete collision.
 - Golden vectors: the first Bitcoin payment's txid, the genesis coinbase txid

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -82,6 +82,15 @@ elab "#assert_axioms " id:ident : command => do
   `native_decide`. Auditing `sha256d` covers `sha256` transitively. -/
 
 #assert_axioms BtcVerified.Sha256.sha256d
+#assert_axioms BtcVerified.Sha256.sha256d_length
+#assert_axioms BtcVerified.Hash256.ofBytesLE_encode
+#assert_axioms BtcVerified.Hash256.encode_ofBytesLE
+
+/-! ## Transaction ids -/
+
+#assert_axioms BtcVerified.Tx.txid_faithful
+#assert_axioms BtcVerified.Tx.wtxid_faithful
+#assert_axioms BtcVerified.Tx.wtxid_legacy
 
 /-! ## BitVM -/
 

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -81,8 +81,12 @@ elab "#assert_axioms " id:ident : command => do
   load-bearing — so the audit guards it against a stray `sorry` or a sneaked-in
   `native_decide`. Auditing `sha256d` covers `sha256` transitively. -/
 
+#assert_axioms BtcVerified.Collision.comp
+#assert_axioms BtcVerified.CollisionResistant.injective
+#assert_axioms BtcVerified.CollisionResistant.comp
 #assert_axioms BtcVerified.Sha256.sha256d
 #assert_axioms BtcVerified.Sha256.sha256d_length
+#assert_axioms BtcVerified.Sha256.collisionResistant_sha256d
 #assert_axioms BtcVerified.Hash256.ofBytesLE_encode
 #assert_axioms BtcVerified.Hash256.encode_ofBytesLE
 

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -92,6 +92,14 @@ elab "#assert_axioms " id:ident : command => do
 #assert_axioms BtcVerified.Tx.wtxid_faithful
 #assert_axioms BtcVerified.Tx.wtxid_legacy
 
+/-! ## The merkle tree -/
+
+#assert_axioms BtcVerified.Merkle.combine_inj
+#assert_axioms BtcVerified.Merkle.computeRoot_eq_root
+#assert_axioms BtcVerified.Merkle.root_inj_of_length_eq
+#assert_axioms BtcVerified.Merkle.root_inj_of_canonical
+#assert_axioms BtcVerified.Block.merkleCommits
+
 /-! ## BitVM -/
 
 #assert_axioms BtcVerified.BitVM.BitCommitment.openings_with_distinct_bits_are_distinct

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -87,8 +87,8 @@ elab "#assert_axioms " id:ident : command => do
 #assert_axioms BtcVerified.Sha256.sha256d
 #assert_axioms BtcVerified.Sha256.sha256d_length
 #assert_axioms BtcVerified.Sha256.collisionResistant_sha256d
-#assert_axioms BtcVerified.Hash256.ofBytesLE_encode
-#assert_axioms BtcVerified.Hash256.encode_ofBytesLE
+#assert_axioms BtcVerified.instCodecHash256
+#assert_axioms BtcVerified.Hash256.encode_length
 
 /-! ## Transaction ids -/
 

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -84,9 +84,12 @@ elab "#assert_axioms " id:ident : command => do
 #assert_axioms BtcVerified.Collision.comp
 #assert_axioms BtcVerified.CollisionResistant.injective
 #assert_axioms BtcVerified.CollisionResistant.comp
+#assert_axioms BtcVerified.Collision.comp_inner
+#assert_axioms BtcVerified.CollisionResistant.of_comp
 #assert_axioms BtcVerified.Sha256.sha256d
 #assert_axioms BtcVerified.Sha256.sha256d_length
 #assert_axioms BtcVerified.Sha256.collisionResistant_sha256d
+#assert_axioms BtcVerified.Sha256.collisionResistant_sha256_iff_sha256d
 #assert_axioms BtcVerified.instCodecHash256
 #assert_axioms BtcVerified.Hash256.encode_length
 

--- a/Tests/BlockFixtures.lean
+++ b/Tests/BlockFixtures.lean
@@ -62,9 +62,9 @@ transaction vectors, tying the fixture to the inline `#guard`s. -/
 def block481824Checks (b : Block) : Bool :=
   b.header.version == 0x20000002
   && b.header.prevBlockHash
-    == 0x000000000000000000cbeff0b533f8e1189cf09dfbebf57a8ebe349362811b80#256
+    == hashOfDisplay "000000000000000000cbeff0b533f8e1189cf09dfbebf57a8ebe349362811b80"
   && b.header.merkleRoot
-    == 0x6438250cad442b982801ae6994edb8a9ec63c0a0ba117779fbe7ef7f07cad140#256
+    == hashOfDisplay "6438250cad442b982801ae6994edb8a9ec63c0a0ba117779fbe7ef7f07cad140"
   && b.header.time == 1503539857
   && b.header.bits == 0x18013ce9
   && b.header.nonce == 575995682

--- a/Tests/BlockFixtures.lean
+++ b/Tests/BlockFixtures.lean
@@ -79,7 +79,12 @@ def block481824Checks (b : Block) : Bool :=
       | none => false)
   -- Both serialization eras appear in the same block.
   && b.txs.val.any Tx.isSegWit
-  && b.txs.val.any fun tx => !tx.isSegWit
+  && (b.txs.val.any fun tx => !tx.isSegWit)
+  -- The header commits to all 1866 transaction ids through the merkle root,
+  -- and the txid list is canonical. With the header-hash check above, every
+  -- transaction byte in the fixture is now pinned: txids → merkle root →
+  -- header → proof-of-work hash.
+  && decide b.merkleCommits
 
 /-- Where a fixture block is cached locally, by display hash. Gitignored. -/
 def fixturePath (blockHash : String) : System.FilePath :=

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -47,6 +47,14 @@ where
 #guard hexBytes? "0" == none
 #guard hexBytes? "0g" == none
 
+/-- A hash from its conventional display hex (big-endian): parse and reverse to
+the raw digest bytes a `Hash256` holds. Total — malformed input yields the
+zero hash, never reached by the literal vectors below. -/
+def hashOfDisplay (s : String) : Hash256 :=
+  match (hexBytes? s).map List.reverse with
+  | some bs => (Hash256.ofBytes? bs).getD 0
+  | none => 0
+
 /-- Decode a transaction from hex and check it consumed every byte and
 re-encodes to exactly the input — then apply the vector's own spot-checks. -/
 def checksOut (hex : String) (spot : Tx → Bool) : Bool :=
@@ -84,9 +92,10 @@ def firstBitcoinPaymentHex : String :=
   && tx.body.outputs.val.length == 2
   && (match tx.body.inputs.val with
       | [i] =>
-        -- The displayed txid is the wire bytes reversed, so the little-endian
-        -- decode equals the display hex read as a number.
-        i.prevout.txid == 0x0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9#256
+        -- The display txid is the raw digest bytes reversed; `hashOfDisplay`
+        -- reverses back to what the byte-native `Hash256` stores.
+        i.prevout.txid
+          == hashOfDisplay "0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9"
         && i.prevout.vout == 0
         && i.sequence == 0xffffffff
       | _ => false)
@@ -123,7 +132,7 @@ def segwitCoinbaseHex : String :=
         version == 1 && outs.val.length == 2
         && (match ins.val with
             | [si] =>
-              si.input.prevout.txid == 0#256
+              si.input.prevout.txid == (0 : Hash256)
               && si.input.prevout.vout == 0xffffffff
               -- One witness item: the 32-zero-byte reserved value.
               && (match si.witness.val with
@@ -160,7 +169,7 @@ def firstSegwitSpendHex : String :=
         (match ins.val with
          | [si] =>
            si.input.prevout.txid
-             == 0x42f7d0545ef45bd3b9cfee6b170cf6314a3bd8b3f09b610eeb436d92993ad440#256
+             == hashOfDisplay "42f7d0545ef45bd3b9cfee6b170cf6314a3bd8b3f09b610eeb436d92993ad440"
            && si.input.prevout.vout == 1
            -- Witness: 72-byte DER signature, then 33-byte compressed pubkey.
            && (match si.witness.val with
@@ -203,11 +212,11 @@ def genesisBlockHex : String :=
 
 #guard blockChecksOut genesisBlockHex fun b =>
   b.header.version == 1
-  && b.header.prevBlockHash == 0#256
+  && b.header.prevBlockHash == (0 : Hash256)
   -- Displayed hashes are the wire bytes reversed, so the little-endian decode
   -- equals the display hex read as a number.
   && b.header.merkleRoot
-    == 0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b#256
+    == hashOfDisplay "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
   && b.header.time == 1231006505
   && b.header.bits == 0x1d00ffff
   && b.header.nonce == 2083236893
@@ -255,9 +264,9 @@ def block170Hex : String :=
 #guard blockChecksOut block170Hex fun b =>
   b.header.version == 1
   && b.header.prevBlockHash
-    == 0x000000002a22cfee1f2c846adbd12b3e183d4f97683f85dad08a79780a84bd55#256
+    == hashOfDisplay "000000002a22cfee1f2c846adbd12b3e183d4f97683f85dad08a79780a84bd55"
   && b.header.merkleRoot
-    == 0x7dac2c5666815c17a3b36427de37bb9d2e2c5ccec3f8633eb91a4205cb4c10ff#256
+    == hashOfDisplay "7dac2c5666815c17a3b36427de37bb9d2e2c5ccec3f8633eb91a4205cb4c10ff"
   && b.header.time == 1231731025
   && b.header.bits == 0x1d00ffff
   && (match b.txs.val with
@@ -311,7 +320,7 @@ def block170Hex : String :=
 -- The first Bitcoin payment; legacy, so wtxid = txid.
 #guard match hexBytes? firstBitcoinPaymentHex >>= Codec.decode (α := Tx) with
   | some (tx, _) =>
-    tx.txid == 0xf4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16#256
+    tx.txid == hashOfDisplay "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16"
     && tx.wtxid == tx.txid
   | none => false
 
@@ -319,7 +328,8 @@ def block170Hex : String :=
 #guard match hexBytes? genesisBlockHex >>= Codec.decode (α := Block) with
   | some (b, _) => match b.txs.val with
     | [coinbase] =>
-      coinbase.txid == 0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b#256
+      coinbase.txid
+        == hashOfDisplay "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
       && coinbase.txid == b.header.merkleRoot
     | _ => false
   | none => false
@@ -327,7 +337,7 @@ def block170Hex : String :=
 -- The SegWit activation coinbase: the witness makes wtxid ≠ txid.
 #guard match hexBytes? segwitCoinbaseHex >>= Codec.decode (α := Tx) with
   | some (tx, _) =>
-    tx.txid == 0xda917699942e4a96272401b534381a75512eeebe8403084500bd637bd47168b3#256
+    tx.txid == hashOfDisplay "da917699942e4a96272401b534381a75512eeebe8403084500bd637bd47168b3"
     && tx.wtxid != tx.txid
   | none => false
 

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -301,4 +301,34 @@ def block170Hex : String :=
 #guard some (Sha256.sha256 (List.replicate 64 0x61)) ==
   hexBytes? "ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb"
 
+/-! ## Transaction ids
+
+  Txids of the standalone transaction vectors against their well-known
+  display hashes. The displayed hex is the digest bytes reversed, so the
+  little-endian `Hash256` value equals the display hex read as a number —
+  the same convention the prevout-txid spot-checks above already pin. -/
+
+-- The first Bitcoin payment; legacy, so wtxid = txid.
+#guard match hexBytes? firstBitcoinPaymentHex >>= Codec.decode (α := Tx) with
+  | some (tx, _) =>
+    tx.txid == 0xf4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16#256
+    && tx.wtxid == tx.txid
+  | none => false
+
+-- The genesis coinbase: its txid is the genesis merkle root.
+#guard match hexBytes? genesisBlockHex >>= Codec.decode (α := Block) with
+  | some (b, _) => match b.txs.val with
+    | [coinbase] =>
+      coinbase.txid == 0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b#256
+      && coinbase.txid == b.header.merkleRoot
+    | _ => false
+  | none => false
+
+-- The SegWit activation coinbase: the witness makes wtxid ≠ txid.
+#guard match hexBytes? segwitCoinbaseHex >>= Codec.decode (α := Tx) with
+  | some (tx, _) =>
+    tx.txid == 0xda917699942e4a96272401b534381a75512eeebe8403084500bd637bd47168b3#256
+    && tx.wtxid != tx.txid
+  | none => false
+
 end Tests.GoldenVectors

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -331,4 +331,35 @@ def block170Hex : String :=
     && tx.wtxid != tx.txid
   | none => false
 
+/-! ## The merkle commitment
+
+  The padding ambiguity and its canonicality fence on synthetic leaves, then
+  the real commitment on real blocks: txids → merkle root → header. -/
+
+-- Materializing the padding of a three-leaf list collides at the root
+-- (CVE-2012-2459); canonicality is what separates the two lists.
+#guard Merkle.computeRoot ([1, 2, 3] : List Hash256)
+  == Merkle.computeRoot ([1, 2, 3, 3] : List Hash256)
+#guard Merkle.canonicalCheck ([1, 2, 3] : List Hash256)
+#guard !Merkle.canonicalCheck ([1, 2, 3, 3] : List Hash256)
+-- A duplicated run of length two only surfaces one level up the tree.
+#guard Merkle.computeRoot ([1, 2, 3, 4, 5, 6] : List Hash256)
+  == Merkle.computeRoot ([1, 2, 3, 4, 5, 6, 5, 6] : List Hash256)
+#guard !Merkle.canonicalCheck ([1, 2, 3, 4, 5, 6, 5, 6] : List Hash256)
+-- A pair-aligned duplicate in the middle is honest content: no shorter list
+-- shares its root, so it stays canonical (Core's uniform scan would reject
+-- it, but such a block has a duplicate txid and dies at transaction
+-- validity instead).
+#guard Merkle.canonicalCheck ([1, 1, 2, 3] : List Hash256)
+
+-- The genesis block commits to its single transaction (root = txid).
+#guard match hexBytes? genesisBlockHex >>= Codec.decode (α := Block) with
+  | some (b, _) => decide b.merkleCommits
+  | none => false
+
+-- Block 170 commits to its two transactions (one real combine).
+#guard match hexBytes? block170Hex >>= Codec.decode (α := Block) with
+  | some (b, _) => decide b.merkleCommits
+  | none => false
+
 end Tests.GoldenVectors


### PR DESCRIPTION
The first consensus-validity leaves, following the ordering decision that validity is logically antecedent to canonicality: before any fork-choice machinery, the commitment layer that ties a block's body to its header.

## Transaction ids (`BtcVerified/Transaction/Txid.lean`)

- `Tx.txid` = double-SHA-256 of the witness-free `TxBody` serialization, read little-endian; `Tx.wtxid` (BIP141) over the full serialization. A legacy transaction's wtxid is its txid by `rfl`.
- **Faithfulness theorems**: equal txids imply equal bodies (equal wtxids imply equal transactions) — or two concrete byte strings witnessing a `sha256d` collision. The collision is a constructed disjunct, never an assumed-absent axiom; the proofs run through `encode_injective`, so the codec laws are exactly what make txids meaningful.
- Groundwork: the SHA-256 digest assembly moved out of the imperative loop so `sha256_length` is structural; `Hash256.ofBytesLE` fixes the one digest-bytes-to-value rule with lossless-on-32-bytes inversion lemmas.

## The merkle tree (`BtcVerified/Crypto/Merkle.lean`)

- **Root computation and canonicality factored apart**: `computeRoot : List Hash256 → Hash256` is one deterministic cryptographic operation (no `mutated` flag in the codomain — the label survives only as background prose), and `Canonical` is a first-class decidable property of the leaf list that consensus demands.
- **Structural spec**: a top-down bisection `Tree` with procedural duplication as an explicit `pad` constructor; `computeRoot_eq_root` proves Bitcoin's bottom-up fold equal to it.
- **Canonicality is minimal**: only right-spine duplications can materialize a shorter list's padding (CVE-2012-2459), so only those are forbidden — the root node is exempt, and an honest middle duplicate stays canonical. Core's uniform scan is strictly stronger; the two agree on transaction-valid blocks (documented remark).
- **Injectivity theorems**: `root_inj_of_length_eq` (equal lengths, no canonicality needed) and `root_inj_of_canonical` (canonical lists of equal enclosing width) — each concluding equality or a concrete `sha256d` collision. The equal-width hypothesis is the documented residual: the 64-byte-transaction leaf/interior ambiguity (Great Consensus Cleanup reference in the module header).

## The commitment (`BtcVerified/Block/Commitment.lean`)

`Block.merkleCommits` = the txid list is canonical AND its merkle root is the header's. Decidable, so it is checked on real blocks: genesis and block 170 at build time, and all 1866 transactions of block 481824 under `lake test` — which, with the existing header-hash check, makes the fixture fully self-authenticating (txids → merkle root → header → proof-of-work hash). The corrupted-byte experiment that previously slipped through the codec-consistency checks now fails.

Golden vectors also exercise the CVE equality itself on synthetic leaves: `[1,2,3]` and `[1,2,3,3]` share a root and canonicality separates them; a duplicated run of length two surfaces one level up.

All headline theorems are registered in the axiom audit; `lake build`, `lake test`, and `lake lint` are green, and every commit in the series builds.

**Note**: this branch is stacked on `wire-serialization` (the serialization commits it depends on); its commits appear here until that branch merges, after which this rebases clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
