### PR TITLE
Add `nix develop` for dev-shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,16 @@ jobs:
           build: true
           test: true
           lint: true
+
+  nix-develop:
+    name: nix develop
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: DeterminateSystems/nix-installer-action@main
+      - name: Check flake
+        run: nix flake check
+      - name: Fetch mathlib cache through dev shell
+        run: nix develop -c lake exe cache get
+      - name: Build through dev shell
+        run: nix develop -c lake build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,14 @@ they prove.
 
 ## Workflow
 
+With Nix installed, enter the development shell first:
+
+```sh
+nix develop
+```
+
+Then run the normal Lean workflow:
+
 ```sh
 lake exe cache get   # once, after cloning or bumping mathlib
 lake build           # builds the library and the tests

--- a/README.md
+++ b/README.md
@@ -330,6 +330,12 @@ The point is to make a public, checked trail toward those larger artifacts.
 
 ## Build
 
+With Nix, enter the development shell first:
+
+```
+nix develop
+```
+
 ```
 lake exe cache get   # fetch the mathlib cache (first build only)
 lake build           # the library, plus the golden vectors and axiom audit

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "Development shell for btc-verified";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              cacert
+              curl
+              git
+              stdenv.cc
+
+              # elan is used instead of nixpkgs#lean4 because nixpkgs currently
+              # has Lean 4.29.1, while we need leanprover/lean4:v4.30.0-rc2.
+              elan
+            ];
+
+            shellHook = ''
+              # Use Nix's certificate bundle for HTTPS fetches from tools such
+              # as curl, git, elan, and Lake.
+              export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+              export GIT_SSL_CAINFO="$SSL_CERT_FILE"
+
+              # Print the repository-pinned Lean toolchain and the usual build
+              # command when entering the shell from the project root.
+              if [ -f lean-toolchain ]; then
+                echo "btc-verified dev shell"
+                echo "Lean toolchain: $(cat lean-toolchain)"
+                echo "Run: lake exe cache get && lake build"
+              fi
+            '';
+          };
+        });
+    };
+}


### PR DESCRIPTION
It is a useful thing for Nix users, who can now run `nix develop` and get all the tools needed to work with the project.