### PR TITLE
Align Ext/List lemma names to the Mathlib transcription convention

### DIFF
--- a/BtcVerified/Ext/List.lean
+++ b/BtcVerified/Ext/List.lean
@@ -17,7 +17,7 @@ variable {α β γ : Type*}
 
 /-- Recombine a list's two projections with their constructor to recover the
 list, when the constructor and projections round-trip. -/
-theorem zipWith_map_proj {f : γ → α} {g : γ → β} {mk : α → β → γ}
+theorem zipWith_map_map_left_right {f : γ → α} {g : γ → β} {mk : α → β → γ}
     (h : ∀ c, mk (f c) (g c) = c) (l : List γ) :
     zipWith mk (l.map f) (l.map g) = l := by
   rw [zipWith_map, zipWith_self]

--- a/BtcVerified/Transaction/Tx.lean
+++ b/BtcVerified/Transaction/Tx.lean
@@ -110,7 +110,7 @@ theorem zipInputs_segwit (ins : CountedList SegwitInput) :
     zipInputs (segwitInputs ins) (segwitWitnesses ins) = ins := by
   apply Subtype.ext
   simp only [zipInputs, segwitInputs, segwitWitnesses]
-  exact List.zipWith_map_proj (fun _ => rfl) ins.val
+  exact List.zipWith_map_map_left_right (fun _ => rfl) ins.val
 
 /-- The unbundled inputs of a rebundling are the inputs we started from. -/
 theorem segwitInputs_zipInputs (txins : CountedList TxIn) (wits : List WitnessStack)


### PR DESCRIPTION
The rename pass over `BtcVerified/Ext/List.lean` deferred from the #8 review: tighten lemma names toward Mathlib's mechanical-transcription convention (head symbols of the LHS outside-in, joined by `_`, with direction tags), so a name is reconstructible from the statement.

## The pass

- **`zipWith_map_proj` → `zipWith_map_map_left_right`** (the name floated in the review). The LHS `zipWith mk (l.map f) (l.map g)` transcribes outside-in as `zipWith_map_map`; the `left_right` tags carry the hypothesis — the mapped functions are the constructor's left and right projections (`mk (f c) (g c) = c`).
- **`map_zipWith_left` / `map_zipWith_right` — unchanged.** They already fit the same scheme: the LHS `(zipWith mk as bs).map f` transcribes as `map_zipWith`, and the side tag says which projection/list the map recovers, mirroring the hypothesis tags above (`f (mk a b) = a` for `left`, `g (mk a b) = b` for `right`).

One call site (`Tx.zipInputs_segwit`) updated to match; the names appear nowhere else (no axiom-audit registrations, no doc mentions). `lake build` and `lake lint` pass, and the new name introduces no clash with Mathlib's own `List.zipWith_map*` family.

Closes #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
