### PR TITLE
Add the blockchain: header hash linkage and the chain notion

### DIFF
--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -19,5 +19,6 @@ import BtcVerified.Transaction.Txid
 import BtcVerified.Block.BlockHeader
 import BtcVerified.Block.Block
 import BtcVerified.Block.Commitment
+import BtcVerified.Block.BlockHash
 import BtcVerified.BitVM.BitCommitment
 import BtcVerified.Impl.BitcoinCore.Merkle

--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -20,5 +20,6 @@ import BtcVerified.Block.BlockHeader
 import BtcVerified.Block.Block
 import BtcVerified.Block.Commitment
 import BtcVerified.Block.BlockHash
+import BtcVerified.Block.Chain
 import BtcVerified.BitVM.BitCommitment
 import BtcVerified.Impl.BitcoinCore.Merkle

--- a/BtcVerified/Block/BlockHash.lean
+++ b/BtcVerified/Block/BlockHash.lean
@@ -1,0 +1,44 @@
+import BtcVerified.Block.BlockHeader
+import BtcVerified.Crypto.Sha256
+/-!
+  # Block header hashes
+
+  The block hash: the double-SHA-256 of a header's 80-byte encoding, the same
+  digest proof of work targets and `prevBlockHash` links commit to. Promoted
+  from the ad hoc `Sha256.sha256d (Codec.encode b.header)` expression the
+  fixture tests computed inline into the library, the same move `Tx.txid`
+  made for transactions.
+
+  As with `Tx.txid_faithful`, the faithfulness theorem here is the
+  collision-disjunct idiom: equal hashes force equal headers, or the two
+  encodings exhibit a concrete double-SHA-256 collision. Collision resistance
+  is never assumed for the concrete hash — only ever a hypothesis a caller
+  supplies over the abstract `Sha256.Collision` vocabulary.
+
+  Checked claims:
+
+  * `BlockHeader.hash_faithful`: equal block hashes mean equal headers — or a
+    concrete double-SHA-256 collision.
+-/
+
+namespace BtcVerified
+
+open BtcVerified.Serialize
+
+/-- The block hash: the double-SHA-256 of the header's 80-byte encoding. This
+is the digest `prevBlockHash` links commit to, and the digest a proof-of-work
+target is checked against (the target check itself belongs to the
+proof-of-work layer, not this module). -/
+def BlockHeader.hash (h : BlockHeader) : Hash256 :=
+  ⟨Sha256.sha256d (Codec.encode h), Sha256.sha256d_length _⟩
+
+/-- Equal block hashes mean equal headers — or two concrete byte strings
+witnessing a double-SHA-256 collision. -/
+theorem BlockHeader.hash_faithful {h₁ h₂ : BlockHeader} (h : h₁.hash = h₂.hash) :
+    h₁ = h₂ ∨ Sha256.Collision := by
+  by_cases he : h₁ = h₂
+  · exact Or.inl he
+  · exact Or.inr ⟨Codec.encode h₁, Codec.encode h₂,
+      fun hc => he (encode_injective hc), congrArg Subtype.val h⟩
+
+end BtcVerified

--- a/BtcVerified/Block/Chain.lean
+++ b/BtcVerified/Block/Chain.lean
@@ -1,0 +1,156 @@
+import BtcVerified.Block.BlockHash
+/-!
+  # The blockchain: header linkage and the chain notion
+
+  A blockchain, in this first iteration, is nothing more than a
+  *structurally linked* sequence of headers. That weakness is the point:
+  every later refinement — proof of work, cumulative work, the block tree,
+  consensus validity — builds on this layer instead of rewriting it.
+
+  ## Linkage
+
+  `BlockHeader.Extends h₂ h₁` is the one structural fact everything else
+  here is built from: `h₂`'s `prevBlockHash` is `h₁`'s hash, i.e. `h₂` is
+  the header that directly follows `h₁` on the chain.
+
+  ## Representation
+
+  `Chain` is an inductive, **tip-first** (the newest header is the outer
+  constructor) and **hash-anchored**: `Chain (h : Hash256)` is a chain whose
+  next link — real or hypothetical — must carry `h` as its `prevBlockHash`.
+  Concretely, `h` is either the anchor of an empty chain (`nil`) or the hash
+  of the chain's own outermost header (`extend`).
+
+  This single index does double duty as both "the anchor a segment hangs
+  from" and "the tip hash a chain currently offers", which is exactly what
+  dissolves the genesis-vs-parameterized tension: the full Bitcoin chain is
+  just `Chain 0` (`0`, the zero hash, is the genesis header's own
+  `prevBlockHash`), with the genesis header as its deepest link, and a
+  segment hanging off any interior block is a `Chain` anchored at that
+  block's hash — no separate treatment needed. Tree paths (the next
+  structural leaf, for fork detection) will want exactly these segments.
+
+  Tip-first orientation matches how the headline theorem below recurses —
+  peel the tip, recurse on what remains — the same direction fork-choice
+  reasoning runs in: backward from the present, not forward from genesis.
+
+  One consequence of the hash-anchored `nil`: the empty chain exists for
+  every anchor, and is the identity for stacking chain segments (a `Chain
+  h₂` on top of a `Chain h₁` whose tip hash is `h₂`). So "nonempty" is a
+  hypothesis theorems needing an actual tip must state, not a structural
+  given.
+
+  ## Scope
+
+  This is the *linear* chain — the structural layer fork-choice reasoning
+  sits on, not fork choice itself. Explicitly out of scope for this leaf:
+  proof of work (`nBits` → target, the `hash ≤ target` check, per-block
+  work), cumulative work and any ordering on chains, the block tree (fork
+  *detection*, which reuses this linkage relation), and all of consensus
+  validity. A chain here is only ever structurally linked headers.
+
+  Checked claims:
+
+  * `Chain.isChain_toList`: a chain's list-of-headers view satisfies the
+    decidable linkage predicate `IsChain` a chain was built to satisfy.
+  * `Chain.tip_commits`: two chains of equal length that share a tip hash
+    carry the same header list — or two concrete byte strings collide under
+    double-SHA-256. The tip hash commits to the entire history.
+-/
+
+namespace BtcVerified
+
+/-! ## Linkage -/
+
+/-- `h₂` directly extends `h₁`: its `prevBlockHash` is `h₁`'s hash — the one
+structural fact a chain's consecutive headers satisfy. -/
+def BlockHeader.Extends (h₂ h₁ : BlockHeader) : Prop := h₂.prevBlockHash = h₁.hash
+
+instance instDecidableExtends (h₂ h₁ : BlockHeader) : Decidable (h₂.Extends h₁) :=
+  inferInstanceAs (Decidable (_ = _))
+
+/-! ## The chain type -/
+
+/-- A structurally linked sequence of block headers, tip-first and
+hash-anchored (see the module header for the design rationale). `Chain h`
+is a chain whose next link must carry `h` as its `prevBlockHash` — either
+because `h` is the anchor of an empty chain, or because `h` is the hash of
+the chain's own outermost header. -/
+inductive Chain : Hash256 → Type where
+  /-- The empty chain hanging from `anchor`: no headers yet, so any header
+  whose `prevBlockHash` is `anchor` may extend it directly. The identity for
+  stacking chain segments. -/
+  | nil (anchor : Hash256) : Chain anchor
+  /-- Extend a chain whose current head is `prev` with a new tip header
+  linking to it. -/
+  | extend (prev : Hash256) (rest : Chain prev) (tip : BlockHeader)
+      (linked : tip.prevBlockHash = prev) : Chain tip.hash
+
+/-- The headers of a chain, tip-first (the newest header at the head of the
+list) — the cheap, structure-forgetting view into plain list space that
+golden vectors and the block tree speak. -/
+def Chain.toList {h : Hash256} : Chain h → List BlockHeader
+  | .nil _ => []
+  | .extend _ rest tip _ => tip :: rest.toList
+
+/-! ## The linkage predicate over plain lists -/
+
+/-- The linkage predicate over a plain, tip-first header list: `hs`'s
+headers link all the way down to `h` — each header's hash is what the next
+one back points to, and (if `hs` is empty) `h` is left an unconstrained
+anchor. Exactly what a `Chain h`'s `toList` satisfies. -/
+def IsChain (h : Hash256) : List BlockHeader → Prop
+  | [] => True
+  | hd :: tl => hd.hash = h ∧ IsChain hd.prevBlockHash tl
+
+/-- `IsChain` is decidable, so real header lists — golden vectors now,
+block-tree paths later — can be checked directly, without building a
+`Chain` term. -/
+instance instDecidableIsChain (h : Hash256) : (hs : List BlockHeader) → Decidable (IsChain h hs)
+  | [] => isTrue True.intro
+  | hd :: tl =>
+    match instDecidableIsChain hd.prevBlockHash tl with
+    | isTrue htl =>
+      if heq : hd.hash = h then isTrue ⟨heq, htl⟩ else isFalse fun hc => heq hc.1
+    | isFalse hntl => isFalse fun hc => hntl hc.2
+
+/-- A chain's list-of-headers view satisfies the linkage predicate it was
+built from. -/
+theorem Chain.isChain_toList {h : Hash256} : (c : Chain h) → IsChain h c.toList
+  | .nil _ => True.intro
+  | .extend _ rest tip linked => by
+      refine ⟨rfl, ?_⟩
+      rw [linked]
+      exact rest.isChain_toList
+
+/-! ## The tip-commitment theorem -/
+
+/-- Two chains of equal length that share a tip hash carry the same header
+list — or two concrete byte strings witness a double-SHA-256 collision. The
+tip hash commits to the entire history: peeling it off (equal hashes give
+equal headers, via `BlockHeader.hash_faithful`, or a collision) and
+recursing identifies the chains one header at a time. -/
+theorem Chain.tip_commits {h₁ h₂ : Hash256} :
+    (c₁ : Chain h₁) → (c₂ : Chain h₂) → h₁ = h₂ →
+      c₁.toList.length = c₂.toList.length →
+      c₁.toList = c₂.toList ∨ Sha256.Collision
+  | .nil _, .nil _, _, _ => Or.inl rfl
+  | .nil _, .extend .., _, hlen => by
+      simp only [Chain.toList, List.length_nil, List.length_cons] at hlen
+      exact absurd hlen (by omega)
+  | .extend .., .nil _, _, hlen => by
+      simp only [Chain.toList, List.length_nil, List.length_cons] at hlen
+      exact absurd hlen (by omega)
+  | .extend prev₁ rest₁ tip₁ linked₁, .extend prev₂ rest₂ tip₂ linked₂, heq, hlen => by
+      rcases BlockHeader.hash_faithful heq with htip | hcol
+      · have hprev : prev₁ = prev₂ :=
+          linked₁.symm.trans ((congrArg BlockHeader.prevBlockHash htip).trans linked₂)
+        have hlen' : rest₁.toList.length = rest₂.toList.length := by
+          simp only [Chain.toList, List.length_cons] at hlen
+          omega
+        rcases Chain.tip_commits rest₁ rest₂ hprev hlen' with heql | hcol
+        · exact Or.inl (by simp only [Chain.toList]; rw [htip, heql])
+        · exact Or.inr hcol
+      · exact Or.inr hcol
+
+end BtcVerified

--- a/README.md
+++ b/README.md
@@ -220,6 +220,47 @@ disjunct is constructed, never assumed away: intractability of producing a
 witness is the consumer's hypothesis, the only form in which collision
 resistance can soundly appear over a concrete hash.
 
+### `BtcVerified` block hashes and the chain
+
+`BlockHeader.hash` — the double-SHA-256 of a header's 80-byte encoding, the
+same digest `prevBlockHash` links commit to and a proof-of-work target is
+checked against (the target check itself is a later leaf). Promoted from the
+ad hoc expression the fixture tests computed inline, the same move `Tx.txid`
+made for transactions.
+
+On top of it, `Chain`: a structurally linked sequence of block headers,
+tip-first (the newest header is the outer constructor) and hash-anchored
+(`Chain (h : Hash256)` is a chain whose next link must carry `h` as its
+`prevBlockHash`). The single index does double duty as both the anchor of an
+empty chain and the tip hash of a nonempty one, which is what makes the full
+Bitcoin chain just `Chain 0` — genesis's own `prevBlockHash` — with no
+separate treatment needed for a segment hanging off an interior block
+(`Chain` anchored at that block's hash). This is the *linear* chain only:
+proof of work, cumulative work, and the block tree (fork detection) are all
+later leaves built on the same linkage relation, not part of this one.
+
+Checked claims:
+
+- `BlockHeader.hash_faithful`: equal block hashes mean equal headers — or a
+  concrete double-SHA-256 collision.
+- `Chain.isChain_toList`: a chain's list-of-headers view satisfies `IsChain`,
+  the decidable linkage predicate over plain lists a `Chain` was built to
+  satisfy — so real header lists can be checked directly, without
+  constructing a `Chain` term.
+- `Chain.tip_commits`: two chains of equal length sharing a tip hash carry the
+  same header list — or a concrete collision. The tip hash commits to the
+  entire history, proved in the same peel-and-recurse style as
+  `Merkle.root_inj_of_length_eq`.
+- Golden vector: block 1 directly extends the genesis header (real mainnet
+  data), and both headers' computed hashes match their well-known display
+  hashes.
+
+Why it matters: fork-choice reasoning compares branches, and a branch has to
+*be* something before validity or cumulative work can be stated over it. This
+is that structural layer — a tip hash commits to an entire history — with
+every later refinement (proof of work, the block tree, validity) building on
+it rather than rewriting it.
+
 ### `BtcVerified.Merkle`
 
 Bitcoin's merkle tree, as a tree — the platonic spec, with the root computation
@@ -339,9 +380,9 @@ lake lint
 
 `lake build` also elaborates `Tests/`: golden vectors that run the verified
 decoder over real mainnet bytes (the first Bitcoin payment, the SegWit
-activation coinbase, the first SegWit spend, the genesis block, block 170) and
-an axiom audit that fails the build if any headline theorem depends on `sorry`
-or an unexpected axiom. `lake test` decodes the full SegWit activation block,
+activation coinbase, the first SegWit spend, the genesis block, block 170, and
+the genesis-to-block-1 chain link) and an axiom audit that fails the build if
+any headline theorem depends on `sorry` or an unexpected axiom. `lake test` decodes the full SegWit activation block,
 fetching it from a block explorer on first run and caching it locally (it is
 public chain data, so it is not committed). See `CONTRIBUTING.md` for the
 contribution workflow.

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -99,6 +99,10 @@ elab "#assert_axioms " id:ident : command => do
 #assert_axioms BtcVerified.Tx.wtxid_faithful
 #assert_axioms BtcVerified.Tx.wtxid_legacy
 
+/-! ## Block hashes -/
+
+#assert_axioms BtcVerified.BlockHeader.hash_faithful
+
 /-! ## The merkle tree -/
 
 #assert_axioms BtcVerified.Merkle.combine_inj

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -103,6 +103,11 @@ elab "#assert_axioms " id:ident : command => do
 
 #assert_axioms BtcVerified.BlockHeader.hash_faithful
 
+/-! ## The chain -/
+
+#assert_axioms BtcVerified.Chain.isChain_toList
+#assert_axioms BtcVerified.Chain.tip_commits
+
 /-! ## The merkle tree -/
 
 #assert_axioms BtcVerified.Merkle.combine_inj

--- a/Tests/BlockFixtures.lean
+++ b/Tests/BlockFixtures.lean
@@ -47,10 +47,10 @@ the fixture's own spot-checks. -/
 def blockFixtureChecksOut (displayHash : String) (bytes : List UInt8)
     (spot : Block → Bool) : Bool :=
   match hexBytes? displayHash, Codec.decode (α := Block) bytes with
-  | some hashBytes, some (b, rest) =>
+  | some _, some (b, rest) =>
     rest == []
     && Codec.encode b == bytes
-    && Sha256.sha256d (Codec.encode b.header) == hashBytes.reverse
+    && b.header.hash == hashOfDisplay displayHash
     && spot b
   | _, _ => false
 

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -277,6 +277,40 @@ def block170Hex : String :=
         && some (Codec.encode payment) == hexBytes? firstBitcoinPaymentHex
       | _ => false)
 
+/-! ## The blockchain: genesis → block 1 linkage
+
+  Block 1 (2009-01-09), hash
+  `00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048`: the
+  first block mined after genesis, extending it directly. Built from its
+  known display-order fields — the way a block explorer presents them —
+  rather than raw wire bytes, since only the linkage relation, not the
+  codec, is under test here.
+-/
+
+/-- Block 1's header. -/
+def block1Header : BlockHeader where
+  version := 1
+  prevBlockHash :=
+    hashOfDisplay "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+  merkleRoot :=
+    hashOfDisplay "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a49f7e77638012"
+  time := 1231469665
+  bits := 0x1d00ffff
+  nonce := 2573394689
+
+#guard match hexBytes? genesisBlockHex >>= Codec.decode (α := Block) with
+  | some (b, _) =>
+    -- The genesis header hashes to the well-known genesis block hash.
+    b.header.hash
+      == hashOfDisplay "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+    -- Block 1 directly extends the genesis header — the chain's first real
+    -- link, checked by the decidable linkage relation.
+    && decide (block1Header.Extends b.header)
+    -- Block 1's own hash matches the well-known block 1 hash.
+    && block1Header.hash
+      == hashOfDisplay "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"
+  | none => false
+
 /-! ## CompactSize boundary values -/
 
 #guard CompactSize.encode 0 == [0x00]


### PR DESCRIPTION
## Summary
- Adds `BlockHeader.hash` (promoted from the test-inline expression, same move as `Tx.txid`) with a collision-disjunct faithfulness theorem.
- Adds the structural blockchain layer: `BlockHeader.Extends`, a tip-first, hash-anchored `Chain` inductive, the decidable `IsChain` list predicate, and the headline `Chain.tip_commits` theorem (the tip hash commits to the entire history, collision-disjunct style).
- Adds a golden vector: block 1 directly extends the genesis header on real mainnet data.
- Wires everything into `BtcVerified.lean`, `Tests/AxiomAudit.lean`, and the README.

Note: this branch predates a few since-merged master commits (serialize refactors, workflow/doc changes) — may need a rebase.

Closes #22.

## ⚠️ Verification note
This was written in a sandbox that blocked `lake build`/`lake test`/`lake lint`, so none of this has been compiled or run. Please run the full build before merging. The block-1 header literals (merkle root, time, bits, nonce) in the golden vector are from memory, not fetched — if the `#guard` fails, only those literals should need correcting.

## Test plan
- [ ] `lake exe cache get`
- [ ] `lake build`
- [ ] `lake test`
- [ ] `lake lint`

🤖 Generated with [Claude Code](https://claude.ai/code)