### PR TITLE
Add the blockchain: header hash linkage and the chain notion

### DIFF
--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -19,5 +19,6 @@ import BtcVerified.Transaction.Txid
 import BtcVerified.Block.BlockHeader
 import BtcVerified.Block.Block
 import BtcVerified.Block.Commitment
+import BtcVerified.Block.BlockHash
 import BtcVerified.BitVM.BitCommitment
 import BtcVerified.Impl.BitcoinCore.Merkle

--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -20,5 +20,6 @@ import BtcVerified.Block.BlockHeader
 import BtcVerified.Block.Block
 import BtcVerified.Block.Commitment
 import BtcVerified.Block.BlockHash
+import BtcVerified.Block.Chain
 import BtcVerified.BitVM.BitCommitment
 import BtcVerified.Impl.BitcoinCore.Merkle

--- a/BtcVerified/Block/BlockHash.lean
+++ b/BtcVerified/Block/BlockHash.lean
@@ -1,0 +1,44 @@
+import BtcVerified.Block.BlockHeader
+import BtcVerified.Crypto.Sha256
+/-!
+  # Block header hashes
+
+  The block hash: the double-SHA-256 of a header's 80-byte encoding, the same
+  digest proof-of-work targets and `prevBlockHash` links commit to. Promoted
+  from the ad hoc `Sha256.sha256d (Codec.encode b.header)` expression the
+  fixture tests computed inline into the library — the same move `Tx.txid`
+  made for transactions.
+
+  As with `Tx.txid_faithful`, the faithfulness theorem here is the
+  collision-disjunct idiom: equal hashes force equal headers, or the two
+  encodings exhibit a concrete double-SHA-256 collision. Collision resistance
+  is never assumed for the concrete hash — only ever a hypothesis a caller
+  supplies over the abstract `Sha256.Collision` vocabulary.
+
+  Checked claims:
+
+  * `BlockHeader.hash_faithful`: equal block hashes mean equal headers — or a
+    concrete double-SHA-256 collision.
+-/
+
+namespace BtcVerified
+
+open BtcVerified.Serialize
+
+/-- The block hash: the double-SHA-256 of the header's 80-byte encoding. This
+is the digest `prevBlockHash` links commit to, and the digest a proof-of-work
+target is checked against (the target check itself belongs to the
+proof-of-work layer, not this module). -/
+def BlockHeader.hash (h : BlockHeader) : Hash256 :=
+  ⟨Sha256.sha256d (Codec.encode h), Sha256.sha256d_length _⟩
+
+/-- Equal block hashes mean equal headers — or two concrete byte strings
+witnessing a double-SHA-256 collision. -/
+theorem BlockHeader.hash_faithful {h₁ h₂ : BlockHeader} (h : h₁.hash = h₂.hash) :
+    h₁ = h₂ ∨ Sha256.Collision := by
+  by_cases he : h₁ = h₂
+  · exact Or.inl he
+  · exact Or.inr ⟨Codec.encode h₁, Codec.encode h₂,
+      fun hc => he (encode_injective hc), congrArg Subtype.val h⟩
+
+end BtcVerified

--- a/BtcVerified/Block/BlockHash.lean
+++ b/BtcVerified/Block/BlockHash.lean
@@ -9,7 +9,7 @@ import BtcVerified.Crypto.Sha256
   fixture tests computed inline into the library — the same move `Tx.txid`
   made for transactions.
 
-  As with `Tx.txid_faithful`, the binding theorem here is the
+  As with `Tx.txid_binding`, the binding theorem here is the
   collision-disjunct idiom (`Merkle.root_inj_of_length_eq` is the same shape):
   the hash is a binding commitment to the header — equal hashes force equal
   headers, or the two encodings exhibit a concrete double-SHA-256 collision.

--- a/BtcVerified/Block/BlockHash.lean
+++ b/BtcVerified/Block/BlockHash.lean
@@ -10,7 +10,8 @@ import BtcVerified.Crypto.Sha256
   made for transactions.
 
   As with `Tx.txid_binding`, the binding theorem here is the
-  collision-disjunct idiom (`Merkle.root_inj_of_length_eq` is the same shape):
+  collision-disjunct idiom (`Merkle.root_binding_of_length_eq` is the same
+  shape):
   the hash is a binding commitment to the header — equal hashes force equal
   headers, or the two encodings exhibit a concrete double-SHA-256 collision.
   Collision resistance is never assumed for the concrete hash — only ever a

--- a/BtcVerified/Block/BlockHash.lean
+++ b/BtcVerified/Block/BlockHash.lean
@@ -9,16 +9,17 @@ import BtcVerified.Crypto.Sha256
   fixture tests computed inline into the library — the same move `Tx.txid`
   made for transactions.
 
-  As with `Tx.txid_faithful`, the injectivity theorem here is the
+  As with `Tx.txid_faithful`, the binding theorem here is the
   collision-disjunct idiom (`Merkle.root_inj_of_length_eq` is the same shape):
-  equal hashes force equal headers, or the two encodings exhibit a concrete
-  double-SHA-256 collision. Collision resistance is never assumed for the
-  concrete hash — only ever a hypothesis a caller supplies over the abstract
-  `Sha256.Collision` vocabulary.
+  the hash is a binding commitment to the header — equal hashes force equal
+  headers, or the two encodings exhibit a concrete double-SHA-256 collision.
+  Collision resistance is never assumed for the concrete hash — only ever a
+  hypothesis a caller supplies over the abstract `Sha256.Collision`
+  vocabulary.
 
   Checked claims:
 
-  * `BlockHeader.hash_inj`: equal block hashes mean equal headers — or a
+  * `BlockHeader.hash_binding`: equal block hashes mean equal headers — or a
     concrete double-SHA-256 collision.
 -/
 
@@ -35,7 +36,7 @@ def BlockHeader.hash (h : BlockHeader) : Hash256 :=
 
 /-- Equal block hashes mean equal headers — or two concrete byte strings
 witnessing a double-SHA-256 collision. -/
-theorem BlockHeader.hash_inj {h₁ h₂ : BlockHeader} (h : h₁.hash = h₂.hash) :
+theorem BlockHeader.hash_binding {h₁ h₂ : BlockHeader} (h : h₁.hash = h₂.hash) :
     h₁ = h₂ ∨ Sha256.Collision := by
   by_cases he : h₁ = h₂
   · exact Or.inl he

--- a/BtcVerified/Block/BlockHash.lean
+++ b/BtcVerified/Block/BlockHash.lean
@@ -9,15 +9,16 @@ import BtcVerified.Crypto.Sha256
   fixture tests computed inline into the library — the same move `Tx.txid`
   made for transactions.
 
-  As with `Tx.txid_faithful`, the faithfulness theorem here is the
-  collision-disjunct idiom: equal hashes force equal headers, or the two
-  encodings exhibit a concrete double-SHA-256 collision. Collision resistance
-  is never assumed for the concrete hash — only ever a hypothesis a caller
-  supplies over the abstract `Sha256.Collision` vocabulary.
+  As with `Tx.txid_faithful`, the injectivity theorem here is the
+  collision-disjunct idiom (`Merkle.root_inj_of_length_eq` is the same shape):
+  equal hashes force equal headers, or the two encodings exhibit a concrete
+  double-SHA-256 collision. Collision resistance is never assumed for the
+  concrete hash — only ever a hypothesis a caller supplies over the abstract
+  `Sha256.Collision` vocabulary.
 
   Checked claims:
 
-  * `BlockHeader.hash_faithful`: equal block hashes mean equal headers — or a
+  * `BlockHeader.hash_inj`: equal block hashes mean equal headers — or a
     concrete double-SHA-256 collision.
 -/
 
@@ -34,7 +35,7 @@ def BlockHeader.hash (h : BlockHeader) : Hash256 :=
 
 /-- Equal block hashes mean equal headers — or two concrete byte strings
 witnessing a double-SHA-256 collision. -/
-theorem BlockHeader.hash_faithful {h₁ h₂ : BlockHeader} (h : h₁.hash = h₂.hash) :
+theorem BlockHeader.hash_inj {h₁ h₂ : BlockHeader} (h : h₁.hash = h₂.hash) :
     h₁ = h₂ ∨ Sha256.Collision := by
   by_cases he : h₁ = h₂
   · exact Or.inl he

--- a/BtcVerified/Block/Chain.lean
+++ b/BtcVerified/Block/Chain.lean
@@ -59,6 +59,11 @@ import BtcVerified.Block.BlockHash
 
 namespace BtcVerified
 
+/- Nothing in this file computes a digest at elaboration time: `seal` keeps
+`whnf` from unfolding `BlockHeader.hash` through the whole codec and SHA-256
+stack while Lean generates the `Chain` inductive's auxiliary machinery. -/
+seal BlockHeader.hash
+
 /-! ## Linkage -/
 
 /-- `h₂` directly extends `h₁`: its `prevBlockHash` is `h₁`'s hash — the one

--- a/BtcVerified/Block/Chain.lean
+++ b/BtcVerified/Block/Chain.lean
@@ -1,0 +1,170 @@
+import BtcVerified.Block.BlockHash
+/-!
+  # The blockchain: header hash linkage and the chain notion
+
+  A blockchain, in this first iteration, is nothing more than a
+  *structurally linked* sequence of headers. That weakness is the point:
+  every later layer — proof of work, cumulative work, the block tree,
+  consensus validity, fork choice — is a refinement of this type, not a
+  rewrite of it.
+
+  ## Linkage
+
+  `BlockHeader.Extends h₂ h₁` is the one structural fact everything here is
+  built from: `h₂`'s `prevBlockHash` is `h₁`'s hash — `h₂` is a header that
+  directly follows `h₁` on a chain.
+
+  ## Representation
+
+  `Chain` is an inductive, **tip-first** (the newest header is the outermost
+  constructor, matching how chain reasoning runs: backward from the present,
+  not forward from genesis) and **hash-anchored at both ends**:
+  `Chain anchor tip` is a segment of linked headers reaching from the block
+  hash `anchor` (exclusive — the anchor's own header is not part of the
+  segment) up to the tip hash `tip`. The indices themselves carry the
+  linkage: `extend` accepts a new tip header exactly when the rest of the
+  chain's tip hash is the new header's `prevBlockHash`, so no embedded
+  equality proof rides along in the constructor.
+
+  Keeping *both* endpoints in the type is what makes segments compose:
+  `Chain.append` stacks a `Chain m t` on top of a `Chain a m`, with `nil` as
+  the identity — the segment algebra the block tree (the next structural
+  leaf, for fork detection) will reuse for branch paths. The full Bitcoin
+  chain is the genesis instantiation `Chain 0 tip`: the zero hash is the
+  genesis header's own `prevBlockHash`, so genesis-anchoring is a special
+  case of the same type, not a separate treatment. One consequence: the
+  empty segment `nil : Chain a a` exists for every anchor, so "nonempty" is
+  a hypothesis on theorems that need an actual tip, never a structural
+  given.
+
+  ## Scope
+
+  This is the *linear* chain — the structural layer fork-choice reasoning
+  sits on, not fork choice itself. Explicitly out of scope for this leaf:
+  proof of work (`nBits` → target decoding, the `hash ≤ target` check,
+  per-block work), cumulative work and any ordering on chains, the block
+  tree (fork *detection*), and all of consensus validity.
+
+  Checked claims:
+
+  * `Chain.toList_append`: stacking chain segments concatenates their header
+    lists — composition is compatible with the plain-list view.
+  * `Chain.isChain_toList`: a chain's list-of-headers view satisfies the
+    decidable linkage predicate `IsChain` the chain's indices guarantee by
+    construction.
+  * `Chain.tip_commits`: two chains of equal length that share a tip hash
+    carry the same header list — or two concrete byte strings collide under
+    double-SHA-256. The tip hash commits to the entire history.
+-/
+
+namespace BtcVerified
+
+/-! ## Linkage -/
+
+/-- `h₂` directly extends `h₁`: its `prevBlockHash` is `h₁`'s hash — the one
+structural fact consecutive headers of a chain satisfy. -/
+def BlockHeader.Extends (h₂ h₁ : BlockHeader) : Prop := h₂.prevBlockHash = h₁.hash
+
+/-- Linkage is decidable: both sides are computable digests. -/
+instance instDecidableExtends (h₂ h₁ : BlockHeader) : Decidable (h₂.Extends h₁) :=
+  inferInstanceAs (Decidable (_ = _))
+
+/-! ## The chain type -/
+
+/-- A structurally linked segment of block headers, tip-first and
+hash-anchored at both ends: `Chain anchor tip` reaches from the block hash
+`anchor` (exclusive) up to the tip hash `tip`, and the indices carry the
+linkage — extending demands the rest's tip hash be the new header's
+`prevBlockHash`. The full Bitcoin chain is `Chain 0 tip`, the zero hash
+being the genesis header's own `prevBlockHash`. -/
+inductive Chain (anchor : Hash256) : Hash256 → Type where
+  /-- The empty segment hanging from `anchor`: no headers yet, so its tip
+  hash is the anchor itself. The identity for `Chain.append`. -/
+  | nil : Chain anchor anchor
+  /-- Extend a chain with a new tip header linking to the old tip. -/
+  | extend (tip : BlockHeader) (rest : Chain anchor tip.prevBlockHash) :
+      Chain anchor tip.hash
+
+/-- The headers of a chain, tip-first (the newest header at the head of the
+list) — the cheap, structure-forgetting view into plain list space that
+golden vectors and the block tree speak. -/
+def Chain.toList {a t : Hash256} : Chain a t → List BlockHeader
+  | .nil => []
+  | .extend tip rest => tip :: rest.toList
+
+/-- Stack a chain segment on top of another whose tip hash is the upper
+segment's anchor. The endpoints compose the way the indices dictate, and
+`nil` is the identity. -/
+def Chain.append {a m t : Hash256} : Chain m t → Chain a m → Chain a t
+  | .nil, c => c
+  | .extend tip rest, c => .extend tip (rest.append c)
+
+/-- Stacking chain segments concatenates their header lists: composition is
+compatible with the plain-list view. -/
+theorem Chain.toList_append {a m t : Hash256} :
+    (c₂ : Chain m t) → (c₁ : Chain a m) →
+      (c₂.append c₁).toList = c₂.toList ++ c₁.toList
+  | .nil, _ => rfl
+  | .extend tip rest, c₁ => by
+      simp only [Chain.append, Chain.toList, Chain.toList_append rest c₁,
+        List.cons_append]
+
+/-! ## The linkage predicate over plain lists -/
+
+/-- The linkage predicate over a plain, tip-first header list: `hs` links
+all the way from the tip hash down to `anchor` — the head hashes to the tip,
+each header's hash is what the header after it (nearer the tip) points back
+to, and an empty segment pins the tip hash to the anchor itself. Exactly
+what a `Chain anchor tip`'s `toList` satisfies. -/
+def IsChain (anchor : Hash256) : Hash256 → List BlockHeader → Prop
+  | tip, [] => tip = anchor
+  | tip, hd :: tl => hd.hash = tip ∧ IsChain anchor hd.prevBlockHash tl
+
+/-- `IsChain` is decidable, so real header lists — golden vectors now, block
+tree paths later — can be checked directly, without building a `Chain`
+term. -/
+instance instDecidableIsChain (a : Hash256) :
+    (t : Hash256) → (hs : List BlockHeader) → Decidable (IsChain a t hs)
+  | t, [] => inferInstanceAs (Decidable (t = a))
+  | _, hd :: tl =>
+    haveI := instDecidableIsChain a hd.prevBlockHash tl
+    inferInstanceAs (Decidable (_ ∧ _))
+
+/-- A chain's list-of-headers view satisfies the linkage predicate the
+chain's indices guarantee by construction. -/
+theorem Chain.isChain_toList {a : Hash256} :
+    {t : Hash256} → (c : Chain a t) → IsChain a t c.toList
+  | _, .nil => rfl
+  | _, .extend tip rest => ⟨rfl, rest.isChain_toList⟩
+
+/-! ## The tip-commitment theorem -/
+
+/-- Two chains of equal length that share a tip hash carry the same header
+list — or two concrete byte strings witness a double-SHA-256 collision. The
+tip hash commits to the entire history: peeling the tip (equal hashes give
+equal headers, via `BlockHeader.hash_faithful`, or a collision) forces equal
+`prevBlockHash`es, and recursing identifies the chains one header at a
+time. -/
+theorem Chain.tip_commits {a₁ a₂ : Hash256} :
+    {t₁ t₂ : Hash256} → (c₁ : Chain a₁ t₁) → (c₂ : Chain a₂ t₂) → t₁ = t₂ →
+      c₁.toList.length = c₂.toList.length →
+      c₁.toList = c₂.toList ∨ Sha256.Collision
+  | _, _, .nil, .nil, _, _ => Or.inl rfl
+  | _, _, .nil, .extend .., _, hlen => by
+      simp only [Chain.toList, List.length_nil, List.length_cons] at hlen
+      exact absurd hlen (by omega)
+  | _, _, .extend .., .nil, _, hlen => by
+      simp only [Chain.toList, List.length_nil, List.length_cons] at hlen
+      exact absurd hlen (by omega)
+  | _, _, .extend tip₁ rest₁, .extend tip₂ rest₂, heq, hlen => by
+      simp only [Chain.toList, List.length_cons] at hlen
+      rcases BlockHeader.hash_faithful heq with htip | hcol
+      · rcases Chain.tip_commits rest₁ rest₂
+          (congrArg BlockHeader.prevBlockHash htip) (by omega) with heql | hcol
+        · refine Or.inl ?_
+          simp only [Chain.toList]
+          rw [heql, htip]
+        · exact Or.inr hcol
+      · exact Or.inr hcol
+
+end BtcVerified

--- a/BtcVerified/Block/Chain.lean
+++ b/BtcVerified/Block/Chain.lean
@@ -51,17 +51,28 @@ import BtcVerified.Block.BlockHash
     lists — composition is compatible with the plain-list view.
   * `Chain.isChain_toList`: a chain's list-of-headers view satisfies the
     decidable linkage predicate `IsChain` the chain's indices guarantee by
-    construction.
+    construction (with `Chain.tipHash_toList` recovering the tip index from
+    the list).
+  * `Chain.tip_commits_prefix`: of two chains sharing a tip hash, the one
+    with no more headers carries a prefix (tip-first) of the other's header
+    list — or two concrete byte strings collide under double-SHA-256. No
+    relation between the anchors is assumed; this is the hypothesis-minimal
+    form of tip commitment.
   * `Chain.tip_commits`: two chains of equal length that share a tip hash
-    carry the same header list — or two concrete byte strings collide under
-    double-SHA-256. The tip hash commits to the entire history.
+    carry the same header list — or a concrete collision. The tip hash
+    commits to the entire history.
 -/
 
 namespace BtcVerified
 
-/- Nothing in this file computes a digest at elaboration time: `seal` keeps
-`whnf` from unfolding `BlockHeader.hash` through the whole codec and SHA-256
-stack while Lean generates the `Chain` inductive's auxiliary machinery. -/
+/- `seal` marks `BlockHeader.hash` irreducible for the remainder of this file
+(it is sugar for `attribute [local irreducible]`): the elaborator treats the
+name as an opaque constant instead of unfolding its definition. Nothing in
+this file should compute a digest at elaboration time, but without the seal,
+generating the `Chain` inductive's auxiliary machinery sends `whnf` through
+`hash` into the whole codec and SHA-256 stack. Sealing is elaboration-local
+and changes no meaning: proofs about `hash` and `decide` checks in other
+files are unaffected. -/
 seal BlockHeader.hash
 
 /-! ## Linkage -/
@@ -116,60 +127,85 @@ theorem Chain.toList_append {a m t : Hash256} :
 
 /-! ## The linkage predicate over plain lists -/
 
-/-- The linkage predicate over a plain, tip-first header list: `hs` links
-all the way from the tip hash down to `anchor` — the head hashes to the tip,
-each header's hash is what the header after it (nearer the tip) points back
-to, and an empty segment pins the tip hash to the anchor itself. Exactly
-what a `Chain anchor tip`'s `toList` satisfies. -/
-def IsChain (anchor : Hash256) : Hash256 → List BlockHeader → Prop
-  | tip, [] => tip = anchor
-  | tip, hd :: tl => hd.hash = tip ∧ IsChain anchor hd.prevBlockHash tl
+/-- The tip hash a plain, tip-first header list reaches up to: the head's
+hash, or the anchor itself when the segment is empty. This is the data a
+`Chain`'s tip index carries, recovered from the list — which is why `IsChain`
+below needs no tip parameter. -/
+def tipHash (anchor : Hash256) : List BlockHeader → Hash256
+  | [] => anchor
+  | hd :: _ => hd.hash
+
+/-- The linkage predicate over a plain, tip-first header list: every header's
+`prevBlockHash` is the hash of what sits below it — the next header, or the
+anchor at the bottom of the segment. Exactly what a `Chain anchor tip`'s
+`toList` satisfies. The tip hash is not a parameter because the list already
+determines it (`tipHash`). -/
+def IsChain (anchor : Hash256) : List BlockHeader → Prop
+  | [] => True
+  | hd :: tl => hd.prevBlockHash = tipHash anchor tl ∧ IsChain anchor tl
 
 /-- `IsChain` is decidable, so real header lists — golden vectors now, block
 tree paths later — can be checked directly, without building a `Chain`
 term. -/
 instance instDecidableIsChain (a : Hash256) :
-    (t : Hash256) → (hs : List BlockHeader) → Decidable (IsChain a t hs)
-  | t, [] => inferInstanceAs (Decidable (t = a))
-  | _, hd :: tl =>
-    haveI := instDecidableIsChain a hd.prevBlockHash tl
+    (hs : List BlockHeader) → Decidable (IsChain a hs)
+  | [] => inferInstanceAs (Decidable True)
+  | _ :: tl =>
+    haveI := instDecidableIsChain a tl
     inferInstanceAs (Decidable (_ ∧ _))
+
+/-- A chain's list-of-headers view reaches up to exactly the chain's tip
+index: the tip hash carried by the type is the one the list determines. -/
+theorem Chain.tipHash_toList {a : Hash256} :
+    {t : Hash256} → (c : Chain a t) → tipHash a c.toList = t
+  | _, .nil => rfl
+  | _, .extend _ _ => rfl
 
 /-- A chain's list-of-headers view satisfies the linkage predicate the
 chain's indices guarantee by construction. -/
 theorem Chain.isChain_toList {a : Hash256} :
-    {t : Hash256} → (c : Chain a t) → IsChain a t c.toList
-  | _, .nil => rfl
-  | _, .extend tip rest => ⟨rfl, rest.isChain_toList⟩
+    {t : Hash256} → (c : Chain a t) → IsChain a c.toList
+  | _, .nil => trivial
+  | _, .extend _ rest => ⟨rest.tipHash_toList.symm, rest.isChain_toList⟩
 
 /-! ## The tip-commitment theorem -/
 
-/-- Two chains of equal length that share a tip hash carry the same header
-list — or two concrete byte strings witness a double-SHA-256 collision. The
-tip hash commits to the entire history: peeling the tip (equal hashes give
-equal headers, via `BlockHeader.hash_faithful`, or a collision) forces equal
-`prevBlockHash`es, and recursing identifies the chains one header at a
-time. -/
-theorem Chain.tip_commits {a₁ a₂ : Hash256} :
+/-- Of two chains sharing a tip hash, the one with no more headers carries a
+prefix (tip-first) of the other's header list — or two concrete byte strings
+witness a double-SHA-256 collision. Peeling the tip (equal hashes give equal
+headers, via `BlockHeader.hash_inj`, or a collision) forces equal
+`prevBlockHash`es, and recursing identifies the chains one header at a time
+until the shorter one runs out. No relation between the anchors is assumed —
+a shorter chain anchored higher up the same history sees exactly a prefix of
+the longer one, which is also why a shared tip cannot force outright
+equality without the length bound. -/
+theorem Chain.tip_commits_prefix {a₁ a₂ : Hash256} :
     {t₁ t₂ : Hash256} → (c₁ : Chain a₁ t₁) → (c₂ : Chain a₂ t₂) → t₁ = t₂ →
-      c₁.toList.length = c₂.toList.length →
-      c₁.toList = c₂.toList ∨ Sha256.Collision
-  | _, _, .nil, .nil, _, _ => Or.inl rfl
-  | _, _, .nil, .extend .., _, hlen => by
-      simp only [Chain.toList, List.length_nil, List.length_cons] at hlen
-      exact absurd hlen (by omega)
+      c₁.toList.length ≤ c₂.toList.length →
+      c₁.toList <+: c₂.toList ∨ Sha256.Collision
+  | _, _, .nil, _, _, _ => Or.inl (List.nil_prefix ..)
   | _, _, .extend .., .nil, _, hlen => by
       simp only [Chain.toList, List.length_nil, List.length_cons] at hlen
       exact absurd hlen (by omega)
   | _, _, .extend tip₁ rest₁, .extend tip₂ rest₂, heq, hlen => by
       simp only [Chain.toList, List.length_cons] at hlen
-      rcases BlockHeader.hash_faithful heq with htip | hcol
-      · rcases Chain.tip_commits rest₁ rest₂
-          (congrArg BlockHeader.prevBlockHash htip) (by omega) with heql | hcol
-        · refine Or.inl ?_
-          simp only [Chain.toList]
-          rw [heql, htip]
+      rcases BlockHeader.hash_inj heq with htip | hcol
+      · rcases Chain.tip_commits_prefix rest₁ rest₂
+          (congrArg BlockHeader.prevBlockHash htip) (by omega) with hpre | hcol
+        · exact Or.inl (by simpa only [Chain.toList, List.cons_prefix_cons]
+            using ⟨htip, hpre⟩)
         · exact Or.inr hcol
       · exact Or.inr hcol
+
+/-- Two chains of equal length that share a tip hash carry the same header
+list — or two concrete byte strings witness a double-SHA-256 collision. The
+tip hash commits to the entire history; the equal-length hypothesis is what
+upgrades `Chain.tip_commits_prefix`'s prefix to equality, and it cannot be
+dropped — a strictly shorter chain anchored higher up shares the tip while
+carrying strictly fewer headers. -/
+theorem Chain.tip_commits {a₁ a₂ t₁ t₂ : Hash256} (c₁ : Chain a₁ t₁) (c₂ : Chain a₂ t₂)
+    (heq : t₁ = t₂) (hlen : c₁.toList.length = c₂.toList.length) :
+    c₁.toList = c₂.toList ∨ Sha256.Collision :=
+  (c₁.tip_commits_prefix c₂ heq (Nat.le_of_eq hlen)).imp (·.eq_of_length hlen) id
 
 end BtcVerified

--- a/BtcVerified/Block/Chain.lean
+++ b/BtcVerified/Block/Chain.lean
@@ -173,7 +173,7 @@ theorem Chain.isChain_toList {a : Hash256} :
 /-- Of two chains sharing a tip hash, the one with no more headers carries a
 prefix (tip-first) of the other's header list — or two concrete byte strings
 witness a double-SHA-256 collision. Peeling the tip (equal hashes give equal
-headers, via `BlockHeader.hash_inj`, or a collision) forces equal
+headers, via `BlockHeader.hash_binding`, or a collision) forces equal
 `prevBlockHash`es, and recursing identifies the chains one header at a time
 until the shorter one runs out. No relation between the anchors is assumed —
 a shorter chain anchored higher up the same history sees exactly a prefix of
@@ -189,7 +189,7 @@ theorem Chain.tip_commits_prefix {a₁ a₂ : Hash256} :
       exact absurd hlen (by omega)
   | _, _, .extend tip₁ rest₁, .extend tip₂ rest₂, heq, hlen => by
       simp only [Chain.toList, List.length_cons] at hlen
-      rcases BlockHeader.hash_inj heq with htip | hcol
+      rcases BlockHeader.hash_binding heq with htip | hcol
       · rcases Chain.tip_commits_prefix rest₁ rest₂
           (congrArg BlockHeader.prevBlockHash htip) (by omega) with hpre | hcol
         · exact Or.inl (by simpa only [Chain.toList, List.cons_prefix_cons]

--- a/BtcVerified/Block/Commitment.lean
+++ b/BtcVerified/Block/Commitment.lean
@@ -23,7 +23,7 @@ namespace BtcVerified
 
 /-- The merkle commitment a consensus-valid block satisfies: its transaction
 ids form a canonical list whose merkle root is the header's. With
-`Merkle.root_inj_of_canonical`, two such blocks sharing a header agree on
+`Merkle.root_binding_of_canonical`, two such blocks sharing a header agree on
 their txid lists — or exhibit a concrete double-SHA-256 collision. -/
 def Block.merkleCommits (b : Block) : Prop :=
   Merkle.Canonical (b.txs.val.map Tx.txid)

--- a/BtcVerified/Crypto/Collision.lean
+++ b/BtcVerified/Crypto/Collision.lean
@@ -35,7 +35,7 @@ def CollisionResistant {α β : Type*} (h : α → β) : Prop := ¬ Collision h
 
 /-- A collision-resistant function is injective: equal images force equal
 inputs. This is the bridge that turns the `… ∨ Collision` disjunct of the
-hashing faithfulness theorems into outright injectivity under a resistance
+hashing binding theorems into outright injectivity under a resistance
 hypothesis. -/
 theorem CollisionResistant.injective {α β : Type*} {h : α → β}
     (hcr : CollisionResistant h) {a b : α} (hab : h a = h b) : a = b := by

--- a/BtcVerified/Crypto/Merkle.lean
+++ b/BtcVerified/Crypto/Merkle.lean
@@ -19,7 +19,7 @@ import Mathlib.Data.Nat.Log
   explicit constructor (`pad`, semantically a node with two equal children)
   instead of an artifact of iteration order.
 
-  Canonicality constrains exactly what threatens injectivity and nothing
+  Canonicality constrains exactly what threatens the root's binding and nothing
   more. Padding only ever duplicates trailing power-of-two-aligned blocks —
   the right spine — so a cross-length collision requires a trailing block
   duplicating its left sibling, and `Canonical` forbids precisely that
@@ -31,7 +31,7 @@ import Mathlib.Data.Nat.Log
   constructed disjunct, and intractability is the consumer's hypothesis.
 
   Known residual, documented not solved: equal *widths* are a hypothesis of
-  `root_inj_of_canonical`. Across widths, a 64-byte transaction whose
+  `root_binding_of_canonical`. Across widths, a 64-byte transaction whose
   serialization equals the concatenation of two digests confuses a leaf with
   an internal node (the SPV-grade ambiguity the Great Consensus Cleanup
   proposes to close by forbidding 64-byte transactions). For block validity
@@ -39,9 +39,9 @@ import Mathlib.Data.Nat.Log
 
   Checked claims:
 
-  * `root_inj_of_length_eq`: between equal-length lists, the root identifies
+  * `root_binding_of_length_eq`: between equal-length lists, the root identifies
     the list — or two concrete byte strings collide under double-SHA-256.
-  * `root_inj_of_canonical`: between canonical lists of equal enclosing
+  * `root_binding_of_canonical`: between canonical lists of equal enclosing
     width, the root identifies the list — or a concrete collision. This is
     the property the canonicality rule exists to restore.
 -/
@@ -57,7 +57,7 @@ def combine (l r : Hash256) : Hash256 :=
 
 /-- Equal merkle nodes have equal children — or their two 64-byte preimages
 collide under double-SHA-256. -/
-theorem combine_inj {l r l' r' : Hash256} (h : combine l r = combine l' r') :
+theorem combine_binding {l r l' r' : Hash256} (h : combine l r = combine l' r') :
     (l = l' ∧ r = r') ∨ Sha256.Collision := by
   have hd : Sha256.sha256d (l.1 ++ r.1) = Sha256.sha256d (l'.1 ++ r'.1) :=
     congrArg Subtype.val h
@@ -120,8 +120,8 @@ def root (xs : List Hash256) : Hash256 := (tree xs).root
 content side of every padding node and the right child of every interior
 node, no interior node may join two subtrees with identical materialized
 leaf sequences — that is exactly the shape a materialized padding suffix
-produces, and (`root_inj_of_canonical`) the only shape that threatens
-injectivity. -/
+produces, and (`root_binding_of_canonical`) the only shape that threatens
+the root's binding. -/
 def Tree.spineCanonical : Tree → Bool
   | .leaf _ => true
   | .pad t => t.spineCanonical
@@ -203,7 +203,8 @@ theorem virtualLeaves_ofList_append :
           ← List.append_assoc, List.take_append_drop]⟩
 
 /-- Equal roots at one width force equal materialized leaf sequences — or a
-concrete double-SHA-256 collision. The hashing direction of injectivity. -/
+concrete double-SHA-256 collision. The hashing direction of the root's
+binding. -/
 theorem virtualLeaves_eq_of_root_eq :
     ∀ (k : Nat) (xs ys : List Hash256),
       (ofList xs k).root = (ofList ys k).root →
@@ -220,7 +221,7 @@ theorem virtualLeaves_eq_of_root_eq :
     · rw [if_pos hx, if_pos hy] at h ⊢
       rw [Tree.root, Tree.root] at h
       rw [Tree.virtualLeaves, Tree.virtualLeaves]
-      rcases combine_inj h with ⟨ha, _⟩ | c
+      rcases combine_binding h with ⟨ha, _⟩ | c
       · rcases ih xs ys ha with hvl | c
         · exact Or.inl (by rw [hvl])
         · exact Or.inr c
@@ -228,7 +229,7 @@ theorem virtualLeaves_eq_of_root_eq :
     · rw [if_pos hx, if_neg hy] at h ⊢
       rw [Tree.root, Tree.root] at h
       rw [Tree.virtualLeaves, Tree.virtualLeaves]
-      rcases combine_inj h with ⟨hl, hr⟩ | c
+      rcases combine_binding h with ⟨hl, hr⟩ | c
       · rcases ih xs (ys.take (2 ^ k)) hl with hvl₁ | c
         · rcases ih xs (ys.drop (2 ^ k)) hr with hvl₂ | c
           · exact Or.inl (by rw [← hvl₁, ← hvl₂])
@@ -238,7 +239,7 @@ theorem virtualLeaves_eq_of_root_eq :
     · rw [if_neg hx, if_pos hy] at h ⊢
       rw [Tree.root, Tree.root] at h
       rw [Tree.virtualLeaves, Tree.virtualLeaves]
-      rcases combine_inj h with ⟨hl, hr⟩ | c
+      rcases combine_binding h with ⟨hl, hr⟩ | c
       · rcases ih (xs.take (2 ^ k)) ys hl with hvl₁ | c
         · rcases ih (xs.drop (2 ^ k)) ys hr with hvl₂ | c
           · exact Or.inl (by rw [hvl₁, hvl₂])
@@ -248,7 +249,7 @@ theorem virtualLeaves_eq_of_root_eq :
     · rw [if_neg hx, if_neg hy] at h ⊢
       rw [Tree.root, Tree.root] at h
       rw [Tree.virtualLeaves, Tree.virtualLeaves]
-      rcases combine_inj h with ⟨hl, hr⟩ | c
+      rcases combine_binding h with ⟨hl, hr⟩ | c
       · rcases ih (xs.take (2 ^ k)) (ys.take (2 ^ k)) hl with hvl₁ | c
         · rcases ih (xs.drop (2 ^ k)) (ys.drop (2 ^ k)) hr with hvl₂ | c
           · exact Or.inl (by rw [hvl₁, hvl₂])
@@ -257,7 +258,8 @@ theorem virtualLeaves_eq_of_root_eq :
       · exact Or.inr c
 
 /-- Equal materialized leaves of canonical-spine trees come from equal actual
-lists: the combinatorial direction of injectivity, no hashing involved. The
+lists: the combinatorial direction of the root's binding, no hashing
+involved. The
 spine conditions kill exactly the materialized-padding case. -/
 theorem eq_of_virtualLeaves_eq :
     ∀ (k : Nat) (xs ys : List Hash256),
@@ -330,7 +332,7 @@ theorem eq_of_virtualLeaves_eq :
 /-- Between equal-length lists the merkle root identifies the list — or two
 concrete byte strings collide under double-SHA-256. No canonicality needed:
 padding only appends, so equal lengths leave no room for ambiguity. -/
-theorem root_inj_of_length_eq {xs ys : List Hash256}
+theorem root_binding_of_length_eq {xs ys : List Hash256}
     (hlen : xs.length = ys.length) (hroot : root xs = root ys) :
     xs = ys ∨ Sha256.Collision := by
   unfold root tree at hroot
@@ -346,11 +348,11 @@ theorem root_inj_of_length_eq {xs ys : List Hash256}
 
 /-- Between canonical lists of equal enclosing width the merkle root
 identifies the list — or two concrete byte strings collide under
-double-SHA-256. This is the injectivity the canonicality rule exists to
+double-SHA-256. This is the binding the canonicality rule exists to
 restore: without `Canonical`, a list extended by its own materialized padding
 shares its root (CVE-2012-2459). Equal widths exclude the cross-height
 leaf/interior ambiguity (see the module header). -/
-theorem root_inj_of_canonical {xs ys : List Hash256}
+theorem root_binding_of_canonical {xs ys : List Hash256}
     (hcx : Canonical xs) (hcy : Canonical ys)
     (h0x : xs ≠ []) (h0y : ys ≠ [])
     (hk : Nat.clog 2 xs.length = Nat.clog 2 ys.length)
@@ -396,7 +398,7 @@ theorem root_inj_of_canonical {xs ys : List Hash256}
     rw [Canonical, canonicalCheck, tree, ← hk, hj] at hcy
     simp only [ofList, if_neg (by omega : ¬ xs.length ≤ 2 ^ j),
       if_neg (by omega : ¬ ys.length ≤ 2 ^ j), Tree.root] at hroot hcx hcy
-    rcases combine_inj hroot with ⟨hl, hr⟩ | c
+    rcases combine_binding hroot with ⟨hl, hr⟩ | c
     · rcases virtualLeaves_eq_of_root_eq j _ _ hl with hvl₁ | c
       · have htake : xs.take (2 ^ j) = ys.take (2 ^ j) := by
           rw [← virtualLeaves_ofList_of_length_eq j (xs.take (2 ^ j))

--- a/BtcVerified/Impl/BitcoinCore/Merkle.lean
+++ b/BtcVerified/Impl/BitcoinCore/Merkle.lean
@@ -481,7 +481,7 @@ theorem canonical_of_not_mutated (xs : List Hash256)
 /-- If Bitcoin Core accepts two nonempty leaf lists of equal enclosing width (no
 mutation) and computes the same merkle root for both, the lists are equal — or
 two concrete byte strings collide under double-SHA-256. Core's single fused check
-recovers the injectivity `root_inj_of_canonical` provides. -/
+recovers the binding `root_binding_of_canonical` provides. -/
 theorem eq_of_computeMerkleRoot_eq_of_not_mutated {xs ys : List Hash256}
     (h0x : xs ≠ []) (h0y : ys ≠ [])
     (hk : Nat.clog 2 xs.length = Nat.clog 2 ys.length)
@@ -493,7 +493,7 @@ theorem eq_of_computeMerkleRoot_eq_of_not_mutated {xs ys : List Hash256}
     rw [computeMerkleRoot_fst, computeRoot_eq_root]
   have hry : (computeMerkleRoot ys).1 = root ys := by
     rw [computeMerkleRoot_fst, computeRoot_eq_root]
-  exact root_inj_of_canonical (canonical_of_not_mutated xs hmx)
+  exact root_binding_of_canonical (canonical_of_not_mutated xs hmx)
     (canonical_of_not_mutated ys hmy) h0x h0y hk (by rw [← hrx, ← hry, hroot])
 
 end BtcVerified.Impl.BitcoinCore

--- a/BtcVerified/Transaction/Txid.lean
+++ b/BtcVerified/Transaction/Txid.lean
@@ -12,7 +12,7 @@ import BtcVerified.Crypto.Hash256
 
   A hash of an encoding only identifies anything because the encoding is
   injective — `encode_injective`, a consequence of the codec round-trip law.
-  The faithfulness theorems here are exactly that observation: equal txids
+  The binding theorems here are exactly that observation: equal txids
   mean equal bodies, and equal wtxids mean equal transactions, or in either
   case there are two concrete byte strings witnessing a double-SHA-256
   collision (`Sha256.Collision`). The collision appears as a constructed
@@ -20,9 +20,9 @@ import BtcVerified.Crypto.Hash256
 
   Checked claims:
 
-  * `Tx.txid_faithful`: equal txids imply equal witness-free bodies, or a
+  * `Tx.txid_binding`: equal txids imply equal witness-free bodies, or a
     concrete `sha256d` collision.
-  * `Tx.wtxid_faithful`: equal wtxids imply equal transactions (witnesses
+  * `Tx.wtxid_binding`: equal wtxids imply equal transactions (witnesses
     included), or a concrete `sha256d` collision.
   * `Tx.wtxid_legacy`: a legacy transaction's wtxid is its txid.
 -/
@@ -50,7 +50,7 @@ theorem Tx.wtxid_legacy (body : TxBody) (h : body.inputs.val ≠ []) :
 
 /-- Equal txids mean equal witness-free bodies — or two concrete byte strings
 witnessing a double-SHA-256 collision. -/
-theorem Tx.txid_faithful {t₁ t₂ : Tx} (h : t₁.txid = t₂.txid) :
+theorem Tx.txid_binding {t₁ t₂ : Tx} (h : t₁.txid = t₂.txid) :
     t₁.body = t₂.body ∨ Sha256.Collision := by
   by_cases hb : t₁.body = t₂.body
   · exact Or.inl hb
@@ -59,7 +59,7 @@ theorem Tx.txid_faithful {t₁ t₂ : Tx} (h : t₁.txid = t₂.txid) :
 
 /-- Equal wtxids mean equal transactions, witnesses included — or two
 concrete byte strings witnessing a double-SHA-256 collision. -/
-theorem Tx.wtxid_faithful {t₁ t₂ : Tx} (h : t₁.wtxid = t₂.wtxid) :
+theorem Tx.wtxid_binding {t₁ t₂ : Tx} (h : t₁.wtxid = t₂.wtxid) :
     t₁ = t₂ ∨ Sha256.Collision := by
   by_cases ht : t₁ = t₂
   · exact Or.inl ht

--- a/README.md
+++ b/README.md
@@ -220,6 +220,51 @@ disjunct is constructed, never assumed away: intractability of producing a
 witness is the consumer's hypothesis, the only form in which collision
 resistance can soundly appear over a concrete hash.
 
+### `BtcVerified` block hashes and the chain
+
+`BlockHeader.hash` — the double-SHA-256 of a header's 80-byte encoding, the
+same digest `prevBlockHash` links commit to and a proof-of-work target is
+checked against (the target check itself is a later leaf). Promoted from the
+ad hoc expression the fixture tests computed inline, the same move `Tx.txid`
+made for transactions.
+
+On top of it, `Chain`: a structurally linked sequence of block headers,
+tip-first (the newest header is the outermost constructor) and hash-anchored
+at both ends — `Chain anchor tip` is a segment reaching from the block hash
+`anchor` (exclusive) up to the tip hash `tip`, with the linkage carried by
+the indices themselves: extending demands the rest's tip hash be the new
+header's `prevBlockHash`. Carrying both endpoints in the type is what lets
+segments compose (`Chain.append`, with the empty segment as identity) — the
+algebra the block tree's branch paths will reuse — while the full Bitcoin
+chain stays the plain genesis instantiation `Chain 0 tip` (the zero hash is
+the genesis header's own `prevBlockHash`), not a special case. This is the
+*linear* chain only: proof of work, cumulative work, and the block tree
+(fork detection) are later leaves built on the same linkage relation.
+
+Checked claims:
+
+- `BlockHeader.hash_faithful`: equal block hashes mean equal headers — or a
+  concrete double-SHA-256 collision.
+- `Chain.toList_append`: stacking chain segments concatenates their header
+  lists — composition is compatible with the plain-list view.
+- `Chain.isChain_toList`: a chain's list-of-headers view satisfies `IsChain`,
+  the decidable linkage predicate over plain lists, so real header lists can
+  be checked directly, without constructing a `Chain` term.
+- `Chain.tip_commits`: two chains of equal length sharing a tip hash carry
+  the same header list — or a concrete collision. The tip hash commits to
+  the entire history, proved in the same peel-and-recurse,
+  collision-disjunct style as `Merkle.root_inj_of_length_eq`.
+- Golden vector: block 1's raw 80 header bytes decode, re-encode, and hash
+  to the well-known block 1 hash; the decoded header extends the decoded
+  genesis header (`BlockHeader.Extends`); and the two headers form an
+  `IsChain 0` chain — the genesis instantiation on real mainnet data.
+
+Why it matters: fork choice compares branches, and a branch has to *be*
+something before validity or cumulative work can be stated over it. This is
+that structural layer — a tip hash commits to an entire history — and every
+later layer (proof of work, the block tree, validity, fork choice) is a
+refinement of this type, not a rewrite.
+
 ### `BtcVerified.Merkle`
 
 Bitcoin's merkle tree, as a tree — the platonic spec, with the root computation
@@ -345,9 +390,10 @@ lake lint
 
 `lake build` also elaborates `Tests/`: golden vectors that run the verified
 decoder over real mainnet bytes (the first Bitcoin payment, the SegWit
-activation coinbase, the first SegWit spend, the genesis block, block 170) and
-an axiom audit that fails the build if any headline theorem depends on `sorry`
-or an unexpected axiom. `lake test` decodes the full SegWit activation block,
+activation coinbase, the first SegWit spend, the genesis block, block 170,
+and the genesis → block 1 chain link) and an axiom audit that fails the
+build if any headline theorem depends on `sorry` or an unexpected axiom.
+`lake test` decodes the full SegWit activation block,
 fetching it from a block explorer on first run and caching it locally (it is
 public chain data, so it is not committed). See `CONTRIBUTING.md` for the
 contribution workflow.

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Checked claims:
 
 - `BlockHeader.hash_binding`: the block hash is a binding commitment to the
   header — equal block hashes mean equal headers, or a concrete
-  double-SHA-256 collision, the same shape as `Merkle.root_inj_of_length_eq`.
+  double-SHA-256 collision, the same shape as `Merkle.root_binding_of_length_eq`.
 - `Chain.toList_append`: stacking chain segments concatenates their header
   lists — composition is compatible with the plain-list view.
 - `Chain.isChain_toList`: a chain's list-of-headers view satisfies `IsChain`,
@@ -259,7 +259,7 @@ Checked claims:
 - `Chain.tip_commits`: two chains of equal length sharing a tip hash carry
   the same header list — or a concrete collision. The tip hash commits to
   the entire history, proved in the same peel-and-recurse,
-  collision-disjunct style as `Merkle.root_inj_of_length_eq`.
+  collision-disjunct style as `Merkle.root_binding_of_length_eq`.
 - Golden vector: block 1's raw 80 header bytes decode, re-encode, and hash
   to the well-known block 1 hash; the decoded header extends the decoded
   genesis header (`BlockHeader.Extends`); and the two headers form an
@@ -277,19 +277,19 @@ Bitcoin's merkle tree, as a tree — the platonic spec, with the root computatio
 and canonicality factored apart. The root is a structural tree fold: the tree is
 built top-down by bisection, procedural duplication an explicit `pad` constructor
 rather than an artifact of iteration order. Canonicality is a first-class
-decidable property of the leaf list, constraining exactly what threatens
-injectivity: padding only duplicates trailing power-of-two-aligned blocks, so
+decidable property of the leaf list, constraining exactly what threatens the
+root's binding: padding only duplicates trailing power-of-two-aligned blocks, so
 only a right-spine duplication can materialize a shorter list's padding
 (CVE-2012-2459). The bottom-up vector computation of this root, and the clients
 that run it, live under `Impl/`.
 
 Checked claims:
 
-- `root_inj_of_length_eq`: between equal-length lists, the root identifies the
-  list — or two concrete byte strings collide under double-SHA-256.
-- `root_inj_of_canonical`: between canonical lists of equal enclosing width,
-  the root identifies the list — or a concrete collision. This is the
-  injectivity the canonicality rule exists to restore.
+- `root_binding_of_length_eq`: between equal-length lists, the root identifies
+  the list — or two concrete byte strings collide under double-SHA-256.
+- `root_binding_of_canonical`: between canonical lists of equal enclosing
+  width, the root identifies the list — or a concrete collision. This is the
+  binding the canonicality rule exists to restore.
 - `Block.merkleCommits`: the consensus condition — a canonical txid list whose
   root is the header's. Checked on the genesis block and block 170 at build
   time, and on all 1866 transactions of block 481824 under `lake test`, which
@@ -331,7 +331,7 @@ Checked claims:
   stronger and no transaction-distinctness hypothesis is needed or used.
 - `eq_of_computeMerkleRoot_eq_of_not_mutated`: two nonempty equal-width lists Core
   accepts with equal roots are equal — or a concrete double-SHA-256 collision.
-  Core's single check recovers the injectivity `root_inj_of_canonical` provides.
+  Core's single check recovers the binding `root_binding_of_canonical` provides.
 - `computeMerkleRoot_fst`: the root Core returns is exactly `computeRoot` (hence
   the spec `root`) on every input — anchored to real chain data through the
   `Block.merkleCommits` checks, and confirmed on block 481824 under `lake test`
@@ -340,7 +340,7 @@ Checked claims:
 Why it matters: this closes the gap between the algorithm Bitcoin Core actually
 runs and the repo's separated root/canonicality model. Core fuses the root and a
 duplicate scan into one pass; the spec factors them apart, and passing Core's
-scan is proved to imply the canonicality that recovers injectivity — the one-way
+scan is proved to imply the canonicality that recovers the binding — the one-way
 direction that matters, since Core is strictly stronger than canonicality
 requires.
 

--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ the genesis header's own `prevBlockHash`), not a special case. This is the
 
 Checked claims:
 
-- `BlockHeader.hash_inj`: the block hash is injective up to an exhibited
-  collision — equal block hashes mean equal headers, or a concrete
+- `BlockHeader.hash_binding`: the block hash is a binding commitment to the
+  header — equal block hashes mean equal headers, or a concrete
   double-SHA-256 collision, the same shape as `Merkle.root_inj_of_length_eq`.
 - `Chain.toList_append`: stacking chain segments concatenates their header
   lists — composition is compatible with the plain-list view.

--- a/README.md
+++ b/README.md
@@ -243,13 +243,19 @@ the genesis header's own `prevBlockHash`), not a special case. This is the
 
 Checked claims:
 
-- `BlockHeader.hash_faithful`: equal block hashes mean equal headers — or a
-  concrete double-SHA-256 collision.
+- `BlockHeader.hash_inj`: the block hash is injective up to an exhibited
+  collision — equal block hashes mean equal headers, or a concrete
+  double-SHA-256 collision, the same shape as `Merkle.root_inj_of_length_eq`.
 - `Chain.toList_append`: stacking chain segments concatenates their header
   lists — composition is compatible with the plain-list view.
 - `Chain.isChain_toList`: a chain's list-of-headers view satisfies `IsChain`,
-  the decidable linkage predicate over plain lists, so real header lists can
-  be checked directly, without constructing a `Chain` term.
+  the decidable linkage predicate over an anchor and a plain list, so real
+  header lists can be checked directly, without constructing a `Chain` term
+  (`Chain.tipHash_toList` recovers the tip index from the list).
+- `Chain.tip_commits_prefix`: of two chains sharing a tip hash, the one with
+  no more headers carries a prefix (tip-first) of the other's header list —
+  or a concrete collision. Nothing relates the anchors: a shorter chain
+  anchored higher up the same history is exactly this prefix situation.
 - `Chain.tip_commits`: two chains of equal length sharing a tip hash carry
   the same header list — or a concrete collision. The tip hash commits to
   the entire history, proved in the same peel-and-recurse,

--- a/README.md
+++ b/README.md
@@ -202,12 +202,12 @@ two coincide by `rfl`.
 
 Checked claims:
 
-- `Tx.txid_faithful`: equal txids imply equal witness-free bodies — or two
+- `Tx.txid_binding`: equal txids imply equal witness-free bodies — or two
   concrete byte strings witnessing a double-SHA-256 collision. With
   `CollisionResistant.injective` (the generalized collision vocabulary in
   `BtcVerified.Collision`), a resistance hypothesis collapses this to outright
   injectivity.
-- `Tx.wtxid_faithful`: equal wtxids imply equal transactions, witnesses
+- `Tx.wtxid_binding`: equal wtxids imply equal transactions, witnesses
   included — or a concrete collision.
 - Golden vectors: the first Bitcoin payment's txid, the genesis coinbase txid
   (which is the genesis merkle root), and the SegWit coinbase's txid with

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -99,6 +99,10 @@ elab "#assert_axioms " id:ident : command => do
 #assert_axioms BtcVerified.Tx.wtxid_faithful
 #assert_axioms BtcVerified.Tx.wtxid_legacy
 
+/-! ## Block hashes -/
+
+#assert_axioms BtcVerified.BlockHeader.hash_faithful
+
 /-! ## The merkle tree -/
 
 #assert_axioms BtcVerified.Merkle.combine_inj

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -103,6 +103,12 @@ elab "#assert_axioms " id:ident : command => do
 
 #assert_axioms BtcVerified.BlockHeader.hash_faithful
 
+/-! ## The chain -/
+
+#assert_axioms BtcVerified.Chain.toList_append
+#assert_axioms BtcVerified.Chain.isChain_toList
+#assert_axioms BtcVerified.Chain.tip_commits
+
 /-! ## The merkle tree -/
 
 #assert_axioms BtcVerified.Merkle.combine_inj

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -101,7 +101,7 @@ elab "#assert_axioms " id:ident : command => do
 
 /-! ## Block hashes -/
 
-#assert_axioms BtcVerified.BlockHeader.hash_inj
+#assert_axioms BtcVerified.BlockHeader.hash_binding
 
 /-! ## The chain -/
 

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -95,8 +95,8 @@ elab "#assert_axioms " id:ident : command => do
 
 /-! ## Transaction ids -/
 
-#assert_axioms BtcVerified.Tx.txid_faithful
-#assert_axioms BtcVerified.Tx.wtxid_faithful
+#assert_axioms BtcVerified.Tx.txid_binding
+#assert_axioms BtcVerified.Tx.wtxid_binding
 #assert_axioms BtcVerified.Tx.wtxid_legacy
 
 /-! ## Block hashes -/

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -112,9 +112,9 @@ elab "#assert_axioms " id:ident : command => do
 
 /-! ## The merkle tree -/
 
-#assert_axioms BtcVerified.Merkle.combine_inj
-#assert_axioms BtcVerified.Merkle.root_inj_of_length_eq
-#assert_axioms BtcVerified.Merkle.root_inj_of_canonical
+#assert_axioms BtcVerified.Merkle.combine_binding
+#assert_axioms BtcVerified.Merkle.root_binding_of_length_eq
+#assert_axioms BtcVerified.Merkle.root_binding_of_canonical
 #assert_axioms BtcVerified.Block.merkleCommits
 
 /-! ## Bitcoin Core's ComputeMerkleRoot -/

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -101,12 +101,13 @@ elab "#assert_axioms " id:ident : command => do
 
 /-! ## Block hashes -/
 
-#assert_axioms BtcVerified.BlockHeader.hash_faithful
+#assert_axioms BtcVerified.BlockHeader.hash_inj
 
 /-! ## The chain -/
 
 #assert_axioms BtcVerified.Chain.toList_append
 #assert_axioms BtcVerified.Chain.isChain_toList
+#assert_axioms BtcVerified.Chain.tip_commits_prefix
 #assert_axioms BtcVerified.Chain.tip_commits
 
 /-! ## The merkle tree -/

--- a/Tests/BlockFixtures.lean
+++ b/Tests/BlockFixtures.lean
@@ -47,10 +47,10 @@ the fixture's own spot-checks. -/
 def blockFixtureChecksOut (displayHash : String) (bytes : List UInt8)
     (spot : Block → Bool) : Bool :=
   match hexBytes? displayHash, Codec.decode (α := Block) bytes with
-  | some hashBytes, some (b, rest) =>
+  | some _, some (b, rest) =>
     rest == []
     && Codec.encode b == bytes
-    && Sha256.sha256d (Codec.encode b.header) == hashBytes.reverse
+    && b.header.hash == hashOfDisplay displayHash
     && spot b
   | _, _ => false
 

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -277,6 +277,44 @@ def block170Hex : String :=
         && some (Codec.encode payment) == hexBytes? firstBitcoinPaymentHex
       | _ => false)
 
+/-! ## The blockchain: genesis → block 1 linkage
+
+  Block 1 (2009-01-09), hash
+  `00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048`: the
+  first block mined after genesis, extending it directly. Only its 80
+  header bytes appear — the chain layer is about headers — decoded by the
+  verified header codec and authenticated end to end by hashing to the
+  well-known block 1 hash, so no single byte of the vector can be wrong
+  without the guard failing.
+-/
+
+/-- Raw wire bytes of block 1's header, fetched from blockstream.info. -/
+def block1HeaderHex : String :=
+  "010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d61900\
+   00000000128063777e9fa444bbbe680e1fee14677ba1a3c3540bf7b1cdb606e8\
+   57233e0e61bc6649ffff001d01e36299"
+
+#guard match hexBytes? block1HeaderHex >>= Codec.decode (α := BlockHeader),
+    hexBytes? genesisBlockHex >>= Codec.decode (α := Block) with
+  | some (b1, rest), some (g, _) =>
+    rest == []
+    -- The decoded header re-encodes byte-for-byte and hashes to the
+    -- well-known block 1 hash — authenticating all 80 bytes at once.
+    && some (Codec.encode b1) == hexBytes? block1HeaderHex
+    && b1.hash
+      == hashOfDisplay "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"
+    -- The genesis header hashes to the well-known genesis block hash.
+    && g.header.hash
+      == hashOfDisplay "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+    -- Block 1 directly extends the genesis header: the chain's first link,
+    -- checked by the decidable linkage relation.
+    && decide (b1.Extends g.header)
+    -- The two headers are a chain from the zero anchor (the genesis
+    -- header's own prevBlockHash) up to block 1's hash — the Chain 0
+    -- instantiation on real mainnet data, via the decidable list predicate.
+    && decide (IsChain 0 b1.hash [b1, g.header])
+  | _, _ => false
+
 /-! ## CompactSize boundary values -/
 
 #guard CompactSize.encode 0 == [0x00]

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -291,7 +291,7 @@ def block170Hex : String :=
 /-- Raw wire bytes of block 1's header, fetched from blockstream.info. -/
 def block1HeaderHex : String :=
   "010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d61900\
-   00000000128063777e9fa444bbbe680e1fee14677ba1a3c3540bf7b1cdb606e8\
+   00000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e8\
    57233e0e61bc6649ffff001d01e36299"
 
 #guard match hexBytes? block1HeaderHex >>= Codec.decode (α := BlockHeader),

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -310,9 +310,11 @@ def block1HeaderHex : String :=
     -- checked by the decidable linkage relation.
     && decide (b1.Extends g.header)
     -- The two headers are a chain from the zero anchor (the genesis
-    -- header's own prevBlockHash) up to block 1's hash — the Chain 0
-    -- instantiation on real mainnet data, via the decidable list predicate.
-    && decide (IsChain 0 b1.hash [b1, g.header])
+    -- header's own prevBlockHash) — the Chain 0 instantiation on real
+    -- mainnet data, via the decidable list predicate; the tip it reaches
+    -- is b1's hash, checked against the known block 1 hash above.
+    && decide (IsChain 0 [b1, g.header])
+    && tipHash 0 [b1, g.header] == b1.hash
   | _, _ => false
 
 /-! ## CompactSize boundary values -/


### PR DESCRIPTION
## Summary
- `BlockHeader.hash` promoted into the library with the collision-disjunct `hash_binding` theorem; the block-fixture check now uses it.
- The structural blockchain layer: `BlockHeader.Extends`, the tip-first, hash-anchored `Chain anchor tip` inductive, `Chain.append` segment algebra, the decidable `IsChain` predicate, and the headline `Chain.tip_commits` theorem.
- Golden vector: block 1's real 80 header bytes decode, re-encode, hash to the known block 1 hash, and extend the decoded genesis header.
- Wired into `BtcVerified.lean`, `Tests/AxiomAudit.lean`, and the README.

`lake build`, `lake test`, and `lake lint` all pass.

Closes #22.

🤖 Generated with [Claude Code](https://claude.ai/code)
