### PR TITLE
Close axiom-audit gaps, correct fixture-authentication comments, fix doc drift

### DIFF
--- a/BtcVerified/Serialize/Codec.lean
+++ b/BtcVerified/Serialize/Codec.lean
@@ -283,7 +283,9 @@ instance instCodecUInt32 : Codec UInt32 :=
 instance instCodecUInt64 : Codec UInt64 :=
   Codec.ofEquiv ⟨UInt64.toBitVec, UInt64.ofBitVec, fun _ => rfl, fun _ => rfl⟩ (bitVecCodecLE 8)
 
-/-- The 256-bit hash type is exactly 32 little-endian bytes. -/
+/-- A 256-bit word is exactly 32 little-endian bytes. (Hashes are not this:
+`Hash256` is 32 raw digest bytes with no endianness step — this instance is
+for numeric 256-bit fields.) -/
 instance instCodecBitVec256 : Codec (BitVec 256) := bitVecCodecLE 32
 
 end BtcVerified.Serialize

--- a/BtcVerified/Transaction/README.md
+++ b/BtcVerified/Transaction/README.md
@@ -28,7 +28,9 @@ format into the types:
   transaction can never encode zero inputs.
 - Every CompactSize-prefixed field — scripts, the input/output vectors, witness
   stacks — is a `CountedList`; witness items are opaque byte strings; scripts
-  are `Script` (see `../Script/`); hashing stays abstract.
+  are `Script` (see `../Script/`); hash-valued fields are opaque `Hash256`
+  digests — nothing in the data model computes a hash (ids are computed in
+  `Txid.lean`, below).
 
 Why it matters: consensus validity, proof of work, and fork choice presuppose
 an actual representation of the substructures that carry their invariants.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ in its header, and makes the next proof packet easier to state.
 
 ```sh
 lake build                                  # everything (default targets: BtcVerified, Tests)
-lake build BtcVerified.Transaction.TxCodec  # one module — the fast iteration loop
+lake build BtcVerified.Transaction.Tx       # one module — the fast iteration loop
 lake build Tests                            # golden vectors + axiom audit only
 lake test                                   # fixture checks (block 481824; fetched on first run, cached gitignored)
 lake lint                                   # batteries runLinter, mathlib standard linter set
@@ -24,6 +24,8 @@ lake lint                                   # batteries runLinter, mathlib stand
 
 Dependency order, bottom-up:
 
+- `BtcVerified/Ext/` — small `List`/`Finmap` lemmas the layers below need;
+  upstreaming candidates.
 - `BtcVerified/Serialize/` — the codec discipline. `Codec.lean` defines the
   `Codec` typeclass: encoder, prefix-consuming decoder over `List UInt8`, and
   the two laws (`decode_encode` round-trip, `decode_canonical` canonicality).
@@ -33,19 +35,33 @@ Dependency order, bottom-up:
   (namespace `BtcVerified.CompactSize`); `CountedList.lean` the
   CompactSize-count-prefixed vector (`CountedList α` = list whose length fits
   `UInt64`).
-- `BtcVerified/Crypto/Hash256.lean` — `Hash256 := BitVec 256`. Hashing is
-  abstract everywhere; nothing computes SHA-256.
+- `BtcVerified/Crypto/` — `Hash256.lean`: a digest as its 32 raw bytes, the
+  one type txids, block hashes, and merkle nodes share. `Sha256.lean`: a
+  computable FIPS 180-4 SHA-256 and `sha256d` — the only place a hash is
+  computed; everything downstream calls it. `Collision.lean`: collisions as
+  concrete witnesses; collision resistance is a consumer hypothesis, never
+  an axiom. `Merkle.lean`: the abstract merkle root, its binding theorems,
+  and the CVE-2012-2459 canonicality predicate.
 - `BtcVerified/Script/Script.lean` — `Script`: a program as raw,
   CompactSize-prefixed bytes. Tokenization is part of execution, not
   deserialization (consensus never requires script fields to tokenize), so
   the wire layer keeps the bytes uninterpreted; the script-language layer
   grows here later.
 - `BtcVerified/Transaction/` — the data model (`OutPoint`, `TxIn`, `TxOut`,
-  `TxBody`, `SegwitInput`, `Tx`) and `TxCodec.lean`, the whole-transaction
-  codec with the legacy/SegWit marker dispatch.
-- `BtcVerified/Block/` — `BlockHeader`, `Block`.
+  `TxBody`, `SegwitInput`, `Tx`), `Tx.lean` — the whole-transaction codec
+  with the legacy/SegWit marker dispatch — and `Txid.lean`, txids and
+  wtxids as binding commitments.
+- `BtcVerified/Chainstate/` — the UTXO set (a `Finmap` over outpoints), coin
+  provenance, and the guard-free transaction action with its value
+  accounting. The machine consensus rules will be stated over, not the
+  rules themselves.
+- `BtcVerified/Block/` — `BlockHeader`, `Block`, the header's merkle
+  commitment to its txid list, the header hash, and hash-linked chains
+  (`Chain.lean`: the tip hash commits to the whole history).
 - `BtcVerified/BitVM/` — abstract bit-commitment model, independent of the
   serialization stack.
+- `BtcVerified/Impl/` — Bitcoin Core's own algorithms transcribed to Lean
+  and proved against the spec, starting with `BitcoinCore/Merkle.lean`.
 
 `BtcVerified.lean` is the root: every module must be imported there or CI
 doesn't build it.
@@ -58,7 +74,7 @@ doesn't build it.
    the codec for free: `instance instCodecFoo : Codec Foo :=
    Codec.ofEquiv Foo.equivProd inferInstance`. No hand-written proofs.
 3. Only write `encode`/`decode` by hand when the wire format and the model
-   genuinely disagree (e.g. `TxCodec.lean`, where BIP144 groups witnesses
+   genuinely disagree (e.g. `Tx.lean`, where BIP144 groups witnesses
    after inputs but the model bundles them per-input). Then prove both laws
    and package them as a `Codec` instance.
 4. Every CompactSize-prefixed wire field (scripts, vectors, witness stacks) is
@@ -79,8 +95,9 @@ Spec/transport split: the spec byte type is `List UInt8`. Do not switch to
   (e.g. `instCodecUInt8…64` in `Serialize/Codec.lean`); sum-type arm-records may
   share a module if they never appear in an outside signature. Tightly-coupled
   clusters become a directory of one-type modules under an umbrella facade (see
-  `BitVM/BitCommitment/`). A `lake`-run introspection audit enforces this
-  (issue #9).
+  `BitVM/BitCommitment/`). A `lake`-run introspection audit to enforce this
+  mechanically is planned — tracked as issue #9; until it lands, review
+  enforces it.
 - **Naming**: rigid Lean/mathlib casing. `UpperCamelCase` for types, props,
   and predicates; `lowerCamelCase` for defs; theorem names describe the
   conclusion mathlib-style (`decode_encode`, `encodeBitVecLE_length`). Full
@@ -104,7 +121,8 @@ Spec/transport split: the spec byte type is `List UInt8`. Do not switch to
 - **Lints**: `weak.linter.mathlibStandardSet` is on; code must be linter-clean
   (`lake lint`).
 - **No `sorry` on master.** New axioms require explicit discussion; the audit
-  allowlist is `propext`, `Classical.choice`, `Quot.sound`.
+  allowlist is `propext`, `Classical.choice`, `Quot.sound`, plus the
+  natively checked LRAT certificates `bv_decide` records.
 
 ## When a leaf lands
 

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -6,8 +6,9 @@ import Lean
   `lake build` succeeds even when a proof uses `sorry` — it is only a warning.
   This file is what turns "it builds" into "it is proved": `#assert_axioms`
   fails elaboration if a registered constant depends on any axiom outside the
-  standard three (`propext`, `Classical.choice`, `Quot.sound`) — in particular
-  on `sorryAx`.
+  standard three (`propext`, `Classical.choice`, `Quot.sound`) and the
+  natively checked `bv_decide` LRAT certificates — in particular on
+  `sorryAx`.
 
   Every headline theorem and codec instance must be registered here when its
   leaf lands. Auditing a `Codec` instance covers both of its law fields and
@@ -27,9 +28,14 @@ def allowedAxioms : List Name := [``propext, ``Classical.choice, ``Quot.sound]
 checked LRAT certificate as a per-declaration axiom named
 `<decl>._native.bv_decide.ax_*`. Those proofs trust the SAT pipeline (solver +
 native LRAT checker), which we accept; this recognizes them so the audit can
-allow them while still rejecting `sorryAx` and any other stray axiom. -/
+allow them while still rejecting `sorryAx` and any other stray axiom. The
+match is on the exact last three name components (`._native.bv_decide.ax_*`),
+not a substring, so an unrelated declaration whose name merely mentions
+`bv_decide` cannot slip through. -/
 def isBvDecideCertificate (ax : Name) : Bool :=
-  (ax.toString.splitOn ".bv_decide.ax").length > 1
+  match ax with
+  | .str (.str (.str _ "_native") "bv_decide") s => s.startsWith "ax_"
+  | _ => false
 
 /-- Fail elaboration if the named constant depends on any axiom outside
 `allowedAxioms` (plus `bv_decide` certificates) — in particular on `sorryAx`. -/
@@ -105,7 +111,12 @@ elab "#assert_axioms " id:ident : command => do
 #assert_axioms BtcVerified.UtxoSet.lookup_spend_of_mem
 #assert_axioms BtcVerified.UtxoSet.lookup_spend_of_notMem
 #assert_axioms BtcVerified.UtxoSet.spend_perm
+#assert_axioms BtcVerified.UtxoSet.mem_spend
+#assert_axioms BtcVerified.UtxoSet.lookup_create_of_notMem
 #assert_axioms BtcVerified.UtxoSet.lookup_create_of_mem
+#assert_axioms BtcVerified.UtxoSet.mem_create
+#assert_axioms BtcVerified.UtxoSet.totalValue_insert
+#assert_axioms BtcVerified.UtxoSet.totalValue_erase
 #assert_axioms BtcVerified.UtxoSet.totalValue_spend
 #assert_axioms BtcVerified.UtxoSet.totalValue_create
 #assert_axioms BtcVerified.UtxoSet.lookup_apply_of_mem_creates

--- a/Tests/BlockFixtures.lean
+++ b/Tests/BlockFixtures.lean
@@ -12,9 +12,12 @@ import Tests.GoldenVectors
   `Tests/fixtures/`, which is gitignored. The download is authenticated as
   far as the current leaves allow: the decoded header must double-SHA-256 to
   the requested block hash (so the 80 header bytes carry their proof of
-  work), and the spot-checks pin the transaction count and the embedded
-  transactions they name byte-for-byte. Full authentication of every
-  transaction byte is the merkle-commitment leaf's job, once it lands.
+  work), the merkle commitment pins every transaction's txid to that header,
+  and the spot-checks pin the embedded transactions they name byte-for-byte.
+  Txids exclude witness data (BIP141), so the SegWit witness bytes of
+  transactions not byte-pinned by a spot-check are the one region a
+  corrupted download could alter undetected; closing it is the
+  witness-commitment leaf's job, once it lands.
 
   The one fixture so far is block 481824, the SegWit activation block: 1866
   transactions mixing the legacy and SegWit serializations, the SegWit
@@ -82,8 +85,10 @@ def block481824Checks (b : Block) : Bool :=
   && (b.txs.val.any fun tx => !tx.isSegWit)
   -- The header commits to all 1866 transaction ids through the merkle root,
   -- and the txid list is canonical. With the header-hash check above, every
-  -- transaction byte in the fixture is now pinned: txids → merkle root →
-  -- header → proof-of-work hash.
+  -- non-witness transaction byte is pinned: txids → merkle root → header →
+  -- proof-of-work hash. Witness bytes are outside the txid preimage (BIP141),
+  -- so only the two byte-pinned transactions above have theirs checked,
+  -- until the witness-commitment leaf lands.
   && decide b.merkleCommits
   -- Bitcoin Core's own algorithm accepts the block: run on the real txid list,
   -- its `mutated` flag is clear — the model agrees with Core, which accepted


### PR DESCRIPTION
Three follow-ups from a code-quality review of the repo. No proof or behavior changes — the only `.lean` changes are audit registrations, a `Bool`-valued name check, and comments.

## Axiom-audit gaps (`Tests/AxiomAudit.lean`)

- `UtxoSet.mem_spend` and `UtxoSet.mem_create` are named as Checked claims in the module header but were neither registered in the audit nor depended on by any registered theorem — a `sorry` in either would have shipped through CI. `lookup_create_of_notMem`, `totalValue_insert`, and `totalValue_erase` were covered only transitively. All are now registered, in header order.
- `isBvDecideCertificate` accepted any axiom whose name *contains* `.bv_decide.ax` as a substring. It now matches the exact shape of the names `bv_decide` records (`<decl>._native.bv_decide.ax_*`, checked empirically against a real certificate), so an unrelated axiom can't slip through on a name coincidence.
- The module header now names the `bv_decide` exemption next to the standard three axioms instead of omitting it.

## Fixture authentication comments (`Tests/BlockFixtures.lean`)

The spot-check comment claimed the txid → merkle root → header → PoW chain pins "every transaction byte" of the fixture, but txids exclude witness data (BIP141): witness bytes of transactions not byte-pinned by a spot-check are unauthenticated until the witness-commitment leaf lands. The module header erred in the opposite direction, still saying the merkle-commitment leaf hadn't landed. Both now state the actual boundary.

## Doc drift (`CLAUDE.md`, `Transaction/README.md`, one doc-string)

CLAUDE.md described a previous generation of the repo: the fast-loop example built the removed `TxCodec.lean`, `Hash256` was described as `BitVec 256` with "nothing computes SHA-256", the architecture list omitted `Ext/`, `Chainstate/`, and `Impl/` (and most of `Crypto/` and `Block/`), the module-discipline audit was described as existing when issue #9 tracks it as planned, and the allowlist description omitted the `bv_decide` certificates. Same drift fixed in `Transaction/README.md` ("hashing stays abstract") and `instCodecBitVec256`'s doc-string ("the 256-bit hash type").

## Verification

`lake build` (823 jobs), `lake lint`, and `lake test` (block 481824: decoded, header hash verified, re-encoded byte-for-byte) all pass. The green audit also confirms the tightened certificate match still accepts real `bv_decide` certificates, since registered theorems (e.g. `CompactSize.decode_encode`) depend on them.

One residual worth its own issue per the repo's deferral rule: the witness-commitment leaf is now referenced by two comments but has no tracked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)