### PR TITLE
Rewrite the Option decoder cascades as monadic do-blocks

### DIFF
--- a/BtcVerified/Serialize/Codec.lean
+++ b/BtcVerified/Serialize/Codec.lean
@@ -132,13 +132,10 @@ def encodeBitVecLE : (n : Nat) → BitVec (8 * n) → List UInt8
 /-- Decode `n` little-endian bytes into a `BitVec (8 * n)`. -/
 def decodeBitVecLE : (n : Nat) → List UInt8 → Option (BitVec (8 * n) × List UInt8)
   | 0, bs => some (0#0, bs)
-  | n + 1, bs =>
-    match decodeByte bs with
-    | none => none
-    | some (b, bs') =>
-      match decodeBitVecLE n bs' with
-      | none => none
-      | some (hi, rest) => some (hi ++ b.toBitVec, rest)
+  | n + 1, bs => do
+    let (b, bs') ← decodeByte bs
+    let (hi, rest) ← decodeBitVecLE n bs'
+    return (hi ++ b.toBitVec, rest)
 
 /-- The low byte of `high ++ low` is `low`. -/
 private theorem setWidth_append_low {n : Nat} (hi : BitVec (8 * n)) (lo : BitVec 8) :
@@ -188,7 +185,8 @@ theorem decodeBitVecLE_encodeBitVecLE :
     rfl
   | succ n ih =>
     intro v rest
-    simp only [encodeBitVecLE, List.cons_append, decodeBitVecLE, decodeByte, ih]
+    simp only [encodeBitVecLE, List.cons_append, decodeBitVecLE, decodeByte,
+      Option.bind_eq_bind, Option.bind_some, ih, Option.pure_def]
     rw [append_split v]
 
 /-- If the little-endian decoder accepts `bs` as the value `v` with tail `rest`,
@@ -207,18 +205,13 @@ theorem decodeBitVecLE_canonical :
     cases bs with
     | nil => simp [decodeBitVecLE, decodeByte] at h
     | cons b bs' =>
-      simp only [decodeBitVecLE, decodeByte] at h
-      cases hd : decodeBitVecLE n bs' with
-      | none => rw [hd] at h; simp at h
-      | some hr =>
-        obtain ⟨hi, r⟩ := hr
-        rw [hd] at h
-        simp only [Option.some.injEq, Prod.mk.injEq] at h
-        obtain ⟨hv, hr'⟩ := h
-        have ihbs := ih bs' hi r hd
-        subst hr'; subst hv
-        simp only [encodeBitVecLE, List.cons_append, setWidth_append_low,
-          setWidth_ushiftRight_append, UInt8.ofBitVec_toBitVec, ihbs]
+      simp only [decodeBitVecLE, decodeByte, Option.bind_eq_bind, Option.bind_some,
+        Option.pure_def, Option.bind_eq_some_iff, Option.some.injEq, Prod.mk.injEq] at h
+      obtain ⟨⟨hi, r⟩, hd, hv, hr'⟩ := h
+      have ihbs := ih bs' hi r hd
+      subst hr'; subst hv
+      simp only [encodeBitVecLE, List.cons_append, setWidth_append_low,
+        setWidth_ushiftRight_append, UInt8.ofBitVec_toBitVec, ihbs]
 
 /-- The little-endian decoder succeeds on any input of at least `n` bytes,
 consuming exactly `n` and leaving the rest as the tail. -/

--- a/BtcVerified/Serialize/Codec.lean
+++ b/BtcVerified/Serialize/Codec.lean
@@ -71,13 +71,10 @@ theorem encode_injective {α : Type} [Codec α] {a b : α}
 
 /-- Decode an `α` then a `β` from the remaining bytes, threading the tail. -/
 def decodeProd {α β : Type} [Codec α] [Codec β]
-    (bs : List UInt8) : Option ((α × β) × List UInt8) :=
-  match Codec.decode (α := α) bs with
-  | none => none
-  | some (a, rest) =>
-    match Codec.decode (α := β) rest with
-    | none => none
-    | some (b, rest') => some ((a, b), rest')
+    (bs : List UInt8) : Option ((α × β) × List UInt8) := do
+  let (a, rest) ← Codec.decode (α := α) bs
+  let (b, rest') ← Codec.decode (α := β) rest
+  return ((a, b), rest')
 
 /-- Decoding a pair from the concatenated encodings of its components returns
 both values, leaving the trailing bytes as the unconsumed tail. -/
@@ -85,7 +82,8 @@ theorem decodeProd_encode {α β : Type} [Codec α] [Codec β]
     (a : α) (b : β) (rest : List UInt8) :
     decodeProd ((Codec.encode a ++ Codec.encode b) ++ rest) = some ((a, b), rest) := by
   unfold decodeProd
-  simp only [List.append_assoc, Codec.decode_encode]
+  simp only [List.append_assoc, Option.bind_eq_bind, Codec.decode_encode,
+    Option.bind_some, Option.pure_def]
 
 /-- If the pair decoder accepts `bs` as `(a, b)` with tail `rest`, then `bs` is
 exactly the two component encodings in sequence followed by `rest`. -/
@@ -95,20 +93,12 @@ theorem decodeProd_canonical {α β : Type} [Codec α] [Codec β]
     bs = (Codec.encode a ++ Codec.encode b) ++ rest := by
   intro h
   unfold decodeProd at h
-  cases hd : Codec.decode (α := α) bs with
-  | none => simp [hd] at h
-  | some ar =>
-    obtain ⟨a', r1⟩ := ar
-    cases hd2 : Codec.decode (α := β) r1 with
-    | none => simp [hd, hd2] at h
-    | some br =>
-      obtain ⟨b', r2⟩ := br
-      simp only [hd, hd2, Option.some.injEq, Prod.mk.injEq] at h
-      obtain ⟨⟨ha, hb⟩, hr⟩ := h
-      have e1 := Codec.decode_canonical bs a' r1 hd
-      have e2 := Codec.decode_canonical r1 b' r2 hd2
-      subst ha; subst hb; subst hr
-      rw [e1, e2, List.append_assoc]
+  simp only [Option.bind_eq_bind, Option.pure_def, Option.bind_eq_some_iff,
+    Option.some.injEq, Prod.mk.injEq] at h
+  obtain ⟨⟨a', r1⟩, hd, ⟨b', r2⟩, hd2, ⟨ha, hb⟩, hr⟩ := h
+  subst ha; subst hb; subst hr
+  rw [Codec.decode_canonical bs a' r1 hd, Codec.decode_canonical r1 b' r2 hd2,
+    List.append_assoc]
 
 /-- Sequential composition of codecs. Encoding concatenates the field encodings;
 decoding parses the fields left to right, threading the tail. Both laws are

--- a/BtcVerified/Serialize/CompactSize.lean
+++ b/BtcVerified/Serialize/CompactSize.lean
@@ -54,7 +54,8 @@ any value below `minValue` (the shortest-form minimum for this marker). -/
 def decodeFixedWidth (byteWidth minValue : Nat) (bs : List UInt8) :
     Option (UInt64 × List UInt8) := do
   let (w, rest) ← decodeBitVecLE byteWidth bs
-  if w.toNat < minValue then none else return (⟨w.setWidth 64⟩, rest)
+  guard (minValue ≤ w.toNat)
+  return (⟨w.setWidth 64⟩, rest)
 
 /-- Encoding a value that lies in this form's range
 (`minValue ≤ n < 2 ^ (8 * byteWidth)`) as its fixed-width payload and then
@@ -67,7 +68,8 @@ theorem decodeFixedWidth_encodeFixedWidth (byteWidth minValue : Nat) (n : UInt64
     rw [BitVec.toNat_setWidth]; exact Nat.mod_eq_of_lt hhi
   simp only [encodeFixedWidth, decodeFixedWidth, decodeBitVecLE_encodeBitVecLE,
     Option.bind_eq_bind, Option.bind_some, hw]
-  rw [if_neg (by omega : ¬ n.toNat < minValue)]
+  unfold guard
+  rw [if_pos hlo]
   simp [setWidth_setWidth_eq_self hhi, UInt64.ofBitVec_toBitVec]
 
 /-- If the fixed-width decoder accepts `bs` as `n` with tail `rest`, then `n`
@@ -81,10 +83,11 @@ theorem decodeFixedWidth_canonical (byteWidth minValue : Nat) (hbw : 8 * byteWid
   intro parses
   unfold decodeFixedWidth at parses
   simp only [Option.bind_eq_bind, Option.bind_eq_some_iff] at parses
-  obtain ⟨⟨w, rest'⟩, hd, parses⟩ := parses
-  by_cases hw : w.toNat < minValue
-  · simp [hw] at parses
-  · rw [if_neg hw] at parses
+  obtain ⟨⟨w, rest'⟩, hd, _, hg, parses⟩ := parses
+  dsimp only at hg parses
+  unfold guard at hg
+  by_cases hw : minValue ≤ w.toNat
+  · rw [if_pos hw] at hg
     simp only [Option.pure_def, Option.some.injEq, Prod.mk.injEq] at parses
     obtain ⟨rfl, rfl⟩ := parses
     have hwlt : w.toNat < 2 ^ (8 * byteWidth) := w.isLt
@@ -92,7 +95,7 @@ theorem decodeFixedWidth_canonical (byteWidth minValue : Nat) (hbw : 8 * byteWid
     have hval : (⟨w.setWidth 64⟩ : UInt64).toNat = w.toNat := by
       rw [UInt64.toNat_ofBitVec, BitVec.toNat_setWidth]; exact Nat.mod_eq_of_lt hw64
     refine ⟨?_, ?_, ?_⟩
-    · rw [hval]; omega
+    · rw [hval]; exact hw
     · rw [hval]; exact hwlt
     · have hbs := decodeBitVecLE_canonical byteWidth bs w rest' hd
       have hb : encodeFixedWidth byteWidth (⟨w.setWidth 64⟩ : UInt64)
@@ -100,6 +103,8 @@ theorem decodeFixedWidth_canonical (byteWidth minValue : Nat) (hbw : 8 * byteWid
         unfold encodeFixedWidth
         rw [UInt64.toBitVec_ofBitVec, setWidth_setWidth_eq_self hw64]
       rw [hbs, hb]
+  · rw [if_neg hw] at hg
+    simp at hg
 
 /-- Canonically encodes a `UInt64` as Bitcoin CompactSize bytes.
 

--- a/BtcVerified/Serialize/CompactSize.lean
+++ b/BtcVerified/Serialize/CompactSize.lean
@@ -52,11 +52,9 @@ theorem encodeFixedWidth_length (byteWidth : Nat) (n : UInt64) :
 /-- Decode `byteWidth` little-endian payload bytes, rejecting as non-canonical
 any value below `minValue` (the shortest-form minimum for this marker). -/
 def decodeFixedWidth (byteWidth minValue : Nat) (bs : List UInt8) :
-    Option (UInt64 × List UInt8) :=
-  match decodeBitVecLE byteWidth bs with
-  | none => none
-  | some (w, rest) =>
-    if w.toNat < minValue then none else some (⟨w.setWidth 64⟩, rest)
+    Option (UInt64 × List UInt8) := do
+  let (w, rest) ← decodeBitVecLE byteWidth bs
+  if w.toNat < minValue then none else return (⟨w.setWidth 64⟩, rest)
 
 /-- Encoding a value that lies in this form's range
 (`minValue ≤ n < 2 ^ (8 * byteWidth)`) as its fixed-width payload and then
@@ -67,7 +65,8 @@ theorem decodeFixedWidth_encodeFixedWidth (byteWidth minValue : Nat) (n : UInt64
     decodeFixedWidth byteWidth minValue (encodeFixedWidth byteWidth n ++ xs) = some (n, xs) := by
   have hw : (n.toBitVec.setWidth (8 * byteWidth)).toNat = n.toNat := by
     rw [BitVec.toNat_setWidth]; exact Nat.mod_eq_of_lt hhi
-  simp only [encodeFixedWidth, decodeFixedWidth, decodeBitVecLE_encodeBitVecLE, hw]
+  simp only [encodeFixedWidth, decodeFixedWidth, decodeBitVecLE_encodeBitVecLE,
+    Option.bind_eq_bind, Option.bind_some, hw]
   rw [if_neg (by omega : ¬ n.toNat < minValue)]
   simp [setWidth_setWidth_eq_self hhi, UInt64.ofBitVec_toBitVec]
 
@@ -81,29 +80,26 @@ theorem decodeFixedWidth_canonical (byteWidth minValue : Nat) (hbw : 8 * byteWid
         bs = encodeFixedWidth byteWidth n ++ rest := by
   intro parses
   unfold decodeFixedWidth at parses
-  cases hd : decodeBitVecLE byteWidth bs with
-  | none => simp [hd] at parses
-  | some wr =>
-    obtain ⟨w, rest'⟩ := wr
-    simp only [hd] at parses
-    by_cases hw : w.toNat < minValue
-    · simp [hw] at parses
-    · rw [if_neg hw] at parses
-      simp only [Option.some.injEq, Prod.mk.injEq] at parses
-      obtain ⟨rfl, rfl⟩ := parses
-      have hwlt : w.toNat < 2 ^ (8 * byteWidth) := w.isLt
-      have hw64 : w.toNat < 2 ^ 64 := lt_of_lt_of_le hwlt (Nat.pow_le_pow_right (by omega) hbw)
-      have hval : (⟨w.setWidth 64⟩ : UInt64).toNat = w.toNat := by
-        rw [UInt64.toNat_ofBitVec, BitVec.toNat_setWidth]; exact Nat.mod_eq_of_lt hw64
-      refine ⟨?_, ?_, ?_⟩
-      · rw [hval]; omega
-      · rw [hval]; exact hwlt
-      · have hbs := decodeBitVecLE_canonical byteWidth bs w rest' hd
-        have hb : encodeFixedWidth byteWidth (⟨w.setWidth 64⟩ : UInt64)
-            = encodeBitVecLE byteWidth w := by
-          unfold encodeFixedWidth
-          rw [UInt64.toBitVec_ofBitVec, setWidth_setWidth_eq_self hw64]
-        rw [hbs, hb]
+  simp only [Option.bind_eq_bind, Option.bind_eq_some_iff] at parses
+  obtain ⟨⟨w, rest'⟩, hd, parses⟩ := parses
+  by_cases hw : w.toNat < minValue
+  · simp [hw] at parses
+  · rw [if_neg hw] at parses
+    simp only [Option.pure_def, Option.some.injEq, Prod.mk.injEq] at parses
+    obtain ⟨rfl, rfl⟩ := parses
+    have hwlt : w.toNat < 2 ^ (8 * byteWidth) := w.isLt
+    have hw64 : w.toNat < 2 ^ 64 := lt_of_lt_of_le hwlt (Nat.pow_le_pow_right (by omega) hbw)
+    have hval : (⟨w.setWidth 64⟩ : UInt64).toNat = w.toNat := by
+      rw [UInt64.toNat_ofBitVec, BitVec.toNat_setWidth]; exact Nat.mod_eq_of_lt hw64
+    refine ⟨?_, ?_, ?_⟩
+    · rw [hval]; omega
+    · rw [hval]; exact hwlt
+    · have hbs := decodeBitVecLE_canonical byteWidth bs w rest' hd
+      have hb : encodeFixedWidth byteWidth (⟨w.setWidth 64⟩ : UInt64)
+          = encodeBitVecLE byteWidth w := by
+        unfold encodeFixedWidth
+        rw [UInt64.toBitVec_ofBitVec, setWidth_setWidth_eq_self hw64]
+      rw [hbs, hb]
 
 /-- Canonically encodes a `UInt64` as Bitcoin CompactSize bytes.
 

--- a/BtcVerified/Serialize/CountedList.lean
+++ b/BtcVerified/Serialize/CountedList.lean
@@ -73,13 +73,10 @@ def encodeElems {α : Type} [Codec α] : List α → List UInt8
 /-- Decode exactly `n` consecutive values, threading the unconsumed tail. -/
 def decodeElems {α : Type} [Codec α] : Nat → List UInt8 → Option (List α × List UInt8)
   | 0, bs => some ([], bs)
-  | n + 1, bs =>
-    match Codec.decode (α := α) bs with
-    | none => none
-    | some (x, rest) =>
-      match decodeElems n rest with
-      | none => none
-      | some (xs, rest') => some (x :: xs, rest')
+  | n + 1, bs => do
+    let (x, rest) ← Codec.decode (α := α) bs
+    let (xs, rest') ← decodeElems n rest
+    return (x :: xs, rest')
 
 /-- Decoding exactly `n` elements yields exactly `n` of them. -/
 theorem decodeElems_length {α : Type} [Codec α] (n : Nat) (bs : List UInt8)
@@ -90,21 +87,11 @@ theorem decodeElems_length {α : Type} [Codec α] (n : Nat) (bs : List UInt8)
     simp only [decodeElems, Option.some.injEq, Prod.mk.injEq] at h
     obtain ⟨rfl, _⟩ := h; rfl
   | succ n ih =>
-    simp only [decodeElems] at h
-    cases hd : Codec.decode (α := α) bs with
-    | none => simp [hd] at h
-    | some xr =>
-      obtain ⟨x, r1⟩ := xr
-      simp only [hd] at h
-      cases hd2 : decodeElems (α := α) n r1 with
-      | none => simp [hd2] at h
-      | some xsr =>
-        obtain ⟨xs', r2⟩ := xsr
-        simp only [hd2] at h
-        simp only [Option.some.injEq, Prod.mk.injEq] at h
-        obtain ⟨rfl, rfl⟩ := h
-        simp only [List.length_cons]
-        rw [ih r1 xs' r2 hd2]
+    simp only [decodeElems, Option.bind_eq_bind, Option.pure_def,
+      Option.bind_eq_some_iff, Option.some.injEq, Prod.mk.injEq] at h
+    obtain ⟨⟨x, r1⟩, hd, ⟨xs', r2⟩, hd2, rfl, rfl⟩ := h
+    simp only [List.length_cons]
+    rw [ih r1 xs' r2 hd2]
 
 /-- Round-trip for the element sequence: encoding a list and decoding exactly its
 length returns it, tail preserved. -/
@@ -113,8 +100,8 @@ theorem decodeElems_encodeElems {α : Type} [Codec α] (xs : List α) (rest : Li
   induction xs generalizing rest with
   | nil => rfl
   | cons x xs ih =>
-    simp only [encodeElems, List.append_assoc, decodeElems,
-      Codec.decode_encode, ih]
+    simp only [encodeElems, List.append_assoc, decodeElems, Option.bind_eq_bind,
+      Codec.decode_encode, Option.bind_some, ih, Option.pure_def]
 
 /-- Canonicality for the element sequence: an accepted parse of `n` elements
 consumed exactly their canonical encodings. -/
@@ -126,22 +113,12 @@ theorem decodeElems_canonical {α : Type} [Codec α] (n : Nat) (bs : List UInt8)
     simp only [decodeElems, Option.some.injEq, Prod.mk.injEq] at h
     obtain ⟨rfl, rfl⟩ := h; rfl
   | succ n ih =>
-    simp only [decodeElems] at h
-    cases hd : Codec.decode (α := α) bs with
-    | none => simp [hd] at h
-    | some xr =>
-      obtain ⟨x, r1⟩ := xr
-      simp only [hd] at h
-      cases hd2 : decodeElems (α := α) n r1 with
-      | none => simp [hd2] at h
-      | some xsr =>
-        obtain ⟨xs', r2⟩ := xsr
-        simp only [hd2] at h
-        simp only [Option.some.injEq, Prod.mk.injEq] at h
-        obtain ⟨rfl, rfl⟩ := h
-        have e1 := Codec.decode_canonical bs x r1 hd
-        have e2 := ih r1 xs' r2 hd2
-        rw [e1, e2, encodeElems, List.append_assoc]
+    simp only [decodeElems, Option.bind_eq_bind, Option.pure_def,
+      Option.bind_eq_some_iff, Option.some.injEq, Prod.mk.injEq] at h
+    obtain ⟨⟨x, r1⟩, hd, ⟨xs', r2⟩, hd2, rfl, rfl⟩ := h
+    have e1 := Codec.decode_canonical bs x r1 hd
+    have e2 := ih r1 xs' r2 hd2
+    rw [e1, e2, encodeElems, List.append_assoc]
 
 /-! ## The counted-list codec -/
 

--- a/BtcVerified/Serialize/CountedList.lean
+++ b/BtcVerified/Serialize/CountedList.lean
@@ -130,16 +130,11 @@ def encodeCountedList {α : Type} [Codec α] (cl : CountedList α) : List UInt8 
 /-- Decode a counted list: read the CompactSize count, decode that many elements,
 then attach the length bound. -/
 def decodeCountedList {α : Type} [Codec α] (bs : List UInt8) :
-    Option (CountedList α × List UInt8) :=
-  match CompactSize.decode bs with
-  | none => none
-  | some (count, rest) =>
-    match decodeElems count.toNat rest with
-    | none => none
-    | some (xs, rest') =>
-      match CountedList.ofList? xs with
-      | none => none
-      | some cl => some (cl, rest')
+    Option (CountedList α × List UInt8) := do
+  let (count, rest) ← CompactSize.decode bs
+  let (xs, rest') ← decodeElems count.toNat rest
+  let cl ← CountedList.ofList? xs
+  return (cl, rest')
 
 /-- Round-trip: a counted list encodes and decodes back to itself, tail
 preserved. -/
@@ -150,8 +145,8 @@ theorem decodeCountedList_encodeCountedList {α : Type} [Codec α]
   unfold encodeCountedList decodeCountedList
   rw [List.append_assoc]
   have hc : (UInt64.ofNat l.length).toNat = l.length := UInt64.toNat_ofNat_of_lt' hl
-  simp only [CompactSize.decode_encode, hc, decodeElems_encodeElems,
-    CountedList.ofList?_eq_some hl]
+  simp only [Option.bind_eq_bind, CompactSize.decode_encode, Option.bind_some, hc,
+    decodeElems_encodeElems, CountedList.ofList?_eq_some hl, Option.pure_def]
 
 /-- Canonicality: an accepted parse consumed exactly the canonical count prefix
 followed by the canonical element encodings. -/
@@ -160,29 +155,17 @@ theorem decodeCountedList_canonical {α : Type} [Codec α]
     (h : decodeCountedList bs = some (cl, rest)) :
     bs = encodeCountedList cl ++ rest := by
   unfold decodeCountedList at h
-  cases hcs : CompactSize.decode bs with
-  | none => simp [hcs] at h
-  | some p =>
-    obtain ⟨count, rest0⟩ := p
-    simp only [hcs] at h
-    cases hln : decodeElems (α := α) count.toNat rest0 with
-    | none => simp [hln] at h
-    | some q =>
-      obtain ⟨xs, rest'⟩ := q
-      simp only [hln] at h
-      cases hof : CountedList.ofList? xs with
-      | none => simp [hof] at h
-      | some cl' =>
-        simp only [hof, Option.some.injEq, Prod.mk.injEq] at h
-        obtain ⟨rfl, rfl⟩ := h
-        have hcv : cl'.val = xs := CountedList.val_of_ofList? hof
-        have ecs := CompactSize.decode_canonical bs count rest0 hcs
-        have eel := decodeElems_canonical count.toNat rest0 xs rest' hln
-        have hlen : xs.length = count.toNat := decodeElems_length count.toNat rest0 xs rest' hln
-        have hcnt : count = UInt64.ofNat xs.length := by
-          rw [hlen, UInt64.ofNat_toNat]
-        unfold encodeCountedList
-        rw [hcv, ecs, eel, hcnt, List.append_assoc]
+  simp only [Option.bind_eq_bind, Option.pure_def, Option.bind_eq_some_iff,
+    Option.some.injEq, Prod.mk.injEq] at h
+  obtain ⟨⟨count, rest0⟩, hcs, ⟨xs, rest'⟩, hln, cl', hof, rfl, rfl⟩ := h
+  have hcv : cl'.val = xs := CountedList.val_of_ofList? hof
+  have ecs := CompactSize.decode_canonical bs count rest0 hcs
+  have eel := decodeElems_canonical count.toNat rest0 xs rest' hln
+  have hlen : xs.length = count.toNat := decodeElems_length count.toNat rest0 xs rest' hln
+  have hcnt : count = UInt64.ofNat xs.length := by
+    rw [hlen, UInt64.ofNat_toNat]
+  unfold encodeCountedList
+  rw [hcv, ecs, eel, hcnt, List.append_assoc]
 
 /-- The codec for a CompactSize-prefixed list: a count prefix followed by the
 elements. Both laws come from the count codec (`CompactSize`) and the element

--- a/BtcVerified/Transaction/Tx.lean
+++ b/BtcVerified/Transaction/Tx.lean
@@ -184,19 +184,12 @@ def encodeTx : Tx → List UInt8
 
 /-- Decode the SegWit body (everything after version, marker, and flag),
 rebundling the separately-read inputs and witnesses. -/
-def decodeSegwit (version : UInt32) (bs : List UInt8) : Option (Tx × List UInt8) :=
-  match Codec.decode (α := CountedList TxIn) bs with
-  | none => none
-  | some (txins, r1) =>
-    match Codec.decode (α := CountedList TxOut) r1 with
-    | none => none
-    | some (outs, r2) =>
-      match decodeElems (α := WitnessStack) txins.val.length r2 with
-      | none => none
-      | some (wits, r3) =>
-        match Codec.decode (α := UInt32) r3 with
-        | none => none
-        | some (lockTime, r4) => some (.segwit version (zipInputs txins wits) outs lockTime, r4)
+def decodeSegwit (version : UInt32) (bs : List UInt8) : Option (Tx × List UInt8) := do
+  let (txins, r1) ← Codec.decode (α := CountedList TxIn) bs
+  let (outs, r2) ← Codec.decode (α := CountedList TxOut) r1
+  let (wits, r3) ← decodeElems (α := WitnessStack) txins.val.length r2
+  let (lockTime, r4) ← Codec.decode (α := UInt32) r3
+  return (.segwit version (zipInputs txins wits) outs lockTime, r4)
 
 /-- Decode a legacy transaction body (everything after version), then attach the
 non-empty-inputs proof via the smart constructor. -/
@@ -235,9 +228,9 @@ theorem decodeSegwit_encode (version : UInt32) (ins : CountedList SegwitInput)
     decodeSegwit version (encodeSegwitBody ins outs lockTime ++ rest)
       = some (.segwit version ins outs lockTime, rest) := by
   unfold decodeSegwit encodeSegwitBody
-  simp only [List.append_assoc, Codec.decode_encode]
+  simp only [List.append_assoc, Option.bind_eq_bind, Codec.decode_encode, Option.bind_some]
   rw [segwitInputs_length, decodeElems_encodeElems]
-  simp only [Codec.decode_encode, zipInputs_segwit]
+  simp only [Option.bind_some, Codec.decode_encode, Option.pure_def, zipInputs_segwit]
 
 /-- Decoding the encoded post-version fields of a body with non-empty inputs
 returns the legacy transaction on that body, tail preserved. -/
@@ -301,37 +294,21 @@ theorem decodeSegwit_canonical (version : UInt32) (bs : List UInt8) (tx : Tx)
     ∃ ins outs lockTime, tx = .segwit version ins outs lockTime ∧
       bs = encodeSegwitBody ins outs lockTime ++ rest := by
   unfold decodeSegwit at h
-  cases hti : Codec.decode (α := CountedList TxIn) bs with
-  | none => simp [hti] at h
-  | some tir =>
-    obtain ⟨txins, r1⟩ := tir
-    simp only [hti] at h
-    cases hto : Codec.decode (α := CountedList TxOut) r1 with
-    | none => simp [hto] at h
-    | some tor =>
-      obtain ⟨outs, r2⟩ := tor
-      simp only [hto] at h
-      cases hwit : decodeElems (α := WitnessStack) txins.val.length r2 with
-      | none => simp [hwit] at h
-      | some wr =>
-        obtain ⟨wits, r3⟩ := wr
-        simp only [hwit] at h
-        cases hlt : Codec.decode (α := UInt32) r3 with
-        | none => simp [hlt] at h
-        | some lr =>
-          obtain ⟨lockTime, r4⟩ := lr
-          simp only [hlt, Option.some.injEq, Prod.mk.injEq] at h
-          obtain ⟨rfl, rfl⟩ := h
-          refine ⟨zipInputs txins wits, outs, lockTime, rfl, ?_⟩
-          have hwlen : wits.length = txins.val.length := decodeElems_length _ _ _ _ hwit
-          have eti := Codec.decode_canonical bs txins r1 hti
-          have eto := Codec.decode_canonical r1 outs r2 hto
-          have ewit := decodeElems_canonical _ _ _ _ hwit
-          have elt := Codec.decode_canonical r3 lockTime r4 hlt
-          unfold encodeSegwitBody
-          rw [segwitInputs_zipInputs txins wits hwlen,
-            segwitWitnesses_zipInputs txins wits hwlen, eti, eto, ewit, elt]
-          simp only [List.append_assoc]
+  simp only [Option.bind_eq_bind, Option.pure_def, Option.bind_eq_some_iff,
+    Option.some.injEq, Prod.mk.injEq] at h
+  obtain ⟨⟨txins, r1⟩, hti, ⟨outs, r2⟩, hto, ⟨wits, r3⟩, hwit, ⟨lockTime, r4⟩, hlt,
+    rfl, rfl⟩ := h
+  dsimp only at hto hwit hlt ⊢
+  refine ⟨zipInputs txins wits, outs, lockTime, rfl, ?_⟩
+  have hwlen : wits.length = txins.val.length := decodeElems_length _ _ _ _ hwit
+  have eti := Codec.decode_canonical bs txins r1 hti
+  have eto := Codec.decode_canonical r1 outs r2 hto
+  have ewit := decodeElems_canonical _ _ _ _ hwit
+  have elt := Codec.decode_canonical r3 lockTime r4 hlt
+  unfold encodeSegwitBody
+  rw [segwitInputs_zipInputs txins wits hwlen,
+    segwitWitnesses_zipInputs txins wits hwlen, eti, eto, ewit, elt]
+  simp only [List.append_assoc]
 
 /-- If the legacy decoder accepts `bs`, the result is a legacy transaction whose
 body carries the given version, its inputs are non-empty, and `bs` is exactly

--- a/BtcVerified/Transaction/Tx.lean
+++ b/BtcVerified/Transaction/Tx.lean
@@ -204,10 +204,8 @@ def decodeLegacy (version : UInt32) (bs : List UInt8) : Option (Tx × List UInt8
 def decodeTx (bs : List UInt8) : Option (Tx × List UInt8) := do
   let (version, rest1) ← Codec.decode (α := UInt32) bs
   match rest1 with
-  | 0x00 :: rest2 =>
-    match rest2 with
-    | 0x01 :: rest3 => decodeSegwit version rest3
-    | _ => none
+  | 0x00 :: 0x01 :: rest3 => decodeSegwit version rest3
+  | 0x00 :: _ => none
   | _ => decodeLegacy version rest1
 
 /-! ## Round-trip -/
@@ -246,9 +244,7 @@ theorem decodeTx_legacy_eq (version : UInt32) (inputs : CountedList TxIn)
   unfold decodeTx
   rw [hbt]
   simp only [List.cons_append, Option.bind_eq_bind, Codec.decode_encode, Option.bind_some]
-  split
-  · next rest2 heq => rw [List.cons.injEq] at heq; exact absurd heq.1 hb
-  · rfl
+  split <;> simp_all
 
 /-- Round-trip: every transaction encodes and decodes back to itself, tail
 preserved. -/
@@ -336,14 +332,12 @@ theorem decodeTx_canonical (bs : List UInt8) (tx : Tx) (rest : List UInt8)
   dsimp only at h
   have ev := Codec.decode_canonical bs version rest1 hv
   split at h
-  · rename_i rest2
-    split at h
-    · rename_i rest3
-      obtain ⟨ins, outs, lockTime, rfl, hbody⟩ :=
-        decodeSegwit_canonical version rest3 tx rest h
-      rw [ev, hbody]
-      simp only [encodeTx, List.append_assoc, List.cons_append]
-    · simp at h
+  · rename_i rest3
+    obtain ⟨ins, outs, lockTime, rfl, hbody⟩ :=
+      decodeSegwit_canonical version rest3 tx rest h
+    rw [ev, hbody]
+    simp only [encodeTx, List.append_assoc, List.cons_append]
+  · simp at h
   · obtain ⟨inputs, outputs, lockTime, hne, rfl, hbody⟩ :=
       decodeLegacy_canonical version rest1 tx rest h
     rw [ev, hbody]

--- a/BtcVerified/Transaction/Tx.lean
+++ b/BtcVerified/Transaction/Tx.lean
@@ -193,19 +193,12 @@ def decodeSegwit (version : UInt32) (bs : List UInt8) : Option (Tx × List UInt8
 
 /-- Decode a legacy transaction body (everything after version), then attach the
 non-empty-inputs proof via the smart constructor. -/
-def decodeLegacy (version : UInt32) (bs : List UInt8) : Option (Tx × List UInt8) :=
-  match Codec.decode (α := CountedList TxIn) bs with
-  | none => none
-  | some (inputs, r1) =>
-    match Codec.decode (α := CountedList TxOut) r1 with
-    | none => none
-    | some (outputs, r2) =>
-      match Codec.decode (α := UInt32) r2 with
-      | none => none
-      | some (lockTime, r3) =>
-        match Tx.legacy? ⟨version, inputs, outputs, lockTime⟩ with
-        | none => none
-        | some tx => some (tx, r3)
+def decodeLegacy (version : UInt32) (bs : List UInt8) : Option (Tx × List UInt8) := do
+  let (inputs, r1) ← Codec.decode (α := CountedList TxIn) bs
+  let (outputs, r2) ← Codec.decode (α := CountedList TxOut) r1
+  let (lockTime, r3) ← Codec.decode (α := UInt32) r2
+  let tx ← Tx.legacy? ⟨version, inputs, outputs, lockTime⟩
+  return (tx, r3)
 
 /-- Decode a transaction: read the version, then dispatch on the marker byte. -/
 def decodeTx (bs : List UInt8) : Option (Tx × List UInt8) :=
@@ -241,8 +234,9 @@ theorem decodeLegacy_encode (body : TxBody) (hne : body.inputs.val ≠ [])
           ++ Codec.encode body.lockTime ++ rest)
       = some (Tx.legacy body hne, rest) := by
   unfold decodeLegacy
-  simp only [List.append_assoc, Codec.decode_encode]
+  simp only [List.append_assoc, Option.bind_eq_bind, Codec.decode_encode, Option.bind_some]
   rw [Tx.legacy?_eq_some hne]
+  rfl
 
 /-- When the byte after the version is not the marker `0x00`, `decodeTx`
 dispatches to the legacy decoder. -/
@@ -320,33 +314,18 @@ theorem decodeLegacy_canonical (version : UInt32) (bs : List UInt8) (tx : Tx)
       tx = Tx.legacy ⟨version, inputs, outputs, lockTime⟩ hne ∧
         bs = Codec.encode inputs ++ Codec.encode outputs ++ Codec.encode lockTime ++ rest := by
   unfold decodeLegacy at h
-  cases hti : Codec.decode (α := CountedList TxIn) bs with
-  | none => simp [hti] at h
-  | some tir =>
-    obtain ⟨inputs, r1⟩ := tir
-    simp only [hti] at h
-    cases hto : Codec.decode (α := CountedList TxOut) r1 with
-    | none => simp [hto] at h
-    | some tor =>
-      obtain ⟨outputs, r2⟩ := tor
-      simp only [hto] at h
-      cases hlt : Codec.decode (α := UInt32) r2 with
-      | none => simp [hlt] at h
-      | some lr =>
-        obtain ⟨lockTime, r3⟩ := lr
-        simp only [hlt] at h
-        cases hleg : Tx.legacy? ⟨version, inputs, outputs, lockTime⟩ with
-        | none => simp [hleg] at h
-        | some tx' =>
-          simp only [hleg, Option.some.injEq, Prod.mk.injEq] at h
-          obtain ⟨rfl, rfl⟩ := h
-          obtain ⟨hne, htxeq⟩ := Tx.legacy_of_legacy? hleg
-          refine ⟨inputs, outputs, lockTime, hne, htxeq, ?_⟩
-          have eti := Codec.decode_canonical bs inputs r1 hti
-          have eto := Codec.decode_canonical r1 outputs r2 hto
-          have elt := Codec.decode_canonical r2 lockTime r3 hlt
-          rw [eti, eto, elt]
-          simp only [List.append_assoc]
+  simp only [Option.bind_eq_bind, Option.pure_def, Option.bind_eq_some_iff,
+    Option.some.injEq, Prod.mk.injEq] at h
+  obtain ⟨⟨inputs, r1⟩, hti, ⟨outputs, r2⟩, hto, ⟨lockTime, r3⟩, hlt, tx', hleg,
+    rfl, rfl⟩ := h
+  dsimp only at hto hlt hleg ⊢
+  obtain ⟨hne, htxeq⟩ := Tx.legacy_of_legacy? hleg
+  refine ⟨inputs, outputs, lockTime, hne, htxeq, ?_⟩
+  have eti := Codec.decode_canonical bs inputs r1 hti
+  have eto := Codec.decode_canonical r1 outputs r2 hto
+  have elt := Codec.decode_canonical r2 lockTime r3 hlt
+  rw [eti, eto, elt]
+  simp only [List.append_assoc]
 
 /-- Canonicality: an accepted parse consumed exactly the canonical encoding,
 including the legacy/SegWit branch the value's own form dictates. -/

--- a/BtcVerified/Transaction/Tx.lean
+++ b/BtcVerified/Transaction/Tx.lean
@@ -201,16 +201,14 @@ def decodeLegacy (version : UInt32) (bs : List UInt8) : Option (Tx × List UInt8
   return (tx, r3)
 
 /-- Decode a transaction: read the version, then dispatch on the marker byte. -/
-def decodeTx (bs : List UInt8) : Option (Tx × List UInt8) :=
-  match Codec.decode (α := UInt32) bs with
-  | none => none
-  | some (version, rest1) =>
-    match rest1 with
-    | 0x00 :: rest2 =>
-      match rest2 with
-      | 0x01 :: rest3 => decodeSegwit version rest3
-      | _ => none
-    | _ => decodeLegacy version rest1
+def decodeTx (bs : List UInt8) : Option (Tx × List UInt8) := do
+  let (version, rest1) ← Codec.decode (α := UInt32) bs
+  match rest1 with
+  | 0x00 :: rest2 =>
+    match rest2 with
+    | 0x01 :: rest3 => decodeSegwit version rest3
+    | _ => none
+  | _ => decodeLegacy version rest1
 
 /-! ## Round-trip -/
 
@@ -247,7 +245,7 @@ theorem decodeTx_legacy_eq (version : UInt32) (inputs : CountedList TxIn)
       = decodeLegacy version (Codec.encode inputs ++ rest1) := by
   unfold decodeTx
   rw [hbt]
-  simp only [List.cons_append, Codec.decode_encode]
+  simp only [List.cons_append, Option.bind_eq_bind, Codec.decode_encode, Option.bind_some]
   split
   · next rest2 heq => rw [List.cons.injEq] at heq; exact absurd heq.1 hb
   · rfl
@@ -259,7 +257,8 @@ theorem decodeTx_encodeTx (tx : Tx) (rest : List UInt8) :
   cases tx with
   | segwit version ins outs lockTime =>
     unfold encodeTx decodeTx
-    simp only [List.append_assoc, List.cons_append, Codec.decode_encode]
+    simp only [List.append_assoc, List.cons_append, Option.bind_eq_bind,
+      Codec.decode_encode, Option.bind_some]
     exact decodeSegwit_encode version ins outs lockTime rest
   | legacy body hne =>
     obtain ⟨b, t, hbt, hb0⟩ := CompactSize.encode_head (UInt64.ofNat body.inputs.val.length)
@@ -332,29 +331,27 @@ including the legacy/SegWit branch the value's own form dictates. -/
 theorem decodeTx_canonical (bs : List UInt8) (tx : Tx) (rest : List UInt8)
     (h : decodeTx bs = some (tx, rest)) : bs = encodeTx tx ++ rest := by
   unfold decodeTx at h
-  cases hv : Codec.decode (α := UInt32) bs with
-  | none => simp [hv] at h
-  | some vr =>
-    obtain ⟨version, rest1⟩ := vr
-    simp only [hv] at h
-    have ev := Codec.decode_canonical bs version rest1 hv
+  simp only [Option.bind_eq_bind, Option.bind_eq_some_iff] at h
+  obtain ⟨⟨version, rest1⟩, hv, h⟩ := h
+  dsimp only at h
+  have ev := Codec.decode_canonical bs version rest1 hv
+  split at h
+  · rename_i rest2
     split at h
-    · rename_i rest2
-      split at h
-      · rename_i rest3
-        obtain ⟨ins, outs, lockTime, rfl, hbody⟩ :=
-          decodeSegwit_canonical version rest3 tx rest h
-        rw [ev, hbody]
-        simp only [encodeTx, List.append_assoc, List.cons_append]
-      · simp at h
-    · obtain ⟨inputs, outputs, lockTime, hne, rfl, hbody⟩ :=
-        decodeLegacy_canonical version rest1 tx rest h
+    · rename_i rest3
+      obtain ⟨ins, outs, lockTime, rfl, hbody⟩ :=
+        decodeSegwit_canonical version rest3 tx rest h
       rw [ev, hbody]
-      simp only [encodeTx]
-      rw [show (Codec.encode (⟨version, inputs, outputs, lockTime⟩ : TxBody) : List UInt8)
-          = Codec.encode version ++ (Codec.encode inputs
-            ++ (Codec.encode outputs ++ Codec.encode lockTime)) from rfl]
-      simp only [List.append_assoc]
+      simp only [encodeTx, List.append_assoc, List.cons_append]
+    · simp at h
+  · obtain ⟨inputs, outputs, lockTime, hne, rfl, hbody⟩ :=
+      decodeLegacy_canonical version rest1 tx rest h
+    rw [ev, hbody]
+    simp only [encodeTx]
+    rw [show (Codec.encode (⟨version, inputs, outputs, lockTime⟩ : TxBody) : List UInt8)
+        = Codec.encode version ++ (Codec.encode inputs
+          ++ (Codec.encode outputs ++ Codec.encode lockTime)) from rfl]
+    simp only [List.append_assoc]
 
 /-- The transaction codec: legacy and SegWit forms, dispatched on the BIP144
 marker byte. -/


### PR DESCRIPTION
## What

Every prefix-consuming decoder in the serialization stack was written as a nested `match ... | none => none` cascade — which is exactly `Option`'s monadic bind, spelled out by hand. This rewrites all eight as `do`-blocks, one commit per definition:

- `decodeProd`, `decodeBitVecLE` (`Serialize/Codec.lean`)
- `decodeFixedWidth` (`Serialize/CompactSize.lean`)
- `decodeElems`, `decodeCountedList` (`Serialize/CountedList.lean`)
- `decodeSegwit`, `decodeLegacy`, `decodeTx` (`Transaction/Tx.lean`)

`decodeTx` keeps its marker-byte dispatch as a match (it scrutinizes the byte list, not an `Option`); only its version read becomes a bind. `CompactSize.decode` and `decodeByte` are untouched for the same reason.

## Proof impact

The statements are unchanged; only the proof scripts that walked the definitional shape moved idiom:

- **Round-trip** proofs add the bind-reduction simp lemmas (`Option.bind_eq_bind`, `Option.bind_some`, `Option.pure_def`) to their existing `simp only` sets.
- **Canonicality** proofs replace the nested `cases hd : ... with | none => ... | some ...` splits with a single `Option.bind_eq_some_iff` destructuring — one `obtain` pulls out all intermediate parses and their equations at once, which reads shorter than the cascade it replaces.
- Where the `do`-desugaring leaves literal pair projections behind (`(outs, r2).2`), a `dsimp only` clears them.

Each commit builds cleanly on its own; `lake build`, `lake lint`, and `lake test` (block-481824 fixture: decode, hash-verify, re-encode byte-for-byte) all pass at the head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
