### PR TITLE
Open PRs automatically after issue-driven Claude runs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -66,5 +66,52 @@ jobs:
           use-mathlib-cache: true
 
       - uses: anthropics/claude-code-action@v1
+        id: claude
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+      # Open the PR that issue-driven Claude runs stop short of creating.
+      # claude-code-action deliberately never runs `gh pr create` itself; it
+      # hands back a quick-pull link instead. But clicking that link makes
+      # the clicker the PR author, and GitHub blocks review/approval of
+      # one's own PRs — so for review separation the bot must be the opener.
+      # Doing it as a deterministic step (option 2 from the issue-22 thread)
+      # keeps Claude's own tool surface unchanged. The Claude App token from
+      # the action's output is used rather than the workflow GITHUB_TOKEN
+      # because PRs created with GITHUB_TOKEN don't trigger `pull_request`
+      # workflows — CI would silently skip the new PR.
+      - name: Open PR for Claude's branch
+        if: >-
+          steps.claude.outputs.branch_name != '' &&
+          (github.event_name == 'issues' ||
+          (github.event_name == 'issue_comment' && !github.event.issue.pull_request))
+        env:
+          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
+          BRANCH: ${{ steps.claude.outputs.branch_name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          # branch_name is set even for runs that never push (e.g. Q&A-only
+          # answers), so only open a PR for a branch that exists on the
+          # remote, is ahead of master, and doesn't already have one.
+          if ! git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null; then
+            echo "Branch $BRANCH was never pushed; nothing to open."
+            exit 0
+          fi
+          ahead=$(gh api "repos/$GITHUB_REPOSITORY/compare/master...$BRANCH" --jq .ahead_by)
+          if [ "$ahead" -eq 0 ]; then
+            echo "Branch $BRANCH has no commits beyond master; nothing to open."
+            exit 0
+          fi
+          if [ -n "$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+            echo "An open PR for $BRANCH already exists."
+            exit 0
+          fi
+          gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "$BRANCH" \
+            --base master \
+            --title "$ISSUE_TITLE" \
+            --body "Automated PR for the @claude run on #${ISSUE_NUMBER}; see that issue's thread for the run's summary and verification notes.
+
+          Closes #${ISSUE_NUMBER}."


### PR DESCRIPTION
Implements option 2 from the [issue #22 discussion](https://github.com/ProofOfKeags/btc-verified/issues/22): issue-driven `@claude` runs get their PR opened by a deterministic workflow step instead of stopping at a quick-pull link.

(Originally pushed to the PR #28 branch after that PR merged; relocated here to its own branch.)

## Why

`claude-code-action` never runs `gh pr create` itself — issue-driven runs push a branch and hand back a pre-filled "Create PR" link (this is how the issue #22 leaf ended up sitting on an unopened branch). Clicking the link is not an acceptable substitute: the clicker becomes the PR author, and GitHub blocks review/approval of one's own PRs, so the maintainer loses the ability to give a proper review. The opener must be the bot.

## How

A step after the `claude-code-action` step (now given `id: claude`) runs `gh pr create` when the triggering event was issue-driven — an `issues` event, or an `issue_comment` on an actual issue (comments on PRs already push to the existing PR branch).

Guards, since the action's `branch_name` output is set even for runs that never push (e.g. Q&A-only answers):

- the branch exists on the remote,
- it is ahead of `master`,
- no open PR for it exists yet.

The step authenticates with the Claude App token from the action's `github_token` output rather than the workflow's `GITHUB_TOKEN`, for two reasons:

1. **claude[bot] becomes the PR author**, preserving reviewer separation.
2. PRs created with `GITHUB_TOKEN` don't trigger `pull_request` workflows — CI would silently skip every Claude PR.

Claude's own tool surface is unchanged: it still cannot invoke `gh pr create` itself; the workflow does it deterministically.

## Caveats

- Verified against the action's source (`branch_name`/`github_token` output semantics, no token revocation on cleanup), but not yet live-tested — the first issue-driven run after this merges is the real test.
- App installation tokens live ~1 hour, so a run that exhausts most of the 60-minute job timeout could hand this step an expired token. The step then fails loudly (red run) and the quick-pull link in Claude's comment remains as the manual fallback — chosen over silently falling back to `GITHUB_TOKEN`, which would produce a CI-less PR.

Refs: #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
