### PR TITLE
Cache elan/lake and the Nix store across CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      # Cache elan's toolchain install plus lake's package checkouts and
+      # build output, keyed on the two files that determine whether either
+      # needs to change. A near-miss (e.g. only the manifest changed) still
+      # restores the previous toolchain via restore-keys.
+      - uses: actions/cache@v4
+        with:
+          path: |
+            .lake
+            ~/.elan
+          key: ${{ runner.os }}-lake-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
+          restore-keys: |
+            ${{ runner.os }}-lake-
       # `lake build` covers the default targets: the library plus Tests
       # (golden vectors and the axiom audit, which fails on `sorry`).
       # `lake test` decodes the block-481824 fixture through the verified
@@ -32,6 +44,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
+      # Persists the Nix store (nixpkgs closure, flake eval) across runs so
+      # `nix-installer-action` and `nix flake check` don't redo the same
+      # evaluation from scratch every time.
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Check flake
         run: nix flake check
       - name: Fetch mathlib cache through dev shell

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,6 +31,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Same cache as ci.yml's lake-build job, keyed identically so a cache
+      # warmed by either workflow benefits the other (the GitHub Actions
+      # cache is scoped per-repo, not per-workflow).
+      - uses: actions/cache@v4
+        with:
+          path: |
+            .lake
+            ~/.elan
+          key: ${{ runner.os }}-lake-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
+          restore-keys: |
+            ${{ runner.os }}-lake-
+
       # Install elan and fetch the mathlib olean cache (`lake exe cache get`)
       # without building, so Claude's own `lake build` doesn't rebuild
       # mathlib from source and eat the whole time budget. The GitHub cache

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -5,8 +5,12 @@ on:
     types: [created, edited]
   pull_request_review_comment:
     types: [created, edited]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [opened]
   issues:
-    types: [opened, assigned]
+    types: [opened, assigned, labeled]
 
 permissions:
   contents: write
@@ -19,11 +23,17 @@ jobs:
   claude:
     # Gate before the job starts: the Lean toolchain + mathlib cache setup
     # below is too expensive to run on every comment, so only proceed when
-    # the triggering comment or issue actually mentions @claude.
+    # the triggering comment, review, PR description, or issue actually
+    # mentions @claude — or when an issue is given the `claude` label (the
+    # assignment-like gesture; the app bot itself is not assignable, so the
+    # label stands in for assigning the issue to Claude).
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'claude')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Closes #27.

Implements the caching design sketched in the issue thread: the vanilla cache action for the Lean toolchain/lake artifacts, plus the Nix cache action. Per the follow-up instruction, the `lake build` inside the `nix-develop` job is left unchanged.

## Changes

- **`ci.yml` (`lake-build` job) and `claude.yml`**: add an `actions/cache@v4` step caching `.lake` and `~/.elan`, keyed on `${{ runner.os }}-lake-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}` with a `restore-keys` prefix fallback. The key is identical in both workflows so a cache warmed by a CI run also speeds up `@claude` runs and vice versa (the Actions cache is scoped per-repo, not per-workflow).
- **`ci.yml` (`nix-develop` job)**: add `DeterminateSystems/magic-nix-cache-action@main` right after the Nix installer so the Nix store (nixpkgs closure, flake eval) persists across runs.

## Cache invalidation

`lean-toolchain` and `lake-manifest.json` are the only two files that determine whether the toolchain or the dependency set changes, so a mathlib/toolchain bump misses the exact key (and falls back to an incremental restore via `restore-keys`), while ordinary proof-leaf commits hit it exactly.

## Known caveat

GitHub's cache is capped at 10 GB per repo with LRU eviction; if the mathlib olean cache plus toolchain doesn't fit comfortably, the fallback is to drop `.lake/packages` from the cached paths or split the entry in two (noted in the issue thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Second commit: widened Claude trigger surface

Per follow-up discussion, `claude.yml` now also subscribes to `pull_request` (opened) and `pull_request_review` (submitted) — the action already scanned PR descriptions and review bodies for `@claude`, but the workflow never woke up for those events — and to `issues: labeled`, gated on the `claude` label. The label stands in for assignment: the Claude app bot is not an assignable user on GitHub (confirmed via the assignees API), and the label is recognized by the action's default `label_trigger`. The `claude` label has been created on the repo.

## Note

A third commit (auto-opening PRs after issue-driven Claude runs) was briefly pushed to this branch after merge; it was relocated to #29.
