### PR TITLE
Move Bitcoin's vector merkle computation out of the spec into BitcoinCore

### DIFF
--- a/BtcVerified/Block/Commitment.lean
+++ b/BtcVerified/Block/Commitment.lean
@@ -27,7 +27,7 @@ ids form a canonical list whose merkle root is the header's. With
 their txid lists — or exhibit a concrete double-SHA-256 collision. -/
 def Block.merkleCommits (b : Block) : Prop :=
   Merkle.Canonical (b.txs.val.map Tx.txid)
-    ∧ Merkle.computeRoot (b.txs.val.map Tx.txid) = b.header.merkleRoot
+    ∧ Merkle.root (b.txs.val.map Tx.txid) = b.header.merkleRoot
 
 instance : DecidablePred Block.merkleCommits := fun _ =>
   inferInstanceAs (Decidable (_ ∧ _))

--- a/BtcVerified/Crypto/Merkle.lean
+++ b/BtcVerified/Crypto/Merkle.lean
@@ -9,27 +9,22 @@ import Mathlib.Data.Nat.Log
   digests. Bitcoin pads an odd level by hashing its last node with itself —
   and that padding rule makes the construction famously non-injective
   (CVE-2012-2459): a list that materializes part of its own padding as actual
-  content produces the same root as the shorter list it extends. Core rejects
-  such blocks with a uniform per-level duplicate-pair scan fused into its root
-  computation (its `mutated` flag). Here the concern is factored apart: the
-  root computation is one deterministic cryptographic operation, and
-  *canonicality* is a first-class, decidable property of the leaf list.
+  content produces the same root as the shorter list it extends. So a consensus
+  rule must demand more than root equality; that extra requirement,
+  *canonicality*, is factored apart here as a first-class, decidable property of
+  the leaf list.
 
   The spec is structural rather than procedural: `Tree` is built top-down by
   bisection at the enclosing power of two, and procedural duplication is an
   explicit constructor (`pad`, semantically a node with two equal children)
-  instead of an artifact of iteration order. The bottom-up fold Bitcoin
-  actually computes (`computeRoot`) is proved equal to the spec.
+  instead of an artifact of iteration order.
 
   Canonicality constrains exactly what threatens injectivity and nothing
   more. Padding only ever duplicates trailing power-of-two-aligned blocks —
   the right spine — so a cross-length collision requires a trailing block
   duplicating its left sibling, and `Canonical` forbids precisely that
   (`Tree.spineCanonical`, root node exempt: a shorter list with the same
-  enclosing width must still split at the root). Core's uniform scan is
-  strictly stronger — it also rejects pair-aligned duplicates that no padding
-  could produce — but the two agree on transaction-valid blocks, where a
-  duplicated leaf means a duplicated txid: a self-double-spend or a collision.
+  enclosing width must still split at the root).
 
   Collision resistance is never assumed: theorems conclude with
   `Sha256.Collision` — two concrete colliding byte strings — as a
@@ -44,8 +39,6 @@ import Mathlib.Data.Nat.Log
 
   Checked claims:
 
-  * `computeRoot_eq_root`: the bottom-up fold computes the structural spec's
-    root.
   * `root_inj_of_length_eq`: between equal-length lists, the root identifies
     the list — or two concrete byte strings collide under double-SHA-256.
   * `root_inj_of_canonical`: between canonical lists of equal enclosing
@@ -120,125 +113,6 @@ def tree (xs : List Hash256) : Tree := ofList xs (Nat.clog 2 xs.length)
 
 /-- The merkle root of a leaf list (the structural spec). -/
 def root (xs : List Hash256) : Hash256 := (tree xs).root
-
-/-! ## The bottom-up computation -/
-
-/-- One level of Bitcoin's bottom-up fold: hash adjacent pairs, hashing an
-unpaired last node with itself. -/
-def foldLevel : List Hash256 → List Hash256
-  | [] => []
-  | [x] => [combine x x]
-  | x :: y :: rest => combine x y :: foldLevel rest
-
-/-- Each fold level halves the node count, rounding up. -/
-theorem foldLevel_length : ∀ xs : List Hash256, (foldLevel xs).length = (xs.length + 1) / 2
-  | [] => by simp [foldLevel]
-  | [_] => by simp [foldLevel]
-  | _ :: _ :: rest => by simp [foldLevel, foldLevel_length rest]; omega
-
-/-- The merkle root as Bitcoin computes it: fold levels bottom-up until one
-node remains. One deterministic cryptographic operation — canonicality of the
-input is `Canonical`'s concern, decided separately. (Core fuses a duplicate
-scan into this same pass under the name `mutated`; see the module header.) -/
-def computeRoot : List Hash256 → Hash256
-  | [] => 0
-  | [x] => x
-  | x :: y :: rest => computeRoot (foldLevel (x :: y :: rest))
-  termination_by xs => xs.length
-  decreasing_by simp [foldLevel_length]; omega
-
-/-- A fold level distributes over an append at an even boundary. -/
-theorem foldLevel_append : ∀ (as bs : List Hash256), as.length % 2 = 0 →
-    foldLevel (as ++ bs) = foldLevel as ++ foldLevel bs
-  | [], _, _ => rfl
-  | [_], _, h => by simp at h
-  | a :: a' :: rest, bs, h => by
-    have hrest : rest.length % 2 = 0 := by simp at h; omega
-    cases bs with
-    | nil => simp [foldLevel]
-    | cons b bs' =>
-      simp only [List.cons_append, foldLevel, foldLevel_append rest (b :: bs') hrest]
-
-/-- One spec level absorbs one fold level: the width-`2 ^ (k + 1)` tree over
-`xs` and the width-`2 ^ k` tree over `foldLevel xs` share a root. -/
-theorem ofList_root_foldLevel :
-    ∀ (k : Nat) (xs : List Hash256), 0 < xs.length → xs.length ≤ 2 ^ (k + 1) →
-      (ofList xs (k + 1)).root = (ofList (foldLevel xs) k).root := by
-  intro k
-  induction k with
-  | zero =>
-    intro xs h0 h2
-    rw [Nat.pow_succ, Nat.pow_zero, Nat.one_mul] at h2
-    cases xs with
-    | nil => simp at h0
-    | cons x xs' =>
-      cases xs' with
-      | nil => simp [ofList, foldLevel, Tree.root]
-      | cons y xs'' =>
-        have hnil : xs'' = [] := by
-          simp only [List.length_cons] at h2
-          exact List.eq_nil_of_length_eq_zero (by omega)
-        subst hnil
-        simp [ofList, foldLevel, Tree.root]
-  | succ k ih =>
-    intro xs h0 h2
-    have hpow : 2 ^ (k + 2) = 2 ^ (k + 1) + 2 ^ (k + 1) := Nat.two_pow_succ (k + 1)
-    have hpow' : 2 ^ (k + 1) = 2 ^ k + 2 ^ k := Nat.two_pow_succ k
-    by_cases hsplit : xs.length ≤ 2 ^ (k + 1)
-    · have hfold : (foldLevel xs).length ≤ 2 ^ k := by
-        rw [foldLevel_length]; omega
-      have hL : ofList xs (k + 1 + 1) = .pad (ofList xs (k + 1)) := by
-        rw [ofList, if_pos hsplit]
-      have hR : ofList (foldLevel xs) (k + 1) = .pad (ofList (foldLevel xs) k) := by
-        rw [ofList, if_pos hfold]
-      rw [hL, hR, Tree.root, Tree.root, ih xs h0 hsplit]
-    · have hsplit' : 2 ^ (k + 1) < xs.length := by omega
-      have htake : (xs.take (2 ^ (k + 1))).length = 2 ^ (k + 1) := by
-        rw [List.length_take]; omega
-      have hsplitFold : foldLevel xs = foldLevel (xs.take (2 ^ (k + 1)))
-          ++ foldLevel (xs.drop (2 ^ (k + 1))) := by
-        rw [← foldLevel_append _ _ (by omega), List.take_append_drop]
-      have hfoldTake : (foldLevel (xs.take (2 ^ (k + 1)))).length = 2 ^ k := by
-        rw [foldLevel_length, htake]; omega
-      have hfoldLen : ¬ (foldLevel xs).length ≤ 2 ^ k := by
-        rw [foldLevel_length]; omega
-      have hL : ofList xs (k + 1 + 1)
-          = .node (ofList (xs.take (2 ^ (k + 1))) (k + 1))
-              (ofList (xs.drop (2 ^ (k + 1))) (k + 1)) := by
-        rw [ofList, if_neg (by omega)]
-      have hR : ofList (foldLevel xs) (k + 1)
-          = .node (ofList ((foldLevel xs).take (2 ^ k)) k)
-              (ofList ((foldLevel xs).drop (2 ^ k)) k) := by
-        rw [ofList, if_neg hfoldLen]
-      have htakeF : (foldLevel xs).take (2 ^ k) = foldLevel (xs.take (2 ^ (k + 1))) := by
-        rw [hsplitFold, List.take_left' hfoldTake]
-      have hdropF : (foldLevel xs).drop (2 ^ k) = foldLevel (xs.drop (2 ^ (k + 1))) := by
-        rw [hsplitFold, List.drop_left' hfoldTake]
-      rw [hL, hR, Tree.root, Tree.root, htakeF, hdropF,
-        ih _ (by rw [List.length_take]; omega) (by omega),
-        ih _ (by rw [List.length_drop]; omega) (by rw [List.length_drop]; omega)]
-
-/-- The bottom-up fold computes the structural spec's root. -/
-theorem computeRoot_eq_root : ∀ xs : List Hash256, computeRoot xs = root xs
-  | [] => by simp [computeRoot, root, tree, Nat.clog_zero_right, ofList, Tree.root]
-  | [x] => by simp [computeRoot, root, tree, Nat.clog_one_right, ofList, Tree.root]
-  | x :: y :: rest => by
-    have hlen : 2 ≤ (x :: y :: rest).length := by simp
-    have hclog : Nat.clog 2 (x :: y :: rest).length
-        = Nat.clog 2 (((x :: y :: rest).length + 1) / 2) + 1 := by
-      rw [Nat.clog_of_two_le (by decide) hlen,
-        show (x :: y :: rest).length + 2 - 1 = (x :: y :: rest).length + 1 by omega]
-    have hfl : (foldLevel (x :: y :: rest)).length = ((x :: y :: rest).length + 1) / 2 :=
-      foldLevel_length _
-    have hrec : computeRoot (x :: y :: rest) = computeRoot (foldLevel (x :: y :: rest)) := by
-      conv_lhs => rw [computeRoot]
-    rw [hrec, computeRoot_eq_root (foldLevel (x :: y :: rest)), root, root, tree, tree,
-      hfl, hclog, ofList_root_foldLevel _ _ (by simp) (by
-        calc (x :: y :: rest).length ≤ 2 ^ Nat.clog 2 (x :: y :: rest).length :=
-              Nat.le_pow_clog (by decide) _
-          _ = 2 ^ (Nat.clog 2 (((x :: y :: rest).length + 1) / 2) + 1) := by rw [← hclog])]
-  termination_by xs => xs.length
-  decreasing_by simp [foldLevel_length]; omega
 
 /-! ## Canonicality -/
 

--- a/BtcVerified/Impl/BitcoinCore/Merkle.lean
+++ b/BtcVerified/Impl/BitcoinCore/Merkle.lean
@@ -2,12 +2,16 @@ import BtcVerified.Crypto.Merkle
 /-!
   # Bitcoin Core's `ComputeMerkleRoot`, checked against the spec
 
-  `BtcVerified.Merkle` is the platonic merkle spec: the root is one deterministic
-  fold (`computeRoot`) and canonicality is a separate decidable property of the
-  leaf list (`Canonical`). This module is not spec — it is *one implementation*,
-  Bitcoin Core's, transcribed and checked against that spec. It lives under
-  `Impl/BitcoinCore/` to keep the spec apart from the implementations measured
-  against it; a second client's algorithm would sit beside it.
+  `BtcVerified.Merkle` is the platonic merkle spec: the root as a tree fold
+  (`root`), with canonicality a separate decidable property of the leaf list
+  (`Canonical`). This module holds Bitcoin's *vector* computation of that root —
+  the bottom-up level fold (`computeRoot`, proved equal to the tree root by
+  `computeRoot_eq_root`) — and Bitcoin Core's fused variant that also computes
+  the `mutated` flag. The level fold and its flag are the implementation-shaped
+  pieces; they live here, not in the spec, because a level is a fact about the
+  flat vector layout, not the tree. Only Bitcoin Core is considered for now, so
+  the vector computation lives with it; a shared layer can be factored out if a
+  second client enters the repo.
 
   ## The algorithm (Bitcoin Core, src/consensus/merkle.cpp @ d84fc352)
 
@@ -79,11 +83,132 @@ import BtcVerified.Crypto.Merkle
     collide under double-SHA-256.
   * `computeMerkleRoot_fst`: the root Core returns is exactly `computeRoot`, on
     every input.
+  * `computeRoot_eq_root`: the bottom-up vector fold computes the spec's tree
+    root.
 -/
 
 namespace BtcVerified.Impl.BitcoinCore
 
 open BtcVerified BtcVerified.Merkle
+
+/-! ## The bottom-up computation -/
+
+/-- One level of Bitcoin's bottom-up fold: hash adjacent pairs, hashing an
+unpaired last node with itself. -/
+def foldLevel : List Hash256 → List Hash256
+  | [] => []
+  | [x] => [combine x x]
+  | x :: y :: rest => combine x y :: foldLevel rest
+
+/-- Each fold level halves the node count, rounding up. -/
+theorem foldLevel_length : ∀ xs : List Hash256, (foldLevel xs).length = (xs.length + 1) / 2
+  | [] => by simp [foldLevel]
+  | [_] => by simp [foldLevel]
+  | _ :: _ :: rest => by simp [foldLevel, foldLevel_length rest]; omega
+
+/-- The merkle root as Bitcoin computes it: fold levels bottom-up until one
+node remains. One deterministic cryptographic operation — canonicality of the
+input is `Canonical`'s concern, decided separately. (Core fuses a duplicate
+scan into this same pass under the name `mutated`; see the module header.) -/
+def computeRoot : List Hash256 → Hash256
+  | [] => 0
+  | [x] => x
+  | x :: y :: rest => computeRoot (foldLevel (x :: y :: rest))
+  termination_by xs => xs.length
+  decreasing_by simp [foldLevel_length]; omega
+
+/-- A fold level distributes over an append at an even boundary. -/
+theorem foldLevel_append : ∀ (as bs : List Hash256), as.length % 2 = 0 →
+    foldLevel (as ++ bs) = foldLevel as ++ foldLevel bs
+  | [], _, _ => rfl
+  | [_], _, h => by simp at h
+  | a :: a' :: rest, bs, h => by
+    have hrest : rest.length % 2 = 0 := by simp at h; omega
+    cases bs with
+    | nil => simp [foldLevel]
+    | cons b bs' =>
+      simp only [List.cons_append, foldLevel, foldLevel_append rest (b :: bs') hrest]
+
+/-- One spec level absorbs one fold level: the width-`2 ^ (k + 1)` tree over
+`xs` and the width-`2 ^ k` tree over `foldLevel xs` share a root. -/
+theorem ofList_root_foldLevel :
+    ∀ (k : Nat) (xs : List Hash256), 0 < xs.length → xs.length ≤ 2 ^ (k + 1) →
+      (ofList xs (k + 1)).root = (ofList (foldLevel xs) k).root := by
+  intro k
+  induction k with
+  | zero =>
+    intro xs h0 h2
+    rw [Nat.pow_succ, Nat.pow_zero, Nat.one_mul] at h2
+    cases xs with
+    | nil => simp at h0
+    | cons x xs' =>
+      cases xs' with
+      | nil => simp [ofList, foldLevel, Tree.root]
+      | cons y xs'' =>
+        have hnil : xs'' = [] := by
+          simp only [List.length_cons] at h2
+          exact List.eq_nil_of_length_eq_zero (by omega)
+        subst hnil
+        simp [ofList, foldLevel, Tree.root]
+  | succ k ih =>
+    intro xs h0 h2
+    have hpow : 2 ^ (k + 2) = 2 ^ (k + 1) + 2 ^ (k + 1) := Nat.two_pow_succ (k + 1)
+    have hpow' : 2 ^ (k + 1) = 2 ^ k + 2 ^ k := Nat.two_pow_succ k
+    by_cases hsplit : xs.length ≤ 2 ^ (k + 1)
+    · have hfold : (foldLevel xs).length ≤ 2 ^ k := by
+        rw [foldLevel_length]; omega
+      have hL : ofList xs (k + 1 + 1) = .pad (ofList xs (k + 1)) := by
+        rw [ofList, if_pos hsplit]
+      have hR : ofList (foldLevel xs) (k + 1) = .pad (ofList (foldLevel xs) k) := by
+        rw [ofList, if_pos hfold]
+      rw [hL, hR, Tree.root, Tree.root, ih xs h0 hsplit]
+    · have hsplit' : 2 ^ (k + 1) < xs.length := by omega
+      have htake : (xs.take (2 ^ (k + 1))).length = 2 ^ (k + 1) := by
+        rw [List.length_take]; omega
+      have hsplitFold : foldLevel xs = foldLevel (xs.take (2 ^ (k + 1)))
+          ++ foldLevel (xs.drop (2 ^ (k + 1))) := by
+        rw [← foldLevel_append _ _ (by omega), List.take_append_drop]
+      have hfoldTake : (foldLevel (xs.take (2 ^ (k + 1)))).length = 2 ^ k := by
+        rw [foldLevel_length, htake]; omega
+      have hfoldLen : ¬ (foldLevel xs).length ≤ 2 ^ k := by
+        rw [foldLevel_length]; omega
+      have hL : ofList xs (k + 1 + 1)
+          = .node (ofList (xs.take (2 ^ (k + 1))) (k + 1))
+              (ofList (xs.drop (2 ^ (k + 1))) (k + 1)) := by
+        rw [ofList, if_neg (by omega)]
+      have hR : ofList (foldLevel xs) (k + 1)
+          = .node (ofList ((foldLevel xs).take (2 ^ k)) k)
+              (ofList ((foldLevel xs).drop (2 ^ k)) k) := by
+        rw [ofList, if_neg hfoldLen]
+      have htakeF : (foldLevel xs).take (2 ^ k) = foldLevel (xs.take (2 ^ (k + 1))) := by
+        rw [hsplitFold, List.take_left' hfoldTake]
+      have hdropF : (foldLevel xs).drop (2 ^ k) = foldLevel (xs.drop (2 ^ (k + 1))) := by
+        rw [hsplitFold, List.drop_left' hfoldTake]
+      rw [hL, hR, Tree.root, Tree.root, htakeF, hdropF,
+        ih _ (by rw [List.length_take]; omega) (by omega),
+        ih _ (by rw [List.length_drop]; omega) (by rw [List.length_drop]; omega)]
+
+/-- The bottom-up fold computes the structural spec's root. -/
+theorem computeRoot_eq_root : ∀ xs : List Hash256, computeRoot xs = root xs
+  | [] => by simp [computeRoot, root, tree, Nat.clog_zero_right, ofList, Tree.root]
+  | [x] => by simp [computeRoot, root, tree, Nat.clog_one_right, ofList, Tree.root]
+  | x :: y :: rest => by
+    have hlen : 2 ≤ (x :: y :: rest).length := by simp
+    have hclog : Nat.clog 2 (x :: y :: rest).length
+        = Nat.clog 2 (((x :: y :: rest).length + 1) / 2) + 1 := by
+      rw [Nat.clog_of_two_le (by decide) hlen,
+        show (x :: y :: rest).length + 2 - 1 = (x :: y :: rest).length + 1 by omega]
+    have hfl : (foldLevel (x :: y :: rest)).length = ((x :: y :: rest).length + 1) / 2 :=
+      foldLevel_length _
+    have hrec : computeRoot (x :: y :: rest) = computeRoot (foldLevel (x :: y :: rest)) := by
+      conv_lhs => rw [computeRoot]
+    rw [hrec, computeRoot_eq_root (foldLevel (x :: y :: rest)), root, root, tree, tree,
+      hfl, hclog, ofList_root_foldLevel _ _ (by simp) (by
+        calc (x :: y :: rest).length ≤ 2 ^ Nat.clog 2 (x :: y :: rest).length :=
+              Nat.le_pow_clog (by decide) _
+          _ = 2 ^ (Nat.clog 2 (((x :: y :: rest).length + 1) / 2) + 1) := by rw [← hclog])]
+  termination_by xs => xs.length
+  decreasing_by simp [foldLevel_length]; omega
 
 /-- One merkle level's pre-padding duplicate-pair scan, exactly Core's
 `for (pos = 0; pos + 1 < size; pos += 2) if (hashes[pos] == hashes[pos+1])`:

--- a/README.md
+++ b/README.md
@@ -222,19 +222,18 @@ resistance can soundly appear over a concrete hash.
 
 ### `BtcVerified.Merkle`
 
-Bitcoin's merkle tree, with the root computation and canonicality factored
-apart. The spec is structural — a tree built top-down by bisection, procedural
-duplication an explicit `pad` constructor rather than an artifact of iteration
-order — and `computeRoot`, the bottom-up fold Bitcoin actually runs, is proved
-equal to it. Canonicality is a first-class decidable property of the leaf
-list, constraining exactly what threatens injectivity: padding only duplicates
-trailing power-of-two-aligned blocks, so only a right-spine duplication can
-materialize a shorter list's padding (CVE-2012-2459). Core's fused `mutated`
-scan is strictly stronger; the two agree on transaction-valid blocks.
+Bitcoin's merkle tree, as a tree — the platonic spec, with the root computation
+and canonicality factored apart. The root is a structural tree fold: the tree is
+built top-down by bisection, procedural duplication an explicit `pad` constructor
+rather than an artifact of iteration order. Canonicality is a first-class
+decidable property of the leaf list, constraining exactly what threatens
+injectivity: padding only duplicates trailing power-of-two-aligned blocks, so
+only a right-spine duplication can materialize a shorter list's padding
+(CVE-2012-2459). The bottom-up vector computation of this root, and the clients
+that run it, live under `Impl/`.
 
 Checked claims:
 
-- `computeRoot_eq_root`: the bottom-up fold computes the structural spec.
 - `root_inj_of_length_eq`: between equal-length lists, the root identifies the
   list — or two concrete byte strings collide under double-SHA-256.
 - `root_inj_of_canonical`: between canonical lists of equal enclosing width,
@@ -256,13 +255,16 @@ is free.
 
 ### `BtcVerified.Impl.BitcoinCore`
 
-Bitcoin Core's `ComputeMerkleRoot` (`src/consensus/merkle.cpp`), transcribed and
-checked against the spec above — kept under `Impl/` to separate the platonic
-merkle spec from the implementations measured against it. The transcription is a
-loop-shaped functional recursion: Core's `while` loop becomes tail recursion, its
-sticky `bool mutation` an accumulator, one recursive call one iteration — so the
-correspondence is up to the imperative-to-functional rendering, not a literal
-copy. The fidelity point is the *ordering*: Core scans each level for an adjacent
+Bitcoin's bottom-up merkle computation over a flat vector, and Bitcoin Core's
+`ComputeMerkleRoot` (`src/consensus/merkle.cpp`) — the fused variant that also
+computes the `mutated` flag — transcribed and checked against the tree spec.
+This lives under `Impl/` because level-folding is a fact about the vector layout,
+not the tree: `computeRoot`, the plain bottom-up fold, is proved equal to the
+spec's `root` by `computeRoot_eq_root`, and Core's `computeMerkleRoot` adds the
+duplicate scan on top. The transcription is up to the imperative-to-functional
+rendering, not a literal copy: Core's `while` loop becomes a recursion, its sticky
+`bool mutation` the OR of each level's scan folded up through the returns.
+The fidelity point is the *ordering*: Core scans each level for an adjacent
 duplicate **before** it pads, so a duplicate that padding synthesizes is never
 compared to its twin (the CVE-2012-2459 defense). The model is computable and run
 on concrete vectors at build time: the attack list `[1, 2, 3, 3]` sets `mutated`,
@@ -271,6 +273,7 @@ does not, and `[7, 7]` is canonical yet mutates — Core is strictly stronger.
 
 Checked claims:
 
+- `computeRoot_eq_root`: the bottom-up vector fold computes the spec's tree root.
 - `canonical_of_not_mutated`: a leaf list Core accepts (`mutated = false`) is the
   spec's `Canonical` — unconditionally, no distinctness, no collision caveat. The
   converse fails (`[a, a]` is canonical yet mutates), so Core's scan is strictly
@@ -278,10 +281,10 @@ Checked claims:
 - `eq_of_computeMerkleRoot_eq_of_not_mutated`: two nonempty equal-width lists Core
   accepts with equal roots are equal — or a concrete double-SHA-256 collision.
   Core's single check recovers the injectivity `root_inj_of_canonical` provides.
-- `computeMerkleRoot_fst`: the root Core returns is exactly `computeRoot` on every
-  input — anchoring it to real chain data through the `Block.merkleCommits`
-  checks, and confirmed on block 481824 under `lake test` (its `mutated` flag is
-  clear, agreeing with Core, which accepted the block).
+- `computeMerkleRoot_fst`: the root Core returns is exactly `computeRoot` (hence
+  the spec `root`) on every input — anchored to real chain data through the
+  `Block.merkleCommits` checks, and confirmed on block 481824 under `lake test`
+  (its `mutated` flag is clear, agreeing with Core, which accepted the block).
 
 Why it matters: this closes the gap between the algorithm Bitcoin Core actually
 runs and the repo's separated root/canonicality model. Core fuses the root and a

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -102,13 +102,13 @@ elab "#assert_axioms " id:ident : command => do
 /-! ## The merkle tree -/
 
 #assert_axioms BtcVerified.Merkle.combine_inj
-#assert_axioms BtcVerified.Merkle.computeRoot_eq_root
 #assert_axioms BtcVerified.Merkle.root_inj_of_length_eq
 #assert_axioms BtcVerified.Merkle.root_inj_of_canonical
 #assert_axioms BtcVerified.Block.merkleCommits
 
 /-! ## Bitcoin Core's ComputeMerkleRoot -/
 
+#assert_axioms BtcVerified.Impl.BitcoinCore.computeRoot_eq_root
 #assert_axioms BtcVerified.Impl.BitcoinCore.computeMerkleRoot_fst
 #assert_axioms BtcVerified.Impl.BitcoinCore.canonical_of_not_mutated
 #assert_axioms BtcVerified.Impl.BitcoinCore.eq_of_computeMerkleRoot_eq_of_not_mutated

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -348,13 +348,13 @@ def block170Hex : String :=
 
 -- Materializing the padding of a three-leaf list collides at the root
 -- (CVE-2012-2459); canonicality is what separates the two lists.
-#guard Merkle.computeRoot ([1, 2, 3] : List Hash256)
-  == Merkle.computeRoot ([1, 2, 3, 3] : List Hash256)
+#guard Merkle.root ([1, 2, 3] : List Hash256)
+  == Merkle.root ([1, 2, 3, 3] : List Hash256)
 #guard Merkle.canonicalCheck ([1, 2, 3] : List Hash256)
 #guard !Merkle.canonicalCheck ([1, 2, 3, 3] : List Hash256)
 -- A duplicated run of length two only surfaces one level up the tree.
-#guard Merkle.computeRoot ([1, 2, 3, 4, 5, 6] : List Hash256)
-  == Merkle.computeRoot ([1, 2, 3, 4, 5, 6, 5, 6] : List Hash256)
+#guard Merkle.root ([1, 2, 3, 4, 5, 6] : List Hash256)
+  == Merkle.root ([1, 2, 3, 4, 5, 6, 5, 6] : List Hash256)
 #guard !Merkle.canonicalCheck ([1, 2, 3, 4, 5, 6, 5, 6] : List Hash256)
 -- A pair-aligned duplicate in the middle is honest content: no shorter list
 -- shares its root, so it stays canonical (Core's uniform scan would reject
@@ -363,10 +363,10 @@ def block170Hex : String :=
 #guard Merkle.canonicalCheck ([1, 1, 2, 3] : List Hash256)
 
 -- Bitcoin Core's `ComputeMerkleRoot`, run on the same vectors. The root always
--- matches `computeRoot`, and the `mutated` flag fires on exactly the
+-- matches the spec root, and the `mutated` flag fires on exactly the
 -- materialized-padding lists — distinct leaves never trip it.
 #guard (Impl.BitcoinCore.computeMerkleRoot ([1, 2, 3] : List Hash256)).1
-  == Merkle.computeRoot ([1, 2, 3] : List Hash256)
+  == Merkle.root ([1, 2, 3] : List Hash256)
 #guard !(Impl.BitcoinCore.computeMerkleRoot ([1, 2, 3] : List Hash256)).2
 #guard (Impl.BitcoinCore.computeMerkleRoot ([1, 2, 3, 3] : List Hash256)).2
 #guard !(Impl.BitcoinCore.computeMerkleRoot ([1, 2, 3, 4, 5] : List Hash256)).2


### PR DESCRIPTION
Completes the spec/impl separation for merkle: the platonic spec becomes **purely the tree**, and Bitcoin's *vector* computation of the root moves into the BitcoinCore module.

Per the review discussion: a merkle root *is* a tree fold (`root = (tree xs).root`); "levels" are a fact about the flat `std::vector` layout, not the tree, so they belong with the computation, not the spec. And there's only one client so far, so the vector computation lives with Bitcoin Core rather than in a speculative shared layer (YAGNI — that can be factored out if a second client appears).

## What moves

Out of `Crypto/Merkle.lean` (spec) and into `Impl/BitcoinCore/Merkle.lean`:
- `foldLevel`, `foldLevel_length`, `foldLevel_append`
- `computeRoot` (the bottom-up fold)
- `ofList_root_foldLevel` and `computeRoot_eq_root` (adequacy: the vector fold computes the tree root)

## What the spec keeps

`combine`, `Tree`/`ofList`/`root`/`virtualLeaves`, `Canonical`/`spineCanonical`, and the injectivity theorems (`root_inj_of_length_eq`, `root_inj_of_canonical`) — none of which ever referenced `foldLevel`.

## Consequences

- `Block.merkleCommits` rebases onto the denotational `root` (equal by `computeRoot_eq_root`; recomputes the same value — the 481824 fixture and golden vectors stay green).
- The spec header loses its remaining Core/`mutated` references, matching the no-implementation-references-in-spec rule already applied to `Commitment.lean`. The strictly-stronger story stays in the BitcoinCore module.
- Golden-vector padding-collision checks rebase onto `Merkle.root`; the audit moves `computeRoot_eq_root` into the BitcoinCore group.
- Drive-by: fixed README wording left stale by the earlier accumulator removal.

## Verification

Full `lake build` (754), `lake lint`, and `lake test` green. A grep confirms `Crypto/Merkle.lean` and `Block/Commitment.lean` contain no `computeRoot`/`foldLevel`/`Core`/`mutated`/`Impl` references. Relocated theorems keep only the allowlist axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
