### PR TITLE
Chainstate: Coin, UtxoSet, and the uniform UTXO action

### DIFF
--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -1,4 +1,5 @@
 import BtcVerified.Ext.List
+import BtcVerified.Ext.Finmap
 import BtcVerified.Serialize.Codec
 import BtcVerified.Serialize.WidthCast
 import BtcVerified.Serialize.CountedList
@@ -16,6 +17,10 @@ import BtcVerified.Transaction.SegwitInput
 import BtcVerified.Transaction.TxBody
 import BtcVerified.Transaction.Tx
 import BtcVerified.Transaction.Txid
+import BtcVerified.Chainstate.Provenance
+import BtcVerified.Chainstate.Coin
+import BtcVerified.Chainstate.UtxoSet
+import BtcVerified.Chainstate.Apply
 import BtcVerified.Block.BlockHeader
 import BtcVerified.Block.Block
 import BtcVerified.Block.Commitment

--- a/BtcVerified/Chainstate/Apply.lean
+++ b/BtcVerified/Chainstate/Apply.lean
@@ -1,0 +1,217 @@
+import BtcVerified.Transaction.Txid
+import BtcVerified.Chainstate.UtxoSet
+/-!
+  # The uniform UTXO action of a transaction
+
+  What a transaction *does* to the UTXO set: erase the outpoints its inputs
+  consume (`TxBody.spends`), insert one coin per output, keyed by txid and
+  output index (`TxBody.creates`). Every transaction — coinbase included —
+  acts through this one function. The coinbase's sole input names the null
+  outpoint, which no set contains, so its erase is vacuous: the action
+  needs no coinbase case. Validity is *not* checked here; guards are
+  consensus rules, stated over this action in a later layer, and the
+  theorems below carry as hypotheses exactly the facts those guards will
+  supply.
+
+  The split of responsibilities is deliberate on both axes. `spends` and
+  `creates` are functions of the transaction *alone* — what it consumes and
+  what it brings into existence — while `Provenance` is context the
+  transaction cannot know (coinbase-ness is positional, a property of
+  sitting first in a block), so the caller supplies it to `apply`, the one
+  place transaction meets context, where it is stamped onto every created
+  coin. And the action is over `TxBody`, not `Tx`: witnesses never touch
+  the UTXO set — they exist only for script verification, which enters
+  later as a guard parameter.
+
+  One width wrinkle, inherited from the wire: `OutPoint.vout` is a
+  `UInt32`, while a `CountedList` structurally admits up to `2⁶⁴ − 1`
+  outputs, so output indexing wraps for a (physically impossible)
+  transaction with more than `2³²` outputs. The action stays total; the
+  characterization theorems take `body.outputs.val.length ≤ 2 ^ 32` where
+  created-key distinctness is needed, and a block-size guard later
+  discharges that bound for any transaction a valid block can contain.
+
+  Checked claims:
+
+  * `UtxoSet.lookup_apply_of_mem_creates`: after applying a transaction
+    (≤ 2³² outputs), lookup at a created outpoint finds that output as a
+    coin stamped with the supplied provenance.
+  * `UtxoSet.lookup_apply_output`: the index form — output `i` sits at the
+    outpoint keyed by the txid and `i`.
+  * `UtxoSet.lookup_apply_of_mem_spends`: lookup at a spent outpoint the
+    transaction does not re-create returns `none`.
+  * `UtxoSet.lookup_apply_of_notMem`: lookup at an outpoint the
+    transaction neither spends nor creates is untouched.
+  * `UtxoSet.totalValue_apply`: the accounting identity — the new total
+    plus the values spent equals the old total plus the values created
+    (subtraction-free, in `Nat`).
+-/
+
+namespace BtcVerified
+
+/-- The outpoints a transaction's inputs consume — the erase half of its
+action on the UTXO set. -/
+def TxBody.spends (body : TxBody) : List OutPoint :=
+  body.inputs.val.map fun input => input.prevout
+
+/-- The keyed outputs a transaction brings into existence — the insert half
+of its action on the UTXO set: output `i`, at the outpoint keyed by the
+transaction's txid and `i`. A function of the transaction alone: the
+provenance the UTXO set stores alongside each output is context, stamped on
+by `UtxoSet.apply`. -/
+def TxBody.creates (body : TxBody) : List (OutPoint × TxOut) :=
+  body.outputs.val.zipIdx.map fun entry =>
+    (⟨body.txid, UInt32.ofNat entry.2⟩, entry.1)
+
+/-- The uniform action of a transaction on the UTXO set: erase what it
+spends, then insert what it creates, each created output stamped with the
+supplied provenance. Total and guard-free — validity lives in the consensus
+layer above. -/
+def UtxoSet.apply (utxos : UtxoSet) (provenance : Provenance) (body : TxBody) : UtxoSet :=
+  (utxos.spend body.spends).create
+    (body.creates.map fun entry => (entry.1, ⟨entry.2, provenance⟩))
+
+/-! ## The created outpoints -/
+
+/-- Every outpoint a transaction creates carries the transaction's txid. -/
+theorem TxBody.txid_of_mem_creates {body : TxBody} {o : OutPoint}
+    (h : o ∈ body.creates.map Prod.fst) : o.txid = body.txid := by
+  simp only [creates, List.map_map, List.mem_map] at h
+  obtain ⟨entry, -, rfl⟩ := h
+  rfl
+
+/-- With at most `2 ^ 32` outputs, the created outpoints are pairwise
+distinct: the shared txid pins the first component, and indices below the
+`vout` width embed injectively into `UInt32`. -/
+theorem TxBody.creates_keys_nodup (body : TxBody)
+    (houtputs : body.outputs.val.length ≤ 2 ^ 32) :
+    (body.creates.map Prod.fst).Nodup := by
+  rw [creates, List.map_map]
+  refine List.Nodup.map_on ?_ (List.Nodup.of_map _ (List.nodup_zipIdx_map_snd _))
+  intro x hx y hy hxy
+  obtain ⟨hxlt, hxget⟩ := List.getElem?_eq_some_iff.mp (List.mem_zipIdx_iff_getElem?.mp hx)
+  obtain ⟨hylt, hyget⟩ := List.getElem?_eq_some_iff.mp (List.mem_zipIdx_iff_getElem?.mp hy)
+  have hv : (UInt32.ofNat x.2).toNat = (UInt32.ofNat y.2).toNat :=
+    congrArg (fun o : OutPoint => o.vout.toNat) hxy
+  rw [UInt32.toNat_ofNat_of_lt' (Nat.lt_of_lt_of_le hxlt houtputs),
+    UInt32.toNat_ofNat_of_lt' (Nat.lt_of_lt_of_le hylt houtputs)] at hv
+  have hfst : x.1 = y.1 := by
+    rw [← hxget, ← hyget]
+    simp [hv]
+  exact Prod.ext_iff.mpr ⟨hfst, hv⟩
+
+/-- Output `i` of a transaction appears among its created outputs, at the
+outpoint keyed by the txid and `i`. -/
+theorem TxBody.mem_creates (body : TxBody) {i : Nat}
+    (hi : i < body.outputs.val.length) :
+    (⟨body.txid, UInt32.ofNat i⟩, body.outputs.val[i]) ∈ body.creates := by
+  rw [creates]
+  have hz : ((body.outputs.val[i], i) : TxOut × Nat) ∈ body.outputs.val.zipIdx :=
+    List.mem_zipIdx_iff_getElem?.mpr (List.getElem?_eq_getElem hi)
+  exact List.mem_map_of_mem hz
+
+/-- The values of the outputs a transaction creates are the values of its
+outputs, in order. -/
+theorem TxBody.creates_values (body : TxBody) :
+    body.creates.map (fun entry => entry.2.value.toNat)
+      = body.outputs.val.map fun output => output.value.toNat := by
+  conv_rhs => rw [← List.zipIdx_map_fst 0 body.outputs.val]
+  rw [creates, List.map_map, List.map_map]
+  rfl
+
+/-- Stamping a provenance onto a transaction's created outputs re-keys
+nothing: the stamped list's outpoints are exactly `creates`'s outpoints. -/
+theorem TxBody.creates_stamped_keys (body : TxBody) (provenance : Provenance) :
+    ((body.creates.map fun entry =>
+        (entry.1, (⟨entry.2, provenance⟩ : Coin))).map Prod.fst)
+      = body.creates.map Prod.fst := by
+  rw [List.map_map]
+  rfl
+
+/-! ## The lookup characterization -/
+
+/-- After applying a transaction with at most `2 ^ 32` outputs, lookup at
+an outpoint it creates finds that output as a coin stamped with the
+supplied provenance. -/
+theorem UtxoSet.lookup_apply_of_mem_creates {utxos : UtxoSet} {provenance : Provenance}
+    {body : TxBody} (houtputs : body.outputs.val.length ≤ 2 ^ 32)
+    {o : OutPoint} {out : TxOut} (hmem : (o, out) ∈ body.creates) :
+    (utxos.apply provenance body).lookup o = some ⟨out, provenance⟩ := by
+  have hkeys : ((body.creates.map fun entry =>
+      (entry.1, (⟨entry.2, provenance⟩ : Coin))).map Prod.fst).Nodup := by
+    rw [TxBody.creates_stamped_keys]
+    exact body.creates_keys_nodup houtputs
+  exact lookup_create_of_mem hkeys (List.mem_map_of_mem hmem)
+
+/-- After applying a transaction with at most `2 ^ 32` outputs, its output
+`i` sits at the outpoint keyed by the txid and `i`, stamped with the
+supplied provenance. -/
+theorem UtxoSet.lookup_apply_output {utxos : UtxoSet} {provenance : Provenance}
+    {body : TxBody} (houtputs : body.outputs.val.length ≤ 2 ^ 32) {i : Nat}
+    (hi : i < body.outputs.val.length) :
+    (utxos.apply provenance body).lookup ⟨body.txid, UInt32.ofNat i⟩
+      = some ⟨body.outputs.val[i], provenance⟩ :=
+  lookup_apply_of_mem_creates houtputs (body.mem_creates hi)
+
+/-- After applying a transaction, lookup at a spent outpoint the
+transaction does not re-create returns `none`. (`TxBody.txid_of_mem_creates`
+discharges the re-creation hypothesis whenever the outpoint's txid differs
+from the transaction's.) -/
+theorem UtxoSet.lookup_apply_of_mem_spends {utxos : UtxoSet} {provenance : Provenance}
+    {body : TxBody} {o : OutPoint} (hspent : o ∈ body.spends)
+    (hnew : o ∉ body.creates.map Prod.fst) :
+    (utxos.apply provenance body).lookup o = none := by
+  rw [← TxBody.creates_stamped_keys body provenance] at hnew
+  have h := lookup_create_of_notMem (utxos := utxos.spend body.spends) hnew
+  rw [lookup_spend_of_mem hspent] at h
+  exact h
+
+/-- Lookup at an outpoint a transaction neither spends nor creates is
+untouched by applying it. -/
+theorem UtxoSet.lookup_apply_of_notMem {utxos : UtxoSet} {provenance : Provenance}
+    {body : TxBody} {o : OutPoint} (hspends : o ∉ body.spends)
+    (hnew : o ∉ body.creates.map Prod.fst) :
+    (utxos.apply provenance body).lookup o = utxos.lookup o := by
+  rw [← TxBody.creates_stamped_keys body provenance] at hnew
+  have h := lookup_create_of_notMem (utxos := utxos.spend body.spends) hnew
+  rw [lookup_spend_of_notMem hspends] at h
+  exact h
+
+/-! ## The accounting identity -/
+
+/-- The accounting identity of the uniform action, subtraction-free in
+`Nat`: after applying a transaction, the total value plus the values spent
+equals the old total plus the values created. The hypotheses — distinct,
+present spends; created keys fresh once the spends are erased; at most
+`2 ^ 32` outputs — are exactly the facts the transaction-validity guards
+supply, so the gated conservation theorems specialize this directly. -/
+theorem UtxoSet.totalValue_apply {utxos : UtxoSet} {provenance : Provenance}
+    {body : TxBody} (houtputs : body.outputs.val.length ≤ 2 ^ 32)
+    (hnodup : body.spends.Nodup) (hmem : ∀ o ∈ body.spends, o ∈ utxos)
+    (hfresh : ∀ o ∈ body.creates.map Prod.fst, o ∉ utxos.spend body.spends) :
+    totalValue (utxos.apply provenance body) + (body.spends.map utxos.valueAt).sum
+      = utxos.totalValue
+        + (body.outputs.val.map fun output => output.value.toNat).sum := by
+  have hkeys : ((body.creates.map fun entry =>
+      (entry.1, (⟨entry.2, provenance⟩ : Coin))).map Prod.fst).Nodup := by
+    rw [TxBody.creates_stamped_keys]
+    exact body.creates_keys_nodup houtputs
+  have hfresh' : ∀ e ∈ (body.creates.map fun entry =>
+      (entry.1, (⟨entry.2, provenance⟩ : Coin))), e.1 ∉ utxos.spend body.spends := by
+    intro e he
+    obtain ⟨entry, hentry, rfl⟩ := List.mem_map.mp he
+    exact hfresh entry.1 (List.mem_map_of_mem hentry)
+  have hcreate := totalValue_create (utxos := utxos.spend body.spends) hkeys hfresh'
+  have hspend := totalValue_spend hnodup hmem
+  have hvals : ((body.creates.map fun entry =>
+      (entry.1, (⟨entry.2, provenance⟩ : Coin))).map
+        fun entry => entry.2.output.value.toNat)
+      = body.outputs.val.map fun output => output.value.toNat := by
+    rw [List.map_map, ← body.creates_values]
+    rfl
+  have hsum := congrArg List.sum hvals
+  change totalValue ((utxos.spend body.spends).create
+    (body.creates.map fun entry => (entry.1, ⟨entry.2, provenance⟩))) + _ = _
+  omega
+
+end BtcVerified

--- a/BtcVerified/Chainstate/Coin.lean
+++ b/BtcVerified/Chainstate/Coin.lean
@@ -1,0 +1,29 @@
+import BtcVerified.Transaction.TxOut
+import BtcVerified.Chainstate.Provenance
+/-!
+  # Coins: what the UTXO set stores
+
+  A coin is an unspent transaction output together with its `Provenance` —
+  the creation height and coinbase-position flag that spend-time guards need
+  and the spending transaction cannot supply. This is Bitcoin Core's
+  chainstate entry (`CTxOut` + `nHeight` + `fCoinBase`), with the two
+  metadata fields bundled as one named concept.
+
+  The `TxOut` is wire data; the provenance is not. A coin is therefore a
+  state-layer object with no serialization — the codomain of the UTXO map,
+  never a field on the wire.
+-/
+
+namespace BtcVerified
+
+/-- An unspent transaction output as the UTXO set stores it: the output
+itself plus the provenance its spend-time guards will consult. -/
+structure Coin where
+  /-- The unspent output: amount and locking script. -/
+  output : TxOut
+  /-- Where the output came from: creation height and coinbase-position
+  flag. -/
+  provenance : Provenance
+deriving DecidableEq
+
+end BtcVerified

--- a/BtcVerified/Chainstate/Provenance.lean
+++ b/BtcVerified/Chainstate/Provenance.lean
@@ -1,0 +1,36 @@
+/-!
+  # Coin provenance
+
+  Where an unspent output came from: the height of the block that created it,
+  and whether it was created in that block's coinbase position.
+
+  Both fields exist for guards that run at *spend* time, arbitrarily many
+  blocks after creation. The spending transaction carries no trace of its
+  inputs' origins, so the UTXO set must remember them: coinbase maturity
+  needs the pair together (an output created in a coinbase position is
+  spendable only once 100 blocks deep), and BIP68 relative locktimes measure
+  from the creation height. This mirrors the height/`fCoinBase` metadata
+  Bitcoin Core keeps per coin in its chainstate.
+
+  Coinbase-ness is *positional* — a property of sitting first in a block, not
+  of the transaction's own bytes — so the flag is supplied by whoever knows
+  the position (the block-application layer), never computed from the
+  transaction. `Provenance` is bookkeeping of the state layer, not a wire
+  structure: nothing here serializes, so there is no `Codec`.
+-/
+
+namespace BtcVerified
+
+/-- Where a coin came from: the height of the block that created it and
+whether it sat in that block's coinbase position. Recorded at creation,
+consumed by spend-time guards (coinbase maturity, BIP68 relative locktimes)
+that the spending transaction alone cannot decide. -/
+structure Provenance where
+  /-- Height of the block the creating transaction is applied in. -/
+  height : Nat
+  /-- Whether the creating transaction occupies the block's coinbase
+  position. Positional, so supplied by the block layer. -/
+  coinbase : Bool
+deriving DecidableEq
+
+end BtcVerified

--- a/BtcVerified/Chainstate/UtxoSet.lean
+++ b/BtcVerified/Chainstate/UtxoSet.lean
@@ -1,0 +1,233 @@
+import BtcVerified.Ext.Finmap
+import BtcVerified.Transaction.OutPoint
+import BtcVerified.Chainstate.Coin
+/-!
+  # The UTXO set
+
+  The chainstate's accumulator: the finite map from outpoints to the coins
+  they name. This module is the *machine*, not the rules — it defines the
+  map, its two primitive bulk operations (`spend` erases a list of
+  outpoints, `create` inserts a list of keyed coins), and the value
+  accounting, all guard-free and total. Consensus guards are stated over
+  this machine later, in `Consensus/`; nothing here decides validity.
+
+  The spec representation is Mathlib's `Finmap` — extensional equality and
+  a ready `lookup`/`insert`/`erase` API. Efficiency is a transport concern
+  for `Impl/`, exactly as `List UInt8` versus `ByteArray` on the
+  serialization side.
+
+  `totalValue` sums in `Nat`, not `UInt64`: `UInt64` addition wraps, and
+  the argument that Bitcoin totals stay below 2⁶⁴ is a consequence of
+  *guards* — which do not exist at this layer. The `Nat` sum makes the
+  accounting identities unconditional.
+
+  Checked claims:
+
+  * `UtxoSet.lookup_spend_of_mem` / `UtxoSet.lookup_spend_of_notMem`: after
+    spending a list of outpoints, lookup returns `none` on the list's
+    members and is untouched elsewhere.
+  * `UtxoSet.spend_perm`: spending is order-insensitive — permuted spend
+    lists produce the same set. Order-freedom within a transaction is a
+    theorem of the machine, not a type-level restatement.
+  * `UtxoSet.mem_spend`: membership after a spend is membership before it,
+    minus the spent list.
+  * `UtxoSet.lookup_create_of_notMem` / `UtxoSet.lookup_create_of_mem`:
+    after creating a list of keyed coins (keys distinct), lookup finds
+    exactly the listed coin at each listed key and is untouched elsewhere.
+  * `UtxoSet.mem_create`: membership after a create is membership before
+    it, plus the created keys.
+  * `UtxoSet.totalValue_insert` / `UtxoSet.totalValue_erase`: inserting a
+    fresh coin adds its value to the total; erasing a present outpoint
+    removes the value held there.
+  * `UtxoSet.totalValue_spend`: spending distinct, present outpoints
+    removes exactly the sum of the values held at them.
+  * `UtxoSet.totalValue_create`: creating coins at distinct, fresh keys
+    adds exactly the sum of their values.
+-/
+
+namespace BtcVerified
+
+/-- The UTXO set: the finite map from outpoints to the coins they name.
+The chainstate accumulator every transaction acts on and every stateful
+consensus guard reads. -/
+abbrev UtxoSet := Finmap fun _ : OutPoint => Coin
+
+/-- The satoshi value the set holds at an outpoint — zero when the outpoint
+is absent. The accounting identities sum this over a transaction's spends. -/
+def UtxoSet.valueAt (utxos : UtxoSet) (outpoint : OutPoint) : Nat :=
+  ((utxos.lookup outpoint).map fun coin => coin.output.value.toNat).getD 0
+
+/-- The total satoshi value held across the whole set, as a `Nat` sum —
+`UInt64` sums wrap, and no guard bounds the total at this layer. -/
+def UtxoSet.totalValue (utxos : UtxoSet) : Nat :=
+  (utxos.entries.map fun entry => entry.2.output.value.toNat).sum
+
+/-- Erase every outpoint in a list — the spend half of a transaction's
+action on the set. -/
+def UtxoSet.spend (utxos : UtxoSet) (outpoints : List OutPoint) : UtxoSet :=
+  outpoints.foldl (fun m outpoint => m.erase outpoint) utxos
+
+/-- Insert a coin at every key in a list — the create half of a
+transaction's action on the set. `Finmap.insert` replaces, so a later entry
+overwrites an earlier one at a duplicated key; the characterization lemmas
+therefore assume distinct keys. -/
+def UtxoSet.create (utxos : UtxoSet) (coins : List (OutPoint × Coin)) : UtxoSet :=
+  coins.foldl (fun m coin => m.insert coin.1 coin.2) utxos
+
+/-! ## Lookup characterizations -/
+
+/-- Spending leaves lookup untouched away from the spent outpoints. -/
+theorem UtxoSet.lookup_spend_of_notMem {utxos : UtxoSet} {outpoints : List OutPoint}
+    {o : OutPoint} (h : o ∉ outpoints) :
+    (utxos.spend outpoints).lookup o = utxos.lookup o := by
+  induction outpoints generalizing utxos with
+  | nil => rfl
+  | cons hd tl ih =>
+    rw [List.mem_cons, not_or] at h
+    change (spend (utxos.erase hd) tl).lookup o = _
+    rw [ih h.2, Finmap.lookup_erase_ne h.1]
+
+/-- Spent outpoints are gone: after spending a list of outpoints, lookup on
+any of its members returns `none`. -/
+theorem UtxoSet.lookup_spend_of_mem {utxos : UtxoSet} {outpoints : List OutPoint}
+    {o : OutPoint} (h : o ∈ outpoints) :
+    (utxos.spend outpoints).lookup o = none := by
+  induction outpoints generalizing utxos with
+  | nil => cases h
+  | cons hd tl ih =>
+    change (spend (utxos.erase hd) tl).lookup o = none
+    by_cases htl : o ∈ tl
+    · exact ih htl
+    · rcases List.mem_cons.mp h with rfl | habs
+      · rw [lookup_spend_of_notMem htl, Finmap.lookup_erase]
+      · exact absurd habs htl
+
+/-- Spending is order-insensitive: permuted spend lists produce the same
+set, because lookup after a spend depends only on membership in the list.
+Order-freedom within a transaction is a theorem of the machine, not a
+type-level restatement. -/
+theorem UtxoSet.spend_perm {utxos : UtxoSet} {l₁ l₂ : List OutPoint} (h : l₁.Perm l₂) :
+    utxos.spend l₁ = utxos.spend l₂ :=
+  Finmap.ext_lookup fun o => by
+    by_cases hmem : o ∈ l₁
+    · rw [lookup_spend_of_mem hmem, lookup_spend_of_mem (h.mem_iff.mp hmem)]
+    · rw [lookup_spend_of_notMem hmem,
+        lookup_spend_of_notMem fun hc => hmem (h.mem_iff.mpr hc)]
+
+/-- Membership after a spend is membership before it, minus the spent
+list. -/
+theorem UtxoSet.mem_spend {utxos : UtxoSet} {outpoints : List OutPoint} {o : OutPoint} :
+    o ∈ utxos.spend outpoints ↔ o ∈ utxos ∧ o ∉ outpoints := by
+  rw [← Finmap.lookup_isSome, ← Finmap.lookup_isSome]
+  by_cases h : o ∈ outpoints
+  · rw [lookup_spend_of_mem h]
+    simp [h]
+  · rw [lookup_spend_of_notMem h]
+    simp [h]
+
+/-- Creating coins leaves lookup untouched away from the created keys. -/
+theorem UtxoSet.lookup_create_of_notMem {utxos : UtxoSet} {coins : List (OutPoint × Coin)}
+    {o : OutPoint} (h : o ∉ coins.map Prod.fst) :
+    (utxos.create coins).lookup o = utxos.lookup o := by
+  induction coins generalizing utxos with
+  | nil => rfl
+  | cons hd tl ih =>
+    rw [List.map_cons, List.mem_cons, not_or] at h
+    change (create (utxos.insert hd.1 hd.2) tl).lookup o = _
+    rw [ih h.2, Finmap.lookup_insert_of_ne _ h.1]
+
+/-- After creating a list of keyed coins with distinct keys, lookup at a
+listed key finds exactly the listed coin. -/
+theorem UtxoSet.lookup_create_of_mem {utxos : UtxoSet} {coins : List (OutPoint × Coin)}
+    (hkeys : (coins.map Prod.fst).Nodup) {o : OutPoint} {c : Coin} (hmem : (o, c) ∈ coins) :
+    (utxos.create coins).lookup o = some c := by
+  induction coins generalizing utxos with
+  | nil => cases hmem
+  | cons hd tl ih =>
+    rw [List.map_cons, List.nodup_cons] at hkeys
+    rcases List.mem_cons.mp hmem with heq | htl
+    · subst heq
+      change (create (utxos.insert o c) tl).lookup o = some c
+      rw [lookup_create_of_notMem hkeys.1, Finmap.lookup_insert]
+    · exact ih hkeys.2 htl
+
+/-- Membership after a create is membership before it, plus the created
+keys. -/
+theorem UtxoSet.mem_create {utxos : UtxoSet} {coins : List (OutPoint × Coin)} {o : OutPoint} :
+    o ∈ utxos.create coins ↔ o ∈ utxos ∨ o ∈ coins.map Prod.fst := by
+  induction coins generalizing utxos with
+  | nil => simp [create]
+  | cons hd tl ih =>
+    change o ∈ create (utxos.insert hd.1 hd.2) tl ↔ _
+    rw [ih]
+    simp only [Finmap.mem_insert, List.map_cons, List.mem_cons]
+    tauto
+
+/-! ## Value accounting -/
+
+/-- Inserting a coin at a fresh key adds its value to the total. -/
+theorem UtxoSet.totalValue_insert {utxos : UtxoSet} {o : OutPoint} {c : Coin}
+    (h : o ∉ utxos) :
+    totalValue (utxos.insert o c) = c.output.value.toNat + utxos.totalValue := by
+  rw [totalValue, totalValue, Finmap.entries_insert_of_notMem h, Multiset.map_cons,
+    Multiset.sum_cons]
+
+/-- Erasing a present outpoint removes exactly the value held there from
+the total. -/
+theorem UtxoSet.totalValue_erase {utxos : UtxoSet} {o : OutPoint} (h : o ∈ utxos) :
+    totalValue (utxos.erase o) + utxos.valueAt o = utxos.totalValue := by
+  obtain ⟨c, hc⟩ := Finmap.mem_iff.mp h
+  have hins : totalValue ((utxos.erase o).insert o c)
+      = c.output.value.toNat + totalValue (utxos.erase o) :=
+    totalValue_insert Finmap.notMem_erase_self
+  rw [Finmap.insert_erase hc] at hins
+  have hval : utxos.valueAt o = c.output.value.toNat := by simp [valueAt, hc]
+  omega
+
+/-- The value held at an outpoint is untouched by erasing a different
+one. -/
+theorem UtxoSet.valueAt_erase_ne {utxos : UtxoSet} {o o' : OutPoint} (h : o ≠ o') :
+    valueAt (utxos.erase o') o = utxos.valueAt o := by
+  rw [valueAt, valueAt, Finmap.lookup_erase_ne h]
+
+/-- Spending distinct, present outpoints removes exactly the sum of the
+values held at them from the total. -/
+theorem UtxoSet.totalValue_spend {utxos : UtxoSet} {outpoints : List OutPoint}
+    (hnodup : outpoints.Nodup) (hmem : ∀ o ∈ outpoints, o ∈ utxos) :
+    totalValue (utxos.spend outpoints) + (outpoints.map utxos.valueAt).sum
+      = utxos.totalValue := by
+  induction outpoints generalizing utxos with
+  | nil => simp [spend]
+  | cons hd tl ih =>
+    rw [List.nodup_cons] at hnodup
+    have hmap : tl.map utxos.valueAt = tl.map (valueAt (utxos.erase hd)) :=
+      List.map_congr_left fun o ho =>
+        (valueAt_erase_ne fun (heq : o = hd) => hnodup.1 (heq ▸ ho)).symm
+    have hrest := ih (utxos := utxos.erase hd) hnodup.2 fun o ho =>
+      Finmap.mem_erase.mpr
+        ⟨fun (heq : o = hd) => hnodup.1 (heq ▸ ho), hmem o (List.mem_cons_of_mem _ ho)⟩
+    have herase := totalValue_erase (hmem hd List.mem_cons_self)
+    change totalValue (spend (utxos.erase hd) tl) + _ = _
+    rw [List.map_cons, List.sum_cons, hmap]
+    omega
+
+/-- Creating coins at distinct keys, all fresh for the set, adds exactly
+the sum of their values to the total. -/
+theorem UtxoSet.totalValue_create {utxos : UtxoSet} {coins : List (OutPoint × Coin)}
+    (hkeys : (coins.map Prod.fst).Nodup) (hfresh : ∀ e ∈ coins, e.1 ∉ utxos) :
+    totalValue (utxos.create coins)
+      = utxos.totalValue + (coins.map fun e => e.2.output.value.toNat).sum := by
+  induction coins generalizing utxos with
+  | nil => simp [create]
+  | cons hd tl ih =>
+    rw [List.map_cons, List.nodup_cons] at hkeys
+    have hfresh' : ∀ e ∈ tl, e.1 ∉ utxos.insert hd.1 hd.2 := fun e he => by
+      rw [Finmap.mem_insert, not_or]
+      exact ⟨fun heq => hkeys.1 (heq ▸ List.mem_map_of_mem he),
+        hfresh e (List.mem_cons_of_mem _ he)⟩
+    change totalValue (create (utxos.insert hd.1 hd.2) tl) = _
+    rw [ih (utxos := utxos.insert hd.1 hd.2) hkeys.2 hfresh',
+      totalValue_insert (hfresh hd List.mem_cons_self), List.map_cons, List.sum_cons]
+    omega
+
+end BtcVerified

--- a/BtcVerified/Ext/Finmap.lean
+++ b/BtcVerified/Ext/Finmap.lean
@@ -1,0 +1,30 @@
+import Mathlib.Data.Finmap
+/-!
+  # `Finmap` extensions
+
+  Lemmas about Mathlib's `Finmap` that Mathlib does not (yet) provide, in
+  the `Finmap` namespace per the `Ext/` convention.
+
+  Checked claims:
+
+  * `Finmap.insert_erase`: re-inserting the value found at a key after
+    erasing that key restores the original map.
+-/
+
+namespace Finmap
+
+variable {α : Type*} {β : α → Type*} [DecidableEq α]
+
+/-- Re-inserting the value found at a key after erasing that key restores
+the original map: erasure only forgets the one entry the insertion puts
+back. Lets a map be peeled one entry at a time by facts about `insert`
+alone. -/
+theorem insert_erase {a : α} {b : β a} {s : Finmap β} (h : s.lookup a = some b) :
+    (s.erase a).insert a b = s :=
+  ext_lookup fun x => by
+    by_cases hx : x = a
+    · subst hx
+      rw [lookup_insert, h]
+    · rw [lookup_insert_of_ne _ hx, lookup_erase_ne hx]
+
+end Finmap

--- a/BtcVerified/Transaction/Txid.lean
+++ b/BtcVerified/Transaction/Txid.lean
@@ -31,12 +31,17 @@ namespace BtcVerified
 
 open BtcVerified.Serialize
 
-/-- The transaction id: the double-SHA-256 of the witness-free `TxBody`
-serialization, as its raw 32 digest bytes (the displayed hex is these bytes
-reversed). Both constructors hash only the body, so witness data never affects
-a txid. -/
+/-- The transaction id of a witness-free body: the double-SHA-256 of the
+`TxBody` serialization, as its raw 32 digest bytes (the displayed hex is these
+bytes reversed). The body alone determines the txid — this is the form the
+UTXO layer uses to key a transaction's outputs. -/
+def TxBody.txid (body : TxBody) : Hash256 :=
+  ⟨Sha256.sha256d (Codec.encode body), Sha256.sha256d_length _⟩
+
+/-- The transaction id: the txid of the witness-free body. Both constructors
+hash only the body, so witness data never affects a txid. -/
 def Tx.txid (tx : Tx) : Hash256 :=
-  ⟨Sha256.sha256d (Codec.encode tx.body), Sha256.sha256d_length _⟩
+  tx.body.txid
 
 /-- The witness transaction id (BIP141): the double-SHA-256 of the full
 serialization, witness included for the SegWit form. -/

--- a/README.md
+++ b/README.md
@@ -368,6 +368,55 @@ Giving programs their own type now — with the protocol's real
 syntax/execution boundary built in — is the anchor the script-language layer
 attaches to without touching the serialization stack.
 
+### `BtcVerified` chainstate
+
+The UTXO set and the uniform action a transaction performs on it — the
+*machine* that consensus rules will be stated over, kept strictly free of the
+rules themselves. `UtxoSet` is the finite map from `OutPoint` to `Coin`
+(Mathlib `Finmap` as the spec representation; efficiency is a later `Impl/`
+transport). A `Coin` is the `TxOut` plus its `Provenance` — creation height
+and coinbase-position flag, the metadata spend-time guards need and the
+spending transaction cannot carry; coinbase-ness is positional, so the block
+layer supplies the flag. `UtxoSet.apply` erases what a transaction spends and
+inserts what it creates, keyed by txid and output index — one total,
+guard-free function for every transaction, coinbase included (its
+null-outpoint erase is vacuous), over `TxBody` because witnesses never touch
+the UTXO set. `totalValue` sums in `Nat`: `UInt64` sums wrap, and the bound
+that would prevent it is a guard, which this layer does not have.
+
+Checked claims:
+
+- `UtxoSet.lookup_apply_of_mem_creates` / `UtxoSet.lookup_apply_output`:
+  after applying a transaction (at most 2³² outputs, the `vout` width),
+  lookup at a created outpoint finds exactly that output as a coin — output
+  `i` sits at the outpoint keyed by the txid and `i`, stamped with the
+  supplied provenance (`TxBody.creates` is a function of the transaction
+  alone; provenance is context, stamped on at `apply`).
+- `UtxoSet.lookup_apply_of_mem_spends`: lookup at a spent outpoint the
+  transaction does not re-create returns `none`.
+- `UtxoSet.lookup_apply_of_notMem`: lookup at an outpoint the transaction
+  neither spends nor creates is untouched.
+- `UtxoSet.totalValue_apply`: the accounting identity, subtraction-free in
+  `Nat` — total value after applying, plus the values spent, equals total
+  value before, plus the values created. Its hypotheses (distinct, present
+  spends; created keys fresh; the 2³² output bound) are exactly what the
+  transaction-validity guards will supply.
+- Beneath these, the primitive characterizations
+  (`UtxoSet.lookup_spend_of_mem` / `of_notMem`, `UtxoSet.lookup_create_of_mem`,
+  `UtxoSet.totalValue_spend`, `UtxoSet.totalValue_create`),
+  `UtxoSet.spend_perm` (order-freedom within a transaction is a theorem of
+  the machine, not a type-level restatement), and `Finmap.insert_erase` in
+  `Ext/`.
+
+Why it matters: this is the validity layer's foundation. Consensus validity
+is stateful — a chain is valid when folding its blocks through the state
+succeeds — and the action/guard split made here is what keeps that layer
+honest: every transaction, coinbase included, *acts* identically; only the
+*guards* differ, and they land as explicitly stated rules in a dedicated
+consensus layer. The accounting identity is the engine of the coming monetary
+theorems: under the block-level delta invariant (`totalValue` grows by at
+most the subsidy) it folds directly into the supply limit.
+
 ## What this is not yet
 
 - Not a full Bitcoin Script semantics.

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -99,6 +99,21 @@ elab "#assert_axioms " id:ident : command => do
 #assert_axioms BtcVerified.Tx.wtxid_binding
 #assert_axioms BtcVerified.Tx.wtxid_legacy
 
+/-! ## The chainstate -/
+
+#assert_axioms Finmap.insert_erase
+#assert_axioms BtcVerified.UtxoSet.lookup_spend_of_mem
+#assert_axioms BtcVerified.UtxoSet.lookup_spend_of_notMem
+#assert_axioms BtcVerified.UtxoSet.spend_perm
+#assert_axioms BtcVerified.UtxoSet.lookup_create_of_mem
+#assert_axioms BtcVerified.UtxoSet.totalValue_spend
+#assert_axioms BtcVerified.UtxoSet.totalValue_create
+#assert_axioms BtcVerified.UtxoSet.lookup_apply_of_mem_creates
+#assert_axioms BtcVerified.UtxoSet.lookup_apply_output
+#assert_axioms BtcVerified.UtxoSet.lookup_apply_of_mem_spends
+#assert_axioms BtcVerified.UtxoSet.lookup_apply_of_notMem
+#assert_axioms BtcVerified.UtxoSet.totalValue_apply
+
 /-! ## Block hashes -/
 
 #assert_axioms BtcVerified.BlockHeader.hash_binding


### PR DESCRIPTION
First leaf of the validity layer: the chainstate *machine* — the UTXO set and the uniform action a transaction performs on it — with consensus guards deliberately absent (they land next, in a dedicated `Consensus/` layer; #36).

## Design (from the 2026-07-05 planning discussion)

- **Action/guard split.** Every transaction — coinbase included — does the same thing to the UTXO set: erase the input outpoints, insert the created outputs. Validity guards are separate rules stated *over* the action later. The coinbase's null-outpoint erase is vacuous, so the action needs no case split; coinbase-ness is positional (first in a block), so `Provenance.coinbase` is supplied by the block layer, never computed from the bytes.
- **Fees are not spec objects.** The accounting identity here is guard-free and subtraction-free in `Nat`; the monetary rule becomes a block-level delta invariant (#37), and Core's incremental fee accounting is an `Impl/` refinement.
- **`Coin` = `TxOut` + `Provenance`** (creation height, coinbase flag) — Core's chainstate triple; spend-time guards (maturity, BIP68) need metadata the spending transaction cannot carry.
- **Spec representation:** Mathlib `Finmap`; efficiency is a later `Impl/` transport (#40). `totalValue` sums in `Nat` because `UInt64` wraps and the bound preventing it is a guard this layer doesn't have.

## Checked claims

- `UtxoSet.lookup_apply_of_mem_creates` / `lookup_apply_output` / `lookup_apply_of_mem_spends` / `lookup_apply_of_notMem`: the complete lookup characterization of the action.
- `UtxoSet.totalValue_apply`: total after + spent = total before + created; hypotheses are exactly what the validity guards (#36) will supply, so gated conservation is a one-line specialization.
- Primitives beneath: `lookup_spend`, `lookup_create_of_mem`, `totalValue_spend`, `totalValue_create`, and `Finmap.insert_erase` (new `Ext/Finmap.lean` — Mathlib gap).

## Notes

- `TxBody.txid` extracted from `Tx.txid` (definitional delegation): the txid's preimage is exactly the body, and the action keys created outputs from a bare `TxBody`.
- The vout width wrinkle is carried honestly: `OutPoint.vout : UInt32` vs a `CountedList`'s 2^64 capacity means the characterization theorems take `outputs.length <= 2^32`; the block-size guard discharges it later (#37).
- BIP30 insert-over-existing semantics deferred to #39.

All commits build individually; `lake build`, `lake lint`, `lake test` clean; headline theorems registered in the axiom audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
