### PR TITLE
Module discipline: split BitCommitment, codify the rule and working norms

### DIFF
--- a/.claude/skills/proof-leaf/SKILL.md
+++ b/.claude/skills/proof-leaf/SKILL.md
@@ -12,8 +12,20 @@ every step is done.
 
 ## 1. The module
 
-- One concern per file, under the matching directory (`Serialize/`,
-  `Transaction/`, `Block/`, `Crypto/`, `BitVM/`).
+- **One major type per module.** A module defines at most one `structure`/
+  `inductive`, and that type's instances — especially of classes we define,
+  like `Codec` — live in its module, never in a collector. (`Prop`-valued
+  predicates and helper `def`s are not "types"; they sit beside the type they
+  are about.) Two exceptions: (A) instances of *our* class over a Core/
+  dependency type live with the *class* — that is why `instCodecUInt8…64` and
+  `instCodecBitVec256` sit in `Serialize/Codec.lean`; (B) record arms of a sum
+  type may share a module *only if* those arm types never appear in a
+  signature outside it (so `SegwitInput`, which appears in `Tx`'s constructor
+  and codec, earns its own module). The audit (issue #9) enforces this.
+- Files sit under the matching directory (`Serialize/`, `Transaction/`,
+  `Block/`, `Crypto/`, `BitVM/`); a leaf with several tightly-coupled types
+  becomes a directory of one-type modules under an umbrella facade that
+  preserves the import surface (see `BitVM/BitCommitment/`).
 - `/-!` module header: two-space indented content, `# Title`, the design
   rationale in prose, and — for proof-bearing modules — a `Checked claims:`
   bullet list naming the theorems. Match the voice of

--- a/BtcVerified/BitVM/BitCommitment.lean
+++ b/BtcVerified/BitVM/BitCommitment.lean
@@ -1,184 +1,31 @@
+import BtcVerified.BitVM.BitCommitment.Bit
+import BtcVerified.BitVM.BitCommitment.Opening
+import BtcVerified.BitVM.BitCommitment.ValidOpening
+import BtcVerified.BitVM.BitCommitment.Collision
+import BtcVerified.BitVM.BitCommitment.Equivocation
 /-!
   # Abstract BitVM bit commitments
 
-  This module models the smallest useful commitment primitive for the BitVM
-  verification track. The hash function is intentionally abstract: the point of
-  this leaf is not to verify SHA-256 or any concrete compression function, but
-  to state the protocol-level shape that any collision-resistant commitment
-  hash must satisfy.
+  This leaf models the smallest useful commitment primitive for the BitVM
+  verification track. The hash function is intentionally abstract: the point is
+  not to verify SHA-256 or any concrete compression function, but to state the
+  protocol-level shape that any collision-resistant commitment hash must
+  satisfy.
 
   A commitment is produced by hashing a bit together with a nonce. An
   equivocation is a single commitment with two valid openings to distinct bits.
-  The checked proof spine is:
+  The checked proof spine, one type per module:
 
-  * distinct opened bits imply distinct openings;
-  * an equivocation therefore gives two distinct openings with the same digest,
-    i.e. a collision;
-  * any equivocation refutes collision resistance;
-  * collision resistance gives non-equivocation;
-  * non-equivocation makes the induced commitments binding.
+  * `Bit` / `Opening` — the committed payload and what reveals it; distinct
+    opened bits imply distinct openings;
+  * `Collision` — two distinct openings with the same digest, and
+    `CollisionResistance` ruling them out;
+  * `ValidOpening` — an opening with its proof, and the `Binding` goal;
+  * `Equivocation` — the binding spine: an equivocation gives a collision, so
+    collision resistance forbids equivocation, and non-equivocation makes the
+    commitments binding.
 
   This is deliberately tiny, but it fixes the vocabulary for later BitVM proof
-  packets: openings, equivocation, collision resistance, and binding.
+  packets: openings, equivocation, collision resistance, and binding. The track
+  is on ice for now; this module is the umbrella over its split parts.
 -/
-
-namespace BtcVerified.BitVM.BitCommitment
-
-/-- The committed payload is a bit. -/
-inductive Bit where
-  | zero
-  | one
-  deriving DecidableEq, Repr
-
-/-- An opening reveals both the committed bit and the nonce used to commit it. -/
-structure Opening (Nonce : Type) where
-  /-- The bit revealed by the opening. -/
-  bit : Bit
-  /-- The nonce paired with the revealed bit. -/
-  nonce : Nonce
-
-/-- If two openings reveal different bits, then the openings themselves are
-different. This is the small structural fact that turns equivocation into a
-collision witness. -/
-theorem openings_with_distinct_bits_are_distinct {Nonce : Type}
-    (left right : Opening Nonce)
-    (hdiff : left.bit ≠ right.bit) : left ≠ right := by
-  exact mt (congrArg Opening.bit) hdiff
-
-/-- A commitment is just a digest value at this abstraction level. -/
-abbrev Commitment (Digest : Type) := Digest
-
-/-- Commits to a bit by hashing the bit together with a nonce. -/
-def commit
-    (hash : Bit → Nonce → Digest)
-    (bit : Bit)
-    (nonce : Nonce) :
-    Commitment Digest :=
-  hash bit nonce
-
-/-- An opening verifies when recomputing the commitment yields the same digest. -/
-def Verifies
-    (hash : Bit → Nonce → Digest)
-    (c : Commitment Digest)
-    (opening : Opening Nonce) :
-    Prop :=
-  commit hash opening.bit opening.nonce = c
-
-/-- The opening used to create a commitment verifies for that commitment. -/
-theorem commitment_verifies_against_original_opening
-    (hash : Bit → Nonce → Digest)
-    (bit : Bit)
-    (nonce : Nonce) :
-    Verifies hash (commit hash bit nonce) ⟨bit, nonce⟩ := by
-  rfl
-
-/-- A valid opening packages an opening together with its verification proof. -/
-structure ValidOpening (hash : Bit → Nonce → Digest) (c : Commitment Digest) where
-  /-- The concrete opening being validated. -/
-  opening : Opening Nonce
-  /-- Evidence that the opening recomputes to the target commitment. -/
-  valid : Verifies hash c opening
-
-/-- Equivocation means one commitment has two valid openings whose revealed bits
-are distinct. -/
-structure Equivocation (hash : Bit → Nonce → Digest) where
-  /-- The commitment that admits two distinct valid openings. -/
-  commitment : Commitment Digest
-  /-- One valid opening for the commitment. -/
-  left : ValidOpening hash commitment
-  /-- Another valid opening for the same commitment. -/
-  right : ValidOpening hash commitment
-  /-- Evidence that the two openings reveal different bits. -/
-  bits_distinct : left.opening.bit ≠ right.opening.bit
-
-/-- A collision is two distinct openings that produce the same commitment digest
-under the abstract hash. -/
-structure Collision (hash : Bit → Nonce → Digest) where
-  /-- One opening in the collision pair. -/
-  left : Opening Nonce
-  /-- The other opening in the collision pair. -/
-  right : Opening Nonce
-  /-- Evidence that the two openings are not the same opening. -/
-  distinct : left ≠ right
-  /-- Evidence that the two openings hash to the same digest. -/
-  same_digest : commit hash left.bit left.nonce = commit hash right.bit right.nonce
-
-/-- Extracts the concrete collision witness contained in an equivocation.
-
-The two openings are distinct because they reveal different bits, and their
-digests are equal because both verify against the same commitment. -/
-def Equivocation.toCollision
-    {hash : Bit → Nonce → Digest}
-    (equivocation : Equivocation hash) :
-    Collision hash :=
-  let ⟨_commitment, left, right, bits_distinct⟩ := equivocation
-  { left := left.opening
-    right := right.opening
-    distinct := openings_with_distinct_bits_are_distinct left.opening right.opening bits_distinct
-    same_digest := by rw [left.valid, right.valid] }
-
-/-- The collision witness extracted from an equivocation; see `Equivocation.toCollision`. -/
-def Collision.ofEquivocation
-    {hash : Bit → Nonce → Digest}
-    (equivocation : Equivocation hash) :
-    Collision hash :=
-  equivocation.toCollision
-
-/-- `CollisionResistance` says that the bundled commitment function admits no
-collision witnesses. -/
-def CollisionResistance (hash : Bit → Nonce → Digest) : Prop := Collision hash → False
-
-/-- Any equivocation refutes collision resistance, because the equivocation can
-be converted into a concrete collision. -/
-theorem equivocation_refutes_collision_resistance
-    (hash : Bit → Nonce → Digest)
-    (equivocation : Equivocation hash) :
-    ¬ CollisionResistance hash := by
-  intro resistance
-  apply resistance
-  exact equivocation.toCollision
-
-/-- `NonEquivocation` says that the bundled commitment function admits no
-equivocation witnesses. -/
-def NonEquivocation (hash : Bit → Nonce → Digest) : Prop := Equivocation hash → False
-
-/-- Collision resistance gives non-equivocation: an equivocation witness would
-produce the collision witness that collision resistance rules out. -/
-theorem CollisionResistance.nonEquivocation
-    {hash : Bit → Nonce → Digest}
-    (resistance : CollisionResistance hash) :
-    NonEquivocation hash := by
-  intro equivocation
-  apply resistance
-  exact equivocation.toCollision
-
-/-- `Binding` says that any two valid openings reveal the same bit. -/
-def Binding (hash : Bit → Nonce → Digest) : Prop :=
-  ∀ (c : Commitment Digest) (left right : ValidOpening hash c),
-    left.opening.bit = right.opening.bit
-
-/-- If equivocation is impossible, then two valid openings for the same commitment
-must reveal the same bit. -/
-theorem NonEquivocation.binding
-    {hash : Bit → Nonce → Digest}
-    (hashForbidsEquivocation : NonEquivocation hash) :
-    Binding hash := by
-  intros commitment left right
-  by_cases same_bits : left.opening.bit = right.opening.bit
-  · exact same_bits
-  · apply False.elim
-    apply hashForbidsEquivocation
-    constructor
-    exact same_bits
-
-/-- Collision resistance makes the induced commitments binding.
-
-Collision resistance gives non-equivocation, and non-equivocation rules out
-pairs of valid openings that reveal different bits. -/
-theorem CollisionResistance.binding
-    {hash : Bit → Nonce → Digest}
-    (resistance : CollisionResistance hash) :
-    Binding hash :=
-  resistance.nonEquivocation.binding
-
-end BtcVerified.BitVM.BitCommitment

--- a/BtcVerified/BitVM/BitCommitment/Bit.lean
+++ b/BtcVerified/BitVM/BitCommitment/Bit.lean
@@ -1,0 +1,15 @@
+/-!
+  # The committed bit
+
+  The payload a BitVM bit commitment commits to: a single bit.
+-/
+
+namespace BtcVerified.BitVM.BitCommitment
+
+/-- The committed payload is a bit. -/
+inductive Bit where
+  | zero
+  | one
+  deriving DecidableEq, Repr
+
+end BtcVerified.BitVM.BitCommitment

--- a/BtcVerified/BitVM/BitCommitment/Collision.lean
+++ b/BtcVerified/BitVM/BitCommitment/Collision.lean
@@ -1,0 +1,28 @@
+import BtcVerified.BitVM.BitCommitment.Opening
+/-!
+  # Collisions and collision resistance
+
+  A collision is two distinct openings that hash to the same commitment digest.
+  Collision resistance says no such witness exists — the abstract hypothesis the
+  binding of the commitment scheme will rest on.
+-/
+
+namespace BtcVerified.BitVM.BitCommitment
+
+/-- A collision is two distinct openings that produce the same commitment digest
+under the abstract hash. -/
+structure Collision (hash : Bit → Nonce → Digest) where
+  /-- One opening in the collision pair. -/
+  left : Opening Nonce
+  /-- The other opening in the collision pair. -/
+  right : Opening Nonce
+  /-- Evidence that the two openings are not the same opening. -/
+  distinct : left ≠ right
+  /-- Evidence that the two openings hash to the same digest. -/
+  same_digest : commit hash left.bit left.nonce = commit hash right.bit right.nonce
+
+/-- `CollisionResistance` says that the bundled commitment function admits no
+collision witnesses. -/
+def CollisionResistance (hash : Bit → Nonce → Digest) : Prop := Collision hash → False
+
+end BtcVerified.BitVM.BitCommitment

--- a/BtcVerified/BitVM/BitCommitment/Equivocation.lean
+++ b/BtcVerified/BitVM/BitCommitment/Equivocation.lean
@@ -1,0 +1,95 @@
+import BtcVerified.BitVM.BitCommitment.ValidOpening
+import BtcVerified.BitVM.BitCommitment.Collision
+/-!
+  # Equivocation and the binding spine
+
+  Equivocation is one commitment with two valid openings to distinct bits. This
+  module closes the proof spine: an equivocation yields a collision witness, so
+  collision resistance forbids equivocation, and non-equivocation makes the
+  commitments binding.
+-/
+
+namespace BtcVerified.BitVM.BitCommitment
+
+/-- Equivocation means one commitment has two valid openings whose revealed bits
+are distinct. -/
+structure Equivocation (hash : Bit → Nonce → Digest) where
+  /-- The commitment that admits two distinct valid openings. -/
+  commitment : Commitment Digest
+  /-- One valid opening for the commitment. -/
+  left : ValidOpening hash commitment
+  /-- Another valid opening for the same commitment. -/
+  right : ValidOpening hash commitment
+  /-- Evidence that the two openings reveal different bits. -/
+  bits_distinct : left.opening.bit ≠ right.opening.bit
+
+/-- Extracts the concrete collision witness contained in an equivocation.
+
+The two openings are distinct because they reveal different bits, and their
+digests are equal because both verify against the same commitment. -/
+def Equivocation.toCollision
+    {hash : Bit → Nonce → Digest}
+    (equivocation : Equivocation hash) :
+    Collision hash :=
+  let ⟨_commitment, left, right, bits_distinct⟩ := equivocation
+  { left := left.opening
+    right := right.opening
+    distinct := openings_with_distinct_bits_are_distinct left.opening right.opening bits_distinct
+    same_digest := by rw [left.valid, right.valid] }
+
+/-- The collision witness extracted from an equivocation; see `Equivocation.toCollision`. -/
+def Collision.ofEquivocation
+    {hash : Bit → Nonce → Digest}
+    (equivocation : Equivocation hash) :
+    Collision hash :=
+  equivocation.toCollision
+
+/-- Any equivocation refutes collision resistance, because the equivocation can
+be converted into a concrete collision. -/
+theorem equivocation_refutes_collision_resistance
+    (hash : Bit → Nonce → Digest)
+    (equivocation : Equivocation hash) :
+    ¬ CollisionResistance hash := by
+  intro resistance
+  apply resistance
+  exact equivocation.toCollision
+
+/-- `NonEquivocation` says that the bundled commitment function admits no
+equivocation witnesses. -/
+def NonEquivocation (hash : Bit → Nonce → Digest) : Prop := Equivocation hash → False
+
+/-- Collision resistance gives non-equivocation: an equivocation witness would
+produce the collision witness that collision resistance rules out. -/
+theorem CollisionResistance.nonEquivocation
+    {hash : Bit → Nonce → Digest}
+    (resistance : CollisionResistance hash) :
+    NonEquivocation hash := by
+  intro equivocation
+  apply resistance
+  exact equivocation.toCollision
+
+/-- If equivocation is impossible, then two valid openings for the same commitment
+must reveal the same bit. -/
+theorem NonEquivocation.binding
+    {hash : Bit → Nonce → Digest}
+    (hashForbidsEquivocation : NonEquivocation hash) :
+    Binding hash := by
+  intros commitment left right
+  by_cases same_bits : left.opening.bit = right.opening.bit
+  · exact same_bits
+  · apply False.elim
+    apply hashForbidsEquivocation
+    constructor
+    exact same_bits
+
+/-- Collision resistance makes the induced commitments binding.
+
+Collision resistance gives non-equivocation, and non-equivocation rules out
+pairs of valid openings that reveal different bits. -/
+theorem CollisionResistance.binding
+    {hash : Bit → Nonce → Digest}
+    (resistance : CollisionResistance hash) :
+    Binding hash :=
+  resistance.nonEquivocation.binding
+
+end BtcVerified.BitVM.BitCommitment

--- a/BtcVerified/BitVM/BitCommitment/Opening.lean
+++ b/BtcVerified/BitVM/BitCommitment/Opening.lean
@@ -1,0 +1,54 @@
+import BtcVerified.BitVM.BitCommitment.Bit
+/-!
+  # Openings and the commitment function
+
+  An opening reveals the bit and the nonce behind a commitment. The commitment
+  itself is a digest produced by hashing the bit with the nonce, and an opening
+  verifies when recomputing that digest reproduces the commitment.
+-/
+
+namespace BtcVerified.BitVM.BitCommitment
+
+/-- An opening reveals both the committed bit and the nonce used to commit it. -/
+structure Opening (Nonce : Type) where
+  /-- The bit revealed by the opening. -/
+  bit : Bit
+  /-- The nonce paired with the revealed bit. -/
+  nonce : Nonce
+
+/-- If two openings reveal different bits, then the openings themselves are
+different. This is the small structural fact that turns equivocation into a
+collision witness. -/
+theorem openings_with_distinct_bits_are_distinct {Nonce : Type}
+    (left right : Opening Nonce)
+    (hdiff : left.bit ≠ right.bit) : left ≠ right := by
+  exact mt (congrArg Opening.bit) hdiff
+
+/-- A commitment is just a digest value at this abstraction level. -/
+abbrev Commitment (Digest : Type) := Digest
+
+/-- Commits to a bit by hashing the bit together with a nonce. -/
+def commit
+    (hash : Bit → Nonce → Digest)
+    (bit : Bit)
+    (nonce : Nonce) :
+    Commitment Digest :=
+  hash bit nonce
+
+/-- An opening verifies when recomputing the commitment yields the same digest. -/
+def Verifies
+    (hash : Bit → Nonce → Digest)
+    (c : Commitment Digest)
+    (opening : Opening Nonce) :
+    Prop :=
+  commit hash opening.bit opening.nonce = c
+
+/-- The opening used to create a commitment verifies for that commitment. -/
+theorem commitment_verifies_against_original_opening
+    (hash : Bit → Nonce → Digest)
+    (bit : Bit)
+    (nonce : Nonce) :
+    Verifies hash (commit hash bit nonce) ⟨bit, nonce⟩ := by
+  rfl
+
+end BtcVerified.BitVM.BitCommitment

--- a/BtcVerified/BitVM/BitCommitment/ValidOpening.lean
+++ b/BtcVerified/BitVM/BitCommitment/ValidOpening.lean
@@ -1,0 +1,24 @@
+import BtcVerified.BitVM.BitCommitment.Opening
+/-!
+  # Valid openings and binding
+
+  A valid opening bundles an opening with its verification proof. `Binding` is
+  the property the whole leaf is aiming at: any two valid openings of one
+  commitment reveal the same bit.
+-/
+
+namespace BtcVerified.BitVM.BitCommitment
+
+/-- A valid opening packages an opening together with its verification proof. -/
+structure ValidOpening (hash : Bit → Nonce → Digest) (c : Commitment Digest) where
+  /-- The concrete opening being validated. -/
+  opening : Opening Nonce
+  /-- Evidence that the opening recomputes to the target commitment. -/
+  valid : Verifies hash c opening
+
+/-- `Binding` says that any two valid openings reveal the same bit. -/
+def Binding (hash : Bit → Nonce → Digest) : Prop :=
+  ∀ (c : Commitment Digest) (left right : ValidOpening hash c),
+    left.opening.bit = right.opening.bit
+
+end BtcVerified.BitVM.BitCommitment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,11 +73,21 @@ Spec/transport split: the spec byte type is `List UInt8`. Do not switch to
 
 ## Conventions
 
+- **One type per module**: a module defines at most one `structure`/`inductive`,
+  and that type's instances live in its module — never a collector. Exceptions:
+  instances of our classes over Core/dependency types live with the *class*
+  (e.g. `instCodecUInt8…64` in `Serialize/Codec.lean`); sum-type arm-records may
+  share a module if they never appear in an outside signature. Tightly-coupled
+  clusters become a directory of one-type modules under an umbrella facade (see
+  `BitVM/BitCommitment/`). A `lake`-run introspection audit enforces this
+  (issue #9).
 - **Naming**: rigid Lean/mathlib casing. `UpperCamelCase` for types, props,
   and predicates; `lowerCamelCase` for defs; theorem names describe the
   conclusion mathlib-style (`decode_encode`, `encodeBitVecLE_length`). Full
   words over abbreviations, except honored Bitcoin nomenclature (`scriptSig`,
-  `scriptPubKey`, `nBits`, `vout`, txid).
+  `scriptPubKey`, `nBits`, `vout`, txid). When you can't recall a Mathlib lemma
+  name, search by *type* (`exact?`/`apply?`/`rw?`, loogle, `#leansearch`) — see
+  `CONTRIBUTING.md`.
 - **Doc-strings**: every public declaration gets `/--`. Text starts on the
   same line one space after `/--` (the `linter.style.docString` rule);
   continuation lines are flush-left; closing `-/` sits at the end of the last
@@ -111,3 +121,12 @@ Spec/transport split: the spec byte type is `List UInt8`. Do not switch to
    "Why it matters:" paragraph tying it to the fork-choice stack.
 
 The `/proof-leaf` skill walks through this checklist.
+
+## Deferring work
+
+A deferral is not "done" until it is a tracked GitHub issue. When you set work
+aside — a follow-up leaf, a known cleanup, a someday-proof, a residual flagged
+in review — file an issue (`gh issue create`) capturing the decision and
+enough context to act on it cold, and reference that issue where the work was
+deferred (commit, PR thread, or module header). "I'll get to it later" without
+an issue is how obligations get lost; the issue is the obligation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,9 @@ they prove.
 - **Naming** follows mathlib conventions: `UpperCamelCase` types and
   predicates, `lowerCamelCase` defs, conclusion-describing theorem names.
   Bitcoin's own nomenclature (`scriptSig`, `nBits`, `vout`) is kept verbatim.
+- **One type per module**: a module defines at most one `structure`/`inductive`,
+  with its instances alongside it (see `CLAUDE.md` for the exact rule and its
+  two exceptions).
 
 ## Workflow
 
@@ -40,6 +43,30 @@ A new proof leaf should:
 
 Commit messages are imperative-mood with a body explaining the why; see
 `git log` for the house style.
+
+## Finding lemmas by type
+
+Mathlib names are transcriptions of the statement (the head symbols of the
+left-hand side, read outside-in, joined by `_`, with relation/connective/
+direction words), so a name is meant to be *reconstructed* from the type
+rather than memorized — see the [naming
+guide](https://leanprover-community.github.io/contribute/naming.html). When
+reconstruction fails, search by type:
+
+- **`exact?` / `apply?` / `rw?`** — built into Lean + Mathlib, zero setup:
+  place the cursor on the goal and they search for a lemma matching its type.
+  The day-to-day tool.
+- **loogle** — search by term *pattern/shape*, e.g. `List.zipWith (_ + _)`:
+  the web UI at <https://loogle.lean-lang.org/>, or the `#loogle` command
+  in-editor.
+- **`#leansearch`** — natural-language queries (<https://leansearch.net>) via
+  LeanSearchClient, which this project already depends on, so it works in any
+  file here.
+
+## Deferring work
+
+If you set work aside, file a GitHub issue for it — a deferral is not done
+until it is tracked. See the policy in `CLAUDE.md`.
 
 See `CLAUDE.md` for the full design conventions (the codec discipline, the
 spec/transport split, doc-string formatting).


### PR DESCRIPTION
Addresses the working-norm review comments on #8, in two commits.

## Split BitCommitment into one type per module

`BtcVerified/BitVM/BitCommitment.lean` defined five types in one module. It's now a `BitVM/BitCommitment/` directory of one-type modules — `Bit`, `Opening` (with the `commit`/`Verifies` machinery), `ValidOpening` (with `Binding`), `Collision` (with `CollisionResistance`), and `Equivocation` (the binding spine) — under an umbrella `BitCommitment.lean` that re-imports them. The namespace is preserved, so every fully-qualified name and its axiom-audit registration is unchanged; `import BtcVerified.BitVM.BitCommitment` still works. Naive split per the review; the BitVM track stays on ice.

## Codify the discipline and two working norms

- **Module discipline** — the one-major-type-per-module rule (instances beside their type; exceptions for our-class-over-Core-types and sum-type arm-records) is now stated in `CLAUDE.md`, `CONTRIBUTING.md`, and the proof-leaf skill. This is the human-readable spec the introspection audit (#9) will enforce.
- **Deferral policy** — a deferral isn't "done" until it's a tracked GitHub issue. Applied retroactively to this review: #9 (audit), #10 (SHA KATs), #11 (SHA formal correctness), #12 (Ext naming).
- **Finding lemmas by type** — a `CONTRIBUTING.md` section pointing at `exact?`/`apply?`/`rw?`, loogle, and `#leansearch`, plus the Mathlib naming guide.

Every commit builds; `lake build`, `lake test`, and `lake lint` are green.

**Stacked on #8** (it carries the `CLAUDE.md`/`CONTRIBUTING.md`/`SKILL.md` this edits, and the unsplit `BitCommitment.lean`); its commits appear here until #8 merges, after which this rebases clean. Should merge after #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
