### PR TITLE
Pre-allow the lake commands in Claude's CI runs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -70,12 +70,20 @@ jobs:
       # bots) falls back to Sonnet 5 so they can't draw down Fable usage.
       # Actors without write access are refused by the action itself before
       # any model is invoked.
+      #
+      # The lake commands are pre-allowed so Claude can iterate to green:
+      # without them every build/test/lint call is permission-blocked in the
+      # headless run, and Claude ships uncompiled proofs with "CI is the
+      # compile check" caveats (see the issue-22 thread). The setup step
+      # above has already warmed the mathlib olean cache, so these commands
+      # are cheap enough to run repeatedly inside the time budget.
       - uses: anthropics/claude-code-action@v1
         id: claude
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --model ${{ github.actor == 'ProofOfKeags' && 'claude-fable-5' || 'claude-sonnet-5' }}
+            --allowedTools "Bash(lake build:*),Bash(lake test:*),Bash(lake lint:*),Bash(lake exe cache get:*)"
 
       # Open the PR that issue-driven Claude runs stop short of creating.
       # claude-code-action deliberately never runs `gh pr create` itself; it


### PR DESCRIPTION
## Summary

Implements the request from [Claude's issue #22 run](https://github.com/ProofOfKeags/btc-verified/issues/22#issuecomment-4870574148): the workflow's headless runs had `lake build` / `lake test` / `lake lint` permission-blocked, so Claude shipped uncompiled proofs with "CI on the PR is the compile check" caveats. This adds

```
--allowedTools "Bash(lake build:*),Bash(lake test:*),Bash(lake lint:*),Bash(lake exe cache get:*)"
```

to the action's `claude_args` so Claude can iterate to green before pushing. The `--model` half of that comment's suggestion already landed in #31's actor-scoping change, so this is only the tool grant.

The setup step already warms the elan/lake caches and fetches the mathlib oleans before the action runs, so repeated in-run builds fit the 60-minute budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)