### PR TITLE
Scope the Claude model to the triggering actor

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -65,10 +65,17 @@ jobs:
           lint: false
           use-mathlib-cache: true
 
+      # Model is scoped to the triggering actor: the maintainer's runs get
+      # Fable 5, anyone else authorized (future collaborators, allowlisted
+      # bots) falls back to Sonnet 5 so they can't draw down Fable usage.
+      # Actors without write access are refused by the action itself before
+      # any model is invoked.
       - uses: anthropics/claude-code-action@v1
         id: claude
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model ${{ github.actor == 'ProofOfKeags' && 'claude-fable-5' || 'claude-sonnet-5' }}
 
       # Open the PR that issue-driven Claude runs stop short of creating.
       # claude-code-action deliberately never runs `gh pr create` itself; it


### PR DESCRIPTION
Pins the Claude workflow's model per triggering actor: runs triggered by @ProofOfKeags use **Fable 5** (`claude-fable-5`); runs triggered by any other authorized actor fall back to **Sonnet 5** (`claude-sonnet-5`).

## Why

Without a `--model` flag the action was defaulting to Sonnet 5 for every run (confirmed from run logs), so maintainer runs get an upgrade. The actor split fences Fable usage on an OSS repo: the maintainer can't control who cuts issues or comments `@claude`, so anyone other than the maintainer never draws on the Fable tier.

Defense in depth already bounding the exposure (verified in `claude-code-action`'s source):

- Actors **without write access are refused** by the action's permission check before any Anthropic tokens are spent — external contributors pinging `@claude` cost nothing but free public-repo runner minutes.
- Fork PRs never receive `CLAUDE_CODE_OAUTH_TOKEN`, so their events can't authenticate at all.
- The fallback tier therefore only ever applies to actors deliberately granted write access later (collaborators, allowlisted bots).

## Caveat

Whether `claude-fable-5` is servable through the OAuth token in this headless context depends on the plan; if not, the run fails loudly in the Actions log and the fix is swapping the model string. The first maintainer-triggered `@claude` run after this merges is the live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
