### PR TITLE
Consensus/: transaction premises for block extension

### DIFF
--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -27,5 +27,6 @@ import BtcVerified.Block.Commitment
 import BtcVerified.Block.BlockHash
 import BtcVerified.Block.Chain
 import BtcVerified.Consensus.Limits
+import BtcVerified.Consensus.TxContext
 import BtcVerified.BitVM.BitCommitment
 import BtcVerified.Impl.BitcoinCore.Merkle

--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -30,5 +30,6 @@ import BtcVerified.Consensus.Limits
 import BtcVerified.Consensus.TxContext
 import BtcVerified.Consensus.ScriptCheck
 import BtcVerified.Consensus.TxStateless
+import BtcVerified.Consensus.TxContextual
 import BtcVerified.BitVM.BitCommitment
 import BtcVerified.Impl.BitcoinCore.Merkle

--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -26,5 +26,6 @@ import BtcVerified.Block.Block
 import BtcVerified.Block.Commitment
 import BtcVerified.Block.BlockHash
 import BtcVerified.Block.Chain
+import BtcVerified.Consensus.Limits
 import BtcVerified.BitVM.BitCommitment
 import BtcVerified.Impl.BitcoinCore.Merkle

--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -28,5 +28,6 @@ import BtcVerified.Block.BlockHash
 import BtcVerified.Block.Chain
 import BtcVerified.Consensus.Limits
 import BtcVerified.Consensus.TxContext
+import BtcVerified.Consensus.ScriptCheck
 import BtcVerified.BitVM.BitCommitment
 import BtcVerified.Impl.BitcoinCore.Merkle

--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -27,6 +27,7 @@ import BtcVerified.Block.Commitment
 import BtcVerified.Block.BlockHash
 import BtcVerified.Block.Chain
 import BtcVerified.Consensus.Limits
+import BtcVerified.Consensus.LockTime
 import BtcVerified.Consensus.TxContext
 import BtcVerified.Consensus.ScriptCheck
 import BtcVerified.Consensus.TxStateless

--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -31,5 +31,6 @@ import BtcVerified.Consensus.TxContext
 import BtcVerified.Consensus.ScriptCheck
 import BtcVerified.Consensus.TxStateless
 import BtcVerified.Consensus.TxContextual
+import BtcVerified.Consensus.ApplyChecked
 import BtcVerified.BitVM.BitCommitment
 import BtcVerified.Impl.BitcoinCore.Merkle

--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -29,5 +29,6 @@ import BtcVerified.Block.Chain
 import BtcVerified.Consensus.Limits
 import BtcVerified.Consensus.TxContext
 import BtcVerified.Consensus.ScriptCheck
+import BtcVerified.Consensus.TxStateless
 import BtcVerified.BitVM.BitCommitment
 import BtcVerified.Impl.BitcoinCore.Merkle

--- a/BtcVerified/Chainstate/Apply.lean
+++ b/BtcVerified/Chainstate/Apply.lean
@@ -183,8 +183,9 @@ theorem UtxoSet.lookup_apply_of_notMem {utxos : UtxoSet} {provenance : Provenanc
 `Nat`: after applying a transaction, the total value plus the values spent
 equals the old total plus the values created. The hypotheses — distinct,
 present spends; created keys fresh once the spends are erased; at most
-`2 ^ 32` outputs — are exactly the facts the transaction-validity guards
-supply, so the gated conservation theorems specialize this directly. -/
+`2 ^ 32` outputs — are exactly the facts the transaction premises of
+block-extension validity supply, so the gated conservation theorems
+specialize this directly. -/
 theorem UtxoSet.totalValue_apply {utxos : UtxoSet} {provenance : Provenance}
     {body : TxBody} (houtputs : body.outputs.val.length ≤ 2 ^ 32)
     (hnodup : body.spends.Nodup) (hmem : ∀ o ∈ body.spends, o ∈ utxos)

--- a/BtcVerified/Chainstate/README.md
+++ b/BtcVerified/Chainstate/README.md
@@ -30,7 +30,7 @@ Checked claims:
   `Nat` — total value after applying, plus the values spent, equals total
   value before, plus the values created. Its hypotheses (distinct, present
   spends; created keys fresh; the 2³² output bound) are exactly what the
-  transaction-validity guards will supply.
+  transaction premises of block-extension validity supply.
 - Beneath these, the primitive characterizations
   (`UtxoSet.lookup_spend_of_mem` / `of_notMem`, `UtxoSet.lookup_create_of_mem`,
   `UtxoSet.totalValue_spend`, `UtxoSet.totalValue_create`),

--- a/BtcVerified/Consensus/ApplyChecked.lean
+++ b/BtcVerified/Consensus/ApplyChecked.lean
@@ -43,7 +43,7 @@ fresh after its spends are erased because spending only shrinks the set. This
 is the exact absence hypothesis the action theorems carry. -/
 theorem Tx.creates_do_not_overwrite_after_spend
     {scriptOk : ScriptCheck} {utxos : UtxoSet}
-    {clock : FinalityClock} {ctx : TxContext} {tx : Tx}
+    {clock : LockTimeClock} {ctx : TxContext} {tx : Tx}
     (h : Tx.Admissible scriptOk utxos clock ctx tx) :
     ∀ o ∈ tx.body.creates.map Prod.fst, o ∉ utxos.spend tx.body.spends :=
   fun o ho hmem =>
@@ -54,7 +54,7 @@ value after application plus the value spent equals total value before plus
 the value created. Every machine hypothesis is discharged by a transaction
 premise, including output-index injectivity via the stripped-size premise. -/
 theorem UtxoSet.totalValue_apply_of_admissible {scriptOk : ScriptCheck}
-    {utxos : UtxoSet} {clock : FinalityClock} {ctx : TxContext}
+    {utxos : UtxoSet} {clock : LockTimeClock} {ctx : TxContext}
     {provenance : Provenance} {tx : Tx} (hwf : tx.WellFormed)
     (hadm : Tx.Admissible scriptOk utxos clock ctx tx) :
     totalValue (utxos.apply provenance tx.body)
@@ -69,7 +69,7 @@ theorem UtxoSet.totalValue_apply_of_admissible {scriptOk : ScriptCheck}
 holds: the total drops by exactly the value the inputs carry beyond the
 outputs — the fee, in English; fees are not spec objects (#37). -/
 theorem UtxoSet.totalValue_apply_le_of_admissible {scriptOk : ScriptCheck}
-    {utxos : UtxoSet} {clock : FinalityClock} {ctx : TxContext}
+    {utxos : UtxoSet} {clock : LockTimeClock} {ctx : TxContext}
     {provenance : Provenance} {tx : Tx} (hwf : tx.WellFormed)
     (hadm : Tx.Admissible scriptOk utxos clock ctx tx) :
     totalValue (utxos.apply provenance tx.body) ≤ utxos.totalValue := by
@@ -84,7 +84,7 @@ internal step of #37's block fold, not a standalone consensus verdict. It
 stamps the provenance a regular transaction earns — created at the admitting
 height, not in coinbase position. -/
 def UtxoSet.applyChecked (scriptOk : ScriptCheck) (utxos : UtxoSet)
-    (clock : FinalityClock) (ctx : TxContext) (tx : Tx) : Option UtxoSet :=
+    (clock : LockTimeClock) (ctx : TxContext) (tx : Tx) : Option UtxoSet :=
   if tx.isWellFormed && tx.isAdmissible scriptOk utxos clock ctx
   then some (utxos.apply ⟨ctx.height, false⟩ tx.body)
   else none
@@ -93,7 +93,7 @@ def UtxoSet.applyChecked (scriptOk : ScriptCheck) (utxos : UtxoSet)
 contextual premises hold, then agrees with the guard-free action under the
 regular-transaction provenance stamp. -/
 theorem UtxoSet.applyChecked_eq_some_iff {scriptOk : ScriptCheck}
-    {utxos next : UtxoSet} {clock : FinalityClock} {ctx : TxContext} {tx : Tx} :
+    {utxos next : UtxoSet} {clock : LockTimeClock} {ctx : TxContext} {tx : Tx} :
     utxos.applyChecked scriptOk clock ctx tx = some next
       ↔ tx.WellFormed ∧ Tx.Admissible scriptOk utxos clock ctx tx
           ∧ next = utxos.apply ⟨ctx.height, false⟩ tx.body := by

--- a/BtcVerified/Consensus/ApplyChecked.lean
+++ b/BtcVerified/Consensus/ApplyChecked.lean
@@ -7,8 +7,10 @@ import BtcVerified.Consensus.TxContextual
   rule-passing transaction's `creates_absent` into the exact absence-after-
   spend hypothesis the action theorems carry, and the gated conservation
   theorems specialize `UtxoSet.totalValue_apply` with every machine
-  hypothesis supplied by a rule — except the output-count bound, which the
-  block-size rule provides (#37), so it stays a hypothesis here.
+  hypothesis supplied by a rule. In particular, the stateless stripped-size
+  rule implies the output-count bound that keeps `UInt32` output indices
+  injective, so the checked interface leaves no root-level transaction
+  property to its caller.
 
   Fees are not spec objects (#37): the conservation statement is the
   accounting identity itself, and "the total drops by exactly the fee" is
@@ -27,7 +29,7 @@ import BtcVerified.Consensus.TxContextual
     outpoints are absent even after its spends are erased.
   * `UtxoSet.totalValue_apply_of_admissible`: for a rule-passing
     transaction the accounting identity holds, every machine hypothesis
-    discharged by a rule (the output-count bound by #37).
+    discharged by a rule.
   * `UtxoSet.totalValue_apply_le_of_admissible`: a rule-passing transaction
     never increases the total value the set holds.
   * `UtxoSet.applyChecked_eq_some_iff`: the strict interface succeeds on
@@ -48,17 +50,18 @@ theorem Tx.creates_absent_spend {scriptOk : ScriptCheck} {utxos : UtxoSet}
 
 /-- For a rule-passing transaction the accounting identity holds: total
 value after application plus the value spent equals total value before plus
-the value created. Every machine hypothesis is discharged by a rule, except
-the output-count bound the block-size rule supplies (#37). -/
+the value created. Every machine hypothesis is discharged by a root-level
+transaction rule, including output-index injectivity via the stripped-size
+guard. -/
 theorem UtxoSet.totalValue_apply_of_admissible {scriptOk : ScriptCheck}
     {utxos : UtxoSet} {ctx : TxContext} {provenance : Provenance} {tx : Tx}
-    (houtputs : tx.body.outputs.val.length ≤ 2 ^ 32)
     (hwf : tx.WellFormed) (hadm : Tx.Admissible scriptOk utxos ctx tx) :
     totalValue (utxos.apply provenance tx.body)
         + (tx.body.spends.map utxos.valueAt).sum
       = utxos.totalValue
         + (tx.body.outputs.val.map fun output => output.value.toNat).sum :=
-  totalValue_apply houtputs hwf.spends_nodup hadm.spends_mem
+  totalValue_apply (Tx.WellFormed.outputs_length_le hwf)
+    hwf.spends_nodup hadm.spends_mem
     (Tx.creates_absent_spend hadm)
 
 /-- A rule-passing transaction never increases the total value the set
@@ -66,10 +69,9 @@ holds: the total drops by exactly the value the inputs carry beyond the
 outputs — the fee, in English; fees are not spec objects (#37). -/
 theorem UtxoSet.totalValue_apply_le_of_admissible {scriptOk : ScriptCheck}
     {utxos : UtxoSet} {ctx : TxContext} {provenance : Provenance} {tx : Tx}
-    (houtputs : tx.body.outputs.val.length ≤ 2 ^ 32)
     (hwf : tx.WellFormed) (hadm : Tx.Admissible scriptOk utxos ctx tx) :
     totalValue (utxos.apply provenance tx.body) ≤ utxos.totalValue := by
-  have hidentity := totalValue_apply_of_admissible houtputs hwf hadm
+  have hidentity := totalValue_apply_of_admissible hwf hadm
     (provenance := provenance)
   have hcover := hadm.values_cover
   omega

--- a/BtcVerified/Consensus/ApplyChecked.lean
+++ b/BtcVerified/Consensus/ApplyChecked.lean
@@ -3,56 +3,55 @@ import BtcVerified.Consensus.TxContextual
 /-!
   # Guarded application
 
-  Where the rules meet the machine. The discharge lemma turns a
-  rule-passing transaction's `creates_absent` into the exact absence-after-
-  spend hypothesis the action theorems carry, and the gated conservation
-  theorems specialize `UtxoSet.totalValue_apply` with every machine
-  hypothesis supplied by a rule. In particular, the stateless stripped-size
-  rule implies the output-count bound that keeps `UInt32` output indices
-  injective, so the checked interface leaves no root-level transaction
-  property to its caller.
+  Where transaction premises meet the machine. The discharge lemma turns
+  `creates_do_not_overwrite` into the exact absence-after-spend hypothesis
+  the action theorems carry, and the gated conservation theorems specialize
+  `UtxoSet.totalValue_apply` with every machine hypothesis supplied by a
+  premise. In particular, the transaction-local stripped-size premise implies
+  the output-count bound that keeps `UInt32` output indices injective.
 
   Fees are not spec objects (#37): the conservation statement is the
   accounting identity itself, and "the total drops by exactly the fee" is
   its English reading, not a definition in the model.
 
-  `applyChecked` is the strict interface — rules first, act on success —
-  provably agreeing with the guard-free action whenever it returns `some`.
-  A convenience in `Consensus/`, never structure in `Chainstate/`: every
-  transaction acts identically; only the rules differ. It stamps the
+  `applyChecked` is the internal regular-transaction step that the block fold
+  in #37 will iterate: check its local and contextual premises, then act on
+  success. It is not a root consensus interface; only the complete block fold,
+  coinbase epilogue, and block-wide premises establish a valid extension. A
+  convenience in `Consensus/`, never structure in `Chainstate/`, it stamps the
   provenance a regular transaction earns — created at the admitting height,
-  not in coinbase position (the coinbase epilogue is a block rule, #37).
+  not in coinbase position.
 
   Checked claims:
 
-  * `Tx.creates_absent_spend`: a rule-passing transaction's created
-    outpoints are absent even after its spends are erased.
-  * `UtxoSet.totalValue_apply_of_admissible`: for a rule-passing
+  * `Tx.creates_do_not_overwrite_after_spend`: a premise-passing
+    transaction's created outpoints remain fresh after its spends are erased.
+  * `UtxoSet.totalValue_apply_of_admissible`: for a premise-passing
     transaction the accounting identity holds, every machine hypothesis
     discharged by a rule.
-  * `UtxoSet.totalValue_apply_le_of_admissible`: a rule-passing transaction
+  * `UtxoSet.totalValue_apply_le_of_admissible`: a premise-passing transaction
     never increases the total value the set holds.
-  * `UtxoSet.applyChecked_eq_some_iff`: the strict interface succeeds on
-    exactly the rule-passing transactions, and then agrees with the
-    guard-free action.
+  * `UtxoSet.applyChecked_eq_some_iff`: the internal step succeeds exactly
+    when its transaction premises hold, and then agrees with the guard-free
+    action.
 -/
 
 namespace BtcVerified
 
-/-- A rule-passing transaction's created outpoints are absent even after its
-spends are erased — `creates_absent` survives the spend because spending
-only shrinks the set. This is the exact absence hypothesis the action
-theorems carry. -/
-theorem Tx.creates_absent_spend {scriptOk : ScriptCheck} {utxos : UtxoSet}
+/-- If a transaction's creations do not overwrite the current set, they remain
+fresh after its spends are erased because spending only shrinks the set. This
+is the exact absence hypothesis the action theorems carry. -/
+theorem Tx.creates_do_not_overwrite_after_spend
+    {scriptOk : ScriptCheck} {utxos : UtxoSet}
     {ctx : TxContext} {tx : Tx} (h : Tx.Admissible scriptOk utxos ctx tx) :
     ∀ o ∈ tx.body.creates.map Prod.fst, o ∉ utxos.spend tx.body.spends :=
-  fun o ho hmem => h.creates_absent o ho (UtxoSet.mem_spend.mp hmem).1
+  fun o ho hmem =>
+    h.creates_do_not_overwrite o ho (UtxoSet.mem_spend.mp hmem).1
 
-/-- For a rule-passing transaction the accounting identity holds: total
+/-- For a premise-passing transaction the accounting identity holds: total
 value after application plus the value spent equals total value before plus
-the value created. Every machine hypothesis is discharged by a root-level
-transaction rule, including output-index injectivity via the stripped-size
-guard. -/
+the value created. Every machine hypothesis is discharged by a transaction
+premise, including output-index injectivity via the stripped-size premise. -/
 theorem UtxoSet.totalValue_apply_of_admissible {scriptOk : ScriptCheck}
     {utxos : UtxoSet} {ctx : TxContext} {provenance : Provenance} {tx : Tx}
     (hwf : tx.WellFormed) (hadm : Tx.Admissible scriptOk utxos ctx tx) :
@@ -62,9 +61,9 @@ theorem UtxoSet.totalValue_apply_of_admissible {scriptOk : ScriptCheck}
         + (tx.body.outputs.val.map fun output => output.value.toNat).sum :=
   totalValue_apply (Tx.WellFormed.outputs_length_le hwf)
     hwf.spends_nodup hadm.spends_mem
-    (Tx.creates_absent_spend hadm)
+    (Tx.creates_do_not_overwrite_after_spend hadm)
 
-/-- A rule-passing transaction never increases the total value the set
+/-- A premise-passing transaction never increases the total value the set
 holds: the total drops by exactly the value the inputs carry beyond the
 outputs — the fee, in English; fees are not spec objects (#37). -/
 theorem UtxoSet.totalValue_apply_le_of_admissible {scriptOk : ScriptCheck}
@@ -76,19 +75,20 @@ theorem UtxoSet.totalValue_apply_le_of_admissible {scriptOk : ScriptCheck}
   have hcover := hadm.values_cover
   omega
 
-/-- Run the regular-transaction rules, then act: `some` of the guard-free
-application on success, `none` on any rule failure. Stamps the provenance a
-regular transaction earns — created at the admitting height, not in
-coinbase position (the coinbase epilogue is a block rule, #37). -/
+/-- Run the premises for one regular-transaction step, then act: `some` of the
+guard-free application on success, `none` on any premise failure. This is the
+internal step of #37's block fold, not a standalone consensus verdict. It
+stamps the provenance a regular transaction earns — created at the admitting
+height, not in coinbase position. -/
 def UtxoSet.applyChecked (scriptOk : ScriptCheck) (utxos : UtxoSet)
     (ctx : TxContext) (tx : Tx) : Option UtxoSet :=
   if tx.isWellFormed && tx.isAdmissible scriptOk utxos ctx
   then some (utxos.apply ⟨ctx.height, false⟩ tx.body)
   else none
 
-/-- The strict interface succeeds on exactly the rule-passing transactions,
-and then agrees with the guard-free action under the regular-transaction
-provenance stamp. -/
+/-- The internal regular-transaction step succeeds exactly when its local and
+contextual premises hold, then agrees with the guard-free action under the
+regular-transaction provenance stamp. -/
 theorem UtxoSet.applyChecked_eq_some_iff {scriptOk : ScriptCheck}
     {utxos next : UtxoSet} {ctx : TxContext} {tx : Tx} :
     utxos.applyChecked scriptOk ctx tx = some next

--- a/BtcVerified/Consensus/ApplyChecked.lean
+++ b/BtcVerified/Consensus/ApplyChecked.lean
@@ -1,0 +1,109 @@
+import BtcVerified.Consensus.TxStateless
+import BtcVerified.Consensus.TxContextual
+/-!
+  # Guarded application
+
+  Where the rules meet the machine. The discharge lemma turns a
+  rule-passing transaction's `creates_absent` into the exact absence-after-
+  spend hypothesis the action theorems carry, and the gated conservation
+  theorems specialize `UtxoSet.totalValue_apply` with every machine
+  hypothesis supplied by a rule — except the output-count bound, which the
+  block-size rule provides (#37), so it stays a hypothesis here.
+
+  Fees are not spec objects (#37): the conservation statement is the
+  accounting identity itself, and "the total drops by exactly the fee" is
+  its English reading, not a definition in the model.
+
+  `applyChecked` is the strict interface — rules first, act on success —
+  provably agreeing with the guard-free action whenever it returns `some`.
+  A convenience in `Consensus/`, never structure in `Chainstate/`: every
+  transaction acts identically; only the rules differ. It stamps the
+  provenance a regular transaction earns — created at the admitting height,
+  not in coinbase position (the coinbase epilogue is a block rule, #37).
+
+  Checked claims:
+
+  * `Tx.creates_absent_spend`: a rule-passing transaction's created
+    outpoints are absent even after its spends are erased.
+  * `UtxoSet.totalValue_apply_of_admissible`: for a rule-passing
+    transaction the accounting identity holds, every machine hypothesis
+    discharged by a rule (the output-count bound by #37).
+  * `UtxoSet.totalValue_apply_le_of_admissible`: a rule-passing transaction
+    never increases the total value the set holds.
+  * `UtxoSet.applyChecked_eq_some_iff`: the strict interface succeeds on
+    exactly the rule-passing transactions, and then agrees with the
+    guard-free action.
+-/
+
+namespace BtcVerified
+
+/-- A rule-passing transaction's created outpoints are absent even after its
+spends are erased — `creates_absent` survives the spend because spending
+only shrinks the set. This is the exact absence hypothesis the action
+theorems carry. -/
+theorem Tx.creates_absent_spend {scriptOk : ScriptCheck} {utxos : UtxoSet}
+    {ctx : TxContext} {tx : Tx} (h : Tx.Admissible scriptOk utxos ctx tx) :
+    ∀ o ∈ tx.body.creates.map Prod.fst, o ∉ utxos.spend tx.body.spends :=
+  fun o ho hmem => h.creates_absent o ho (UtxoSet.mem_spend.mp hmem).1
+
+/-- For a rule-passing transaction the accounting identity holds: total
+value after application plus the value spent equals total value before plus
+the value created. Every machine hypothesis is discharged by a rule, except
+the output-count bound the block-size rule supplies (#37). -/
+theorem UtxoSet.totalValue_apply_of_admissible {scriptOk : ScriptCheck}
+    {utxos : UtxoSet} {ctx : TxContext} {provenance : Provenance} {tx : Tx}
+    (houtputs : tx.body.outputs.val.length ≤ 2 ^ 32)
+    (hwf : tx.WellFormed) (hadm : Tx.Admissible scriptOk utxos ctx tx) :
+    totalValue (utxos.apply provenance tx.body)
+        + (tx.body.spends.map utxos.valueAt).sum
+      = utxos.totalValue
+        + (tx.body.outputs.val.map fun output => output.value.toNat).sum :=
+  totalValue_apply houtputs hwf.spends_nodup hadm.spends_mem
+    (Tx.creates_absent_spend hadm)
+
+/-- A rule-passing transaction never increases the total value the set
+holds: the total drops by exactly the value the inputs carry beyond the
+outputs — the fee, in English; fees are not spec objects (#37). -/
+theorem UtxoSet.totalValue_apply_le_of_admissible {scriptOk : ScriptCheck}
+    {utxos : UtxoSet} {ctx : TxContext} {provenance : Provenance} {tx : Tx}
+    (houtputs : tx.body.outputs.val.length ≤ 2 ^ 32)
+    (hwf : tx.WellFormed) (hadm : Tx.Admissible scriptOk utxos ctx tx) :
+    totalValue (utxos.apply provenance tx.body) ≤ utxos.totalValue := by
+  have hidentity := totalValue_apply_of_admissible houtputs hwf hadm
+    (provenance := provenance)
+  have hcover := hadm.values_cover
+  omega
+
+/-- Run the regular-transaction rules, then act: `some` of the guard-free
+application on success, `none` on any rule failure. Stamps the provenance a
+regular transaction earns — created at the admitting height, not in
+coinbase position (the coinbase epilogue is a block rule, #37). -/
+def UtxoSet.applyChecked (scriptOk : ScriptCheck) (utxos : UtxoSet)
+    (ctx : TxContext) (tx : Tx) : Option UtxoSet :=
+  if tx.isWellFormed && tx.isAdmissible scriptOk utxos ctx
+  then some (utxos.apply ⟨ctx.height, false⟩ tx.body)
+  else none
+
+/-- The strict interface succeeds on exactly the rule-passing transactions,
+and then agrees with the guard-free action under the regular-transaction
+provenance stamp. -/
+theorem UtxoSet.applyChecked_eq_some_iff {scriptOk : ScriptCheck}
+    {utxos next : UtxoSet} {ctx : TxContext} {tx : Tx} :
+    utxos.applyChecked scriptOk ctx tx = some next
+      ↔ tx.WellFormed ∧ Tx.Admissible scriptOk utxos ctx tx
+          ∧ next = utxos.apply ⟨ctx.height, false⟩ tx.body := by
+  unfold applyChecked
+  split
+  · next hcond =>
+      rw [Bool.and_eq_true, Tx.isWellFormed_iff, Tx.isAdmissible_iff] at hcond
+      simp only [Option.some.injEq]
+      exact ⟨fun hnext => ⟨hcond.1, hcond.2, hnext.symm⟩,
+        fun ⟨_, _, hnext⟩ => hnext.symm⟩
+  · next hcond =>
+      refine iff_of_false (fun h => by cases h) ?_
+      rintro ⟨hwf, hadm, -⟩
+      refine hcond ?_
+      rw [Bool.and_eq_true]
+      exact ⟨Tx.isWellFormed_iff.mpr hwf, Tx.isAdmissible_iff.mpr hadm⟩
+
+end BtcVerified

--- a/BtcVerified/Consensus/ApplyChecked.lean
+++ b/BtcVerified/Consensus/ApplyChecked.lean
@@ -43,7 +43,8 @@ fresh after its spends are erased because spending only shrinks the set. This
 is the exact absence hypothesis the action theorems carry. -/
 theorem Tx.creates_do_not_overwrite_after_spend
     {scriptOk : ScriptCheck} {utxos : UtxoSet}
-    {ctx : TxContext} {tx : Tx} (h : Tx.Admissible scriptOk utxos ctx tx) :
+    {clock : FinalityClock} {ctx : TxContext} {tx : Tx}
+    (h : Tx.Admissible scriptOk utxos clock ctx tx) :
     ∀ o ∈ tx.body.creates.map Prod.fst, o ∉ utxos.spend tx.body.spends :=
   fun o ho hmem =>
     h.creates_do_not_overwrite o ho (UtxoSet.mem_spend.mp hmem).1
@@ -53,8 +54,9 @@ value after application plus the value spent equals total value before plus
 the value created. Every machine hypothesis is discharged by a transaction
 premise, including output-index injectivity via the stripped-size premise. -/
 theorem UtxoSet.totalValue_apply_of_admissible {scriptOk : ScriptCheck}
-    {utxos : UtxoSet} {ctx : TxContext} {provenance : Provenance} {tx : Tx}
-    (hwf : tx.WellFormed) (hadm : Tx.Admissible scriptOk utxos ctx tx) :
+    {utxos : UtxoSet} {clock : FinalityClock} {ctx : TxContext}
+    {provenance : Provenance} {tx : Tx} (hwf : tx.WellFormed)
+    (hadm : Tx.Admissible scriptOk utxos clock ctx tx) :
     totalValue (utxos.apply provenance tx.body)
         + (tx.body.spends.map utxos.valueAt).sum
       = utxos.totalValue
@@ -67,8 +69,9 @@ theorem UtxoSet.totalValue_apply_of_admissible {scriptOk : ScriptCheck}
 holds: the total drops by exactly the value the inputs carry beyond the
 outputs — the fee, in English; fees are not spec objects (#37). -/
 theorem UtxoSet.totalValue_apply_le_of_admissible {scriptOk : ScriptCheck}
-    {utxos : UtxoSet} {ctx : TxContext} {provenance : Provenance} {tx : Tx}
-    (hwf : tx.WellFormed) (hadm : Tx.Admissible scriptOk utxos ctx tx) :
+    {utxos : UtxoSet} {clock : FinalityClock} {ctx : TxContext}
+    {provenance : Provenance} {tx : Tx} (hwf : tx.WellFormed)
+    (hadm : Tx.Admissible scriptOk utxos clock ctx tx) :
     totalValue (utxos.apply provenance tx.body) ≤ utxos.totalValue := by
   have hidentity := totalValue_apply_of_admissible hwf hadm
     (provenance := provenance)
@@ -81,8 +84,8 @@ internal step of #37's block fold, not a standalone consensus verdict. It
 stamps the provenance a regular transaction earns — created at the admitting
 height, not in coinbase position. -/
 def UtxoSet.applyChecked (scriptOk : ScriptCheck) (utxos : UtxoSet)
-    (ctx : TxContext) (tx : Tx) : Option UtxoSet :=
-  if tx.isWellFormed && tx.isAdmissible scriptOk utxos ctx
+    (clock : FinalityClock) (ctx : TxContext) (tx : Tx) : Option UtxoSet :=
+  if tx.isWellFormed && tx.isAdmissible scriptOk utxos clock ctx
   then some (utxos.apply ⟨ctx.height, false⟩ tx.body)
   else none
 
@@ -90,9 +93,9 @@ def UtxoSet.applyChecked (scriptOk : ScriptCheck) (utxos : UtxoSet)
 contextual premises hold, then agrees with the guard-free action under the
 regular-transaction provenance stamp. -/
 theorem UtxoSet.applyChecked_eq_some_iff {scriptOk : ScriptCheck}
-    {utxos next : UtxoSet} {ctx : TxContext} {tx : Tx} :
-    utxos.applyChecked scriptOk ctx tx = some next
-      ↔ tx.WellFormed ∧ Tx.Admissible scriptOk utxos ctx tx
+    {utxos next : UtxoSet} {clock : FinalityClock} {ctx : TxContext} {tx : Tx} :
+    utxos.applyChecked scriptOk clock ctx tx = some next
+      ↔ tx.WellFormed ∧ Tx.Admissible scriptOk utxos clock ctx tx
           ∧ next = utxos.apply ⟨ctx.height, false⟩ tx.body := by
   unfold applyChecked
   split

--- a/BtcVerified/Consensus/Limits.lean
+++ b/BtcVerified/Consensus/Limits.lean
@@ -1,0 +1,34 @@
+/-!
+  # Protocol limits
+
+  The numeric constants Bitcoin's consensus rules compare against, collected in
+  one place so every rule cites a named limit instead of a bare literal. Each
+  constant corresponds 1:1 to a constant in Bitcoin Core (the file is named in
+  the doc-string); none of them carries activation information — a limit is a
+  number, and which rules consult it at which heights is the ruleset mapping's
+  business.
+
+  Values are `Nat` wherever the rules do arithmetic on them (`Nat` is the
+  accounting type throughout `Chainstate/`), and stay in the wire's own type
+  where the rules only compare for equality (`sequenceFinal`).
+-/
+
+namespace BtcVerified.Consensus
+
+/-- The most satoshis consensus ever admits in an amount or a sum of amounts:
+21 million bitcoin (Core's `MAX_MONEY`, `src/consensus/amount.h`). -/
+def maxMoney : Nat := 21_000_000 * 100_000_000
+
+/-- How many blocks deep a coinbase-created coin must be before it may be
+spent (Core's `COINBASE_MATURITY`, `src/consensus/consensus.h`). -/
+def coinbaseMaturity : Nat := 100
+
+/-- The lock-time axis switch: lock times below it are block heights, at or
+above it UNIX timestamps (Core's `LOCKTIME_THRESHOLD`, `src/script/script.h`). -/
+def lockTimeThreshold : Nat := 500_000_000
+
+/-- The sequence value that opts an input out of lock-time enforcement
+(Core's `CTxIn::SEQUENCE_FINAL`, `src/primitives/transaction.h`). -/
+def sequenceFinal : UInt32 := 0xffffffff
+
+end BtcVerified.Consensus

--- a/BtcVerified/Consensus/Limits.lean
+++ b/BtcVerified/Consensus/Limits.lean
@@ -23,6 +23,15 @@ def maxMoney : Nat := 21_000_000 * 100_000_000
 spent (Core's `COINBASE_MATURITY`, `src/consensus/consensus.h`). -/
 def coinbaseMaturity : Nat := 100
 
+/-- The maximum total weight of a block, and the ceiling Core reuses for one
+transaction's stripped serialization multiplied by `witnessScaleFactor`
+([Bitcoin Core v28.0, `consensus.h` line 15](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/consensus.h#L15)). -/
+def maxBlockWeight : Nat := 4_000_000
+
+/-- The multiplier that converts a stripped byte to weight units
+([Bitcoin Core v28.0, `consensus.h` line 21](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/consensus.h#L21)). -/
+def witnessScaleFactor : Nat := 4
+
 /-- The lock-time axis switch: lock times below it are block heights, at or
 above it UNIX timestamps (Core's `LOCKTIME_THRESHOLD`, `src/script/script.h`). -/
 def lockTimeThreshold : Nat := 500_000_000

--- a/BtcVerified/Consensus/Limits.lean
+++ b/BtcVerified/Consensus/Limits.lean
@@ -16,7 +16,8 @@
 namespace BtcVerified.Consensus
 
 /-- The most satoshis consensus ever admits in an amount or a sum of amounts:
-21 million bitcoin (Core's `MAX_MONEY`, `src/consensus/amount.h`). -/
+21 million bitcoin ([Bitcoin Core v28.0, `amount.h` lines
+17–27](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/amount.h#L17-L27)). -/
 def maxMoney : Nat := 21_000_000 * 100_000_000
 
 /-- How many blocks deep a coinbase-created coin must be before it may be

--- a/BtcVerified/Consensus/Limits.lean
+++ b/BtcVerified/Consensus/Limits.lean
@@ -21,7 +21,8 @@ namespace BtcVerified.Consensus
 def maxMoney : Nat := 21_000_000 * 100_000_000
 
 /-- How many blocks deep a coinbase-created coin must be before it may be
-spent (Core's `COINBASE_MATURITY`, `src/consensus/consensus.h`). -/
+spent ([Bitcoin Core v28.0, `COINBASE_MATURITY`, `consensus.h` lines
+18–19](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/consensus.h#L18-L19)). -/
 def coinbaseMaturity : Nat := 100
 
 /-- The maximum total weight of a block, and the ceiling Core reuses for one
@@ -34,11 +35,13 @@ def maxBlockWeight : Nat := 4_000_000
 def witnessScaleFactor : Nat := 4
 
 /-- The lock-time axis switch: lock times below it are block heights, at or
-above it UNIX timestamps (Core's `LOCKTIME_THRESHOLD`, `src/script/script.h`). -/
+above it UNIX timestamps ([Bitcoin Core v28.0, `LOCKTIME_THRESHOLD`, `script.h`
+lines 44–46](https://github.com/bitcoin/bitcoin/blob/v28.0/src/script/script.h#L44-L46)). -/
 def lockTimeThreshold : Nat := 500_000_000
 
 /-- The sequence value that opts an input out of lock-time enforcement
-(Core's `CTxIn::SEQUENCE_FINAL`, `src/primitives/transaction.h`). -/
+([Bitcoin Core v28.0, `CTxIn::SEQUENCE_FINAL`, `transaction.h` lines
+74–87](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L74-L87)). -/
 def sequenceFinal : UInt32 := 0xffffffff
 
 end BtcVerified.Consensus

--- a/BtcVerified/Consensus/Limits.lean
+++ b/BtcVerified/Consensus/Limits.lean
@@ -25,12 +25,22 @@ spent ([Bitcoin Core v28.0, `COINBASE_MATURITY`, `consensus.h` lines
 18–19](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/consensus.h#L18-L19)). -/
 def coinbaseMaturity : Nat := 100
 
-/-- The maximum total weight of a block, and the ceiling Core reuses for one
-transaction's stripped serialization multiplied by `witnessScaleFactor`
+/-- The historical ceiling on legacy serialized size: one million bytes.
+Before SegWit, Core applied `MAX_BLOCK_SIZE` directly to each transaction's
+serialization ([Bitcoin Core v0.12.1, `main.cpp` lines
+940–946](https://github.com/bitcoin/bitcoin/blob/v0.12.1/src/main.cpp#L940-L946)),
+with the constant defined at [`consensus.h` lines
+9–10](https://github.com/bitcoin/bitcoin/blob/v0.12.1/src/consensus/consensus.h#L9-L10).
+Current Core preserves the same rule on the stripped serialization, expressed
+indirectly in weight units; `Tx.stripped_size_bound_iff_core` proves the two
+statements equivalent. -/
+def maxLegacySerializedSize : Nat := 1_000_000
+
+/-- The maximum total weight of a block under SegWit
 ([Bitcoin Core v28.0, `consensus.h` line 15](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/consensus.h#L15)). -/
 def maxBlockWeight : Nat := 4_000_000
 
-/-- The multiplier that converts a stripped byte to weight units
+/-- The scale factor in Bitcoin's weight calculation
 ([Bitcoin Core v28.0, `consensus.h` line 21](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/consensus.h#L21)). -/
 def witnessScaleFactor : Nat := 4
 

--- a/BtcVerified/Consensus/LockTime.lean
+++ b/BtcVerified/Consensus/LockTime.lean
@@ -1,0 +1,81 @@
+import BtcVerified.Consensus.Limits
+/-!
+  # Absolute transaction lock time
+
+  The consensus reading of the raw `TxBody.lockTime` wire field. The field is
+  zero when disabled; otherwise values below `lockTimeThreshold` name an
+  absolute block height and values at or above it name an absolute UNIX time
+  ([Bitcoin Core v28.0, `IsFinalTx`, `tx_verify.cpp` lines
+  17–37](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L17-L37)).
+
+  Keeping this interpretation as an algebraic data type makes the selected
+  axis structural in the reasoning model instead of repeating Core's nested
+  numeric conditional in every rule. The wire object remains `UInt32`, and
+  `LockTime.ofUInt32` is the explicit boundary between syntax and semantics.
+
+  This type describes the transaction's absolute `nLockTime`. BIP68 relative
+  lock times are a separate interpretation of each input's sequence field and
+  remain the sequence-locks leaf tracked by #46 ([Bitcoin Core v28.0,
+  `CalculateSequenceLocks`, `tx_verify.cpp` lines
+  39–109](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L39-L109)).
+-/
+
+namespace BtcVerified.Consensus
+
+/-- The semantic reading of a transaction's absolute lock-time wire field. -/
+inductive LockTime where
+  /-- Lock-time enforcement is disabled by the zero wire value. -/
+  | disabled
+  /-- The transaction is locked until strictly after this block height. -/
+  | blockHeight (height : Nat)
+  /-- The transaction is locked until strictly after this UNIX time. -/
+  | blockTime (time : Nat)
+  deriving DecidableEq
+
+/-- Interpret the raw transaction lock-time field, making its selected axis
+explicit. Relative lock times do not come from this field; #46 will interpret
+input sequence fields separately. -/
+def LockTime.ofUInt32 (value : UInt32) : LockTime :=
+  if value = 0 then
+    .disabled
+  else if value.toNat < lockTimeThreshold then
+    .blockHeight value.toNat
+  else
+    .blockTime value.toNat
+
+/-- The semantic proposition that an absolute lock time has passed at the
+given admitting height and selected measuring time. -/
+def LockTime.Past : LockTime → Nat → Nat → Prop
+  | .disabled, _, _ => True
+  | .blockHeight lockHeight, height, _ => lockHeight < height
+  | .blockTime lockTime, _, time => lockTime < time
+
+/-- Decide whether an absolute lock time has passed at the given admitting
+height and selected measuring time. -/
+def LockTime.isPast : LockTime → Nat → Nat → Bool
+  | .disabled, _, _ => true
+  | .blockHeight lockHeight, height, _ => decide (lockHeight < height)
+  | .blockTime lockTime, _, time => decide (lockTime < time)
+
+/-- The executable absolute-lock-time comparison enforces exactly its
+semantic proposition. -/
+theorem LockTime.isPast_iff {lockTime : LockTime} {height time : Nat} :
+    lockTime.isPast height time = true ↔ lockTime.Past height time := by
+  cases lockTime <;> simp [isPast, Past]
+
+/-- Interpreting the wire field and comparing its semantic value is exactly
+Core's raw zero-or-threshold conditional. This is the compatibility bridge
+from the reasoning type back to the wire-shaped statement. -/
+theorem LockTime.ofUInt32_past_iff {value : UInt32} {height time : Nat} :
+    (LockTime.ofUInt32 value).Past height time ↔
+      value = 0 ∨ value.toNat <
+        (if value.toNat < lockTimeThreshold then height else time) := by
+  unfold ofUInt32
+  by_cases hzero : value = 0
+  · simp [hzero, Past]
+  · simp only [hzero, ↓reduceIte]
+    by_cases hheight : value.toNat < lockTimeThreshold
+    · simp [hheight, Past]
+    · simp [hheight, Past]
+
+end BtcVerified.Consensus

--- a/BtcVerified/Consensus/README.md
+++ b/BtcVerified/Consensus/README.md
@@ -20,9 +20,9 @@ release-pinned source citation. Implementation-shaped transcriptions belong in
 boundary — accepted block extensions and the state transitions they produce —
 and other implementations or forks can be compared against the same object.
 Second, no premise embeds an activation height: premises take evaluation
-context (the admitting block's height, the time lock times are measured
-against), and "which rules are in force when" is an external mapping, a later
-leaf (#38). Third, an enforced premise is a runnable `Bool` checker (the
+context (the admitting block's height, block time, and median-time-past) plus
+an explicit finality-clock choice, and "which rules are in force when" is an
+external mapping, a later leaf (#38). Third, an enforced premise is a runnable `Bool` checker (the
 definition), a `Prop` specification record naming its structural content, and a
 proved equivalence between them; derived properties (conservation, the supply
 limit) are theorems only, never runtime checks.
@@ -31,12 +31,15 @@ limit) are theorems only, never runtime checks.
 
 `Limits.lean` holds the numeric constants (`maxMoney`, `coinbaseMaturity`,
 `maxBlockWeight`, `witnessScaleFactor`, `lockTimeThreshold`,
-`sequenceFinal`), each citing its Core counterpart.
-`TxContext.lean` is the evaluation context — height and measuring time;
-BIP113 changed which clock Core passes without changing `IsFinalTx`
+`sequenceFinal`), each citing its Core counterpart. `LockTime.lean` interprets
+the raw transaction lock-time field as disabled, an absolute block height, or
+an absolute time; BIP68 relative locks remain the separate sequence-field leaf
+#46. `TxContext.lean` carries the admitting height plus separately named block
+time and median-time-past values. `FinalityClock` selects which one measures
+absolute time locks: BIP113 changed that choice without changing `IsFinalTx`
 ([Bitcoin Core v28.0, `validation.cpp` lines
 4224–4238](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L4224-L4238)),
-so the clock choice belongs to the activation layer. `ScriptCheck.lean` is the
+so #38's ruleset mapping owns the explicit clock choice. `ScriptCheck.lean` is the
 script-validity parameter: no formal script model exists yet, so these
 premises take an abstract judgment over (all spent coins, input index,
 spending transaction) — wide in the coin list because taproot signature

--- a/BtcVerified/Consensus/README.md
+++ b/BtcVerified/Consensus/README.md
@@ -66,12 +66,14 @@ regular transactions judged here.
 `TxContextual.lean`: what a regular transaction must satisfy relative to the
 UTXO set and the admitting block — Core's `Consensus::CheckTxInputs` and
 `IsFinalTx`, script validity as the parameter, plus `creates_absent`: no
-created outpoint may currently hold an unspent coin. That last rule is
-BIP30's content in current-state vocabulary — recreating a fully-spent
-outpoint stays legal; the two 2010 duplicate-coinbase blocks and Core's
-post-BIP34 skip of the scan are activation history (#38/#39), not rule
-content. BIP68 relative lock times need median-time-past history no leaf
-provides yet and are deferred.
+created outpoint may currently hold an unspent coin. Input value and fee
+retain Core's explicit `MoneyRange` checks over arbitrary UTXO sets; #50
+tracks proving them redundant on reachable states once #37 supplies the
+supply invariant. The no-overwrite rule is BIP30's content in current-state
+vocabulary — recreating a fully-spent outpoint stays legal; the two 2010
+duplicate-coinbase blocks and Core's post-BIP34 skip of the scan are
+activation history (#38/#39), not rule content. BIP68 relative lock times
+need median-time-past history no leaf provides yet and are deferred.
 
 Checked claims:
 
@@ -84,9 +86,10 @@ Checked claims:
 - `Tx.spentCoins_length`: under the existence rule, the spent-coin list
   aligns with the inputs — one coin per input, in order.
 - `Tx.isAdmissible_iff`: the contextual checker accepts exactly when inputs
-  exist, coinbase spends are mature, inputs cover outputs, the transaction
-  is final, no created outpoint is currently unspent, and every input passes
-  the script judgment.
+  exist, coinbase spends are mature, cumulative input value and fee remain
+  within `maxMoney`, inputs cover outputs, the transaction is final, no
+  created outpoint is currently unspent, and every input passes the script
+  judgment.
 
 Why it matters: the specification record's fields are, by construction,
 the hypotheses of the machine's action theorems — the rules are stated in

--- a/BtcVerified/Consensus/README.md
+++ b/BtcVerified/Consensus/README.md
@@ -1,0 +1,115 @@
+# BtcVerified/Consensus
+
+The rules layer: the central, legible statement of what Bitcoin consensus
+demands, stated over the `Chainstate/` machine and never inside it (rules
+import the machine; the machine never imports rules). Rules separate along
+two axes — what they judge (transactions vs blocks) and what they need
+(nothing beyond the object vs chain state and position). This directory
+currently fills the two transaction buckets; block rules are next (#37).
+
+Three disciplines hold everywhere. Every rule corresponds 1:1 to a check in
+Bitcoin Core's consensus module and its doc-string says which; the *checkers*
+are stated at whatever level of abstraction reads best, with equivalence to
+Core's literal control flow left to `Impl/` transcriptions if ever wanted.
+No rule embeds an activation height — rules take evaluation context (the
+admitting block's height, the time lock times are measured against), and
+"which rules are in force when" is an external mapping, a later leaf (#38).
+An enforced rule is a runnable `Bool` checker (the definition), a `Prop`
+specification record naming its structural content, and a proved equivalence
+between them; derived properties (conservation, the supply limit) are
+theorems only, never runtime checks.
+
+## The shape of a rule
+
+`Limits.lean` holds the numeric constants (`maxMoney`, `coinbaseMaturity`,
+`lockTimeThreshold`, `sequenceFinal`), each citing its Core counterpart.
+`TxContext.lean` is the evaluation context — height and measuring time;
+BIP113 changed which clock Core passes without changing any rule, so the
+clock choice belongs to the activation layer. `ScriptCheck.lean` is the
+script-validity parameter: consensus does not execute scripts yet, so the
+rules take a judgment over (all spent coins, input index, spending
+transaction) — wide in the coin list because taproot signature hashes commit
+to every spent output — with widening combinators (`ofCoinFree`,
+`ofPerInput`) so narrower judgments are stated at their natural scope.
+
+## Stateless transaction rules
+
+`TxStateless.lean`: what a regular transaction must satisfy before any chain
+state is consulted — Core's `CheckTransaction`. Empty inputs need no rule
+(the transaction type cannot represent them), negative amounts are
+unrepresentable, and in `Nat` one total-value bound subsumes Core's
+per-output and running-total `MoneyRange` checks; oversize and the coinbase's
+structural checks are block rules (#37).
+
+Checked claims:
+
+- `Tx.isWellFormed_iff`: the stateless checker accepts a transaction exactly
+  when some output exists, no outpoint is spent twice, no input claims the
+  null outpoint, and the outputs create at most `maxMoney` satoshis.
+- `Tx.body_inputs_ne_nil` (with the `Tx` type): every transaction has at
+  least one input — Core's empty-`vin` check as a type invariant.
+
+Why it matters: these are the rules a block validator runs on every
+transaction before it ever reads the UTXO set, and the null-outpoint rule is
+what separates the coinbase (judged positionally, by block rules) from the
+regular transactions judged here.
+
+## Contextual transaction rules
+
+`TxContextual.lean`: what a regular transaction must satisfy relative to the
+UTXO set and the admitting block — Core's `Consensus::CheckTxInputs` and
+`IsFinalTx`, script validity as the parameter, plus `creates_absent`: no
+created outpoint may currently hold an unspent coin. That last rule is
+BIP30's content in current-state vocabulary — recreating a fully-spent
+outpoint stays legal; the two 2010 duplicate-coinbase blocks and Core's
+post-BIP34 skip of the scan are activation history (#38/#39), not rule
+content. BIP68 relative lock times need median-time-past history no leaf
+provides yet and are deferred.
+
+Checked claims:
+
+- `Coin.isMature_iff`: the maturity checker accepts a coin at a height
+  exactly when it is non-coinbase or at least `coinbaseMaturity` blocks
+  deep.
+- `TxBody.isFinal_iff`: the finality checker accepts exactly when the lock
+  time is zero, already past on the axis it selects, or overridden by every
+  input carrying the final sequence.
+- `Tx.spentCoins_length`: under the existence rule, the spent-coin list
+  aligns with the inputs — one coin per input, in order.
+- `Tx.isAdmissible_iff`: the contextual checker accepts exactly when inputs
+  exist, coinbase spends are mature, inputs cover outputs, the transaction
+  is final, no created outpoint is currently unspent, and every input passes
+  the script judgment.
+
+Why it matters: the specification record's fields are, by construction,
+the hypotheses of the machine's action theorems — the rules are stated in
+exactly the vocabulary the ledger accounting consumes.
+
+## Guarded application
+
+`ApplyChecked.lean`: where rules meet machine. The discharge lemma converts
+a rule-passing transaction's guarantees into the action theorems'
+hypotheses, the gated conservation theorems specialize the accounting
+identity with everything discharged (the output-count bound arrives with the
+block-size rule, #37), and `applyChecked` is the strict rules-then-act
+interface. Fees are not spec objects: conservation is the accounting
+identity, and "the total drops by exactly the fee" is its English reading.
+
+Checked claims:
+
+- `Tx.creates_absent_spend`: a rule-passing transaction's created outpoints
+  are absent even after its spends are erased.
+- `UtxoSet.totalValue_apply_of_admissible`: for a rule-passing transaction,
+  total value after plus value spent equals total value before plus value
+  created.
+- `UtxoSet.totalValue_apply_le_of_admissible`: a rule-passing transaction
+  never increases the total value the set holds.
+- `UtxoSet.applyChecked_eq_some_iff`: the strict interface succeeds on
+  exactly the rule-passing transactions and then agrees with the guard-free
+  action.
+
+Why it matters: this is the per-transaction step the block fold (#37)
+iterates. The delta invariant — a block grows the total by at most the
+subsidy — and from it the 21-million supply bound are inductions over
+exactly these theorems, and the ruleset mapping (#38) attaches exactly these
+rules to heights.

--- a/BtcVerified/Consensus/README.md
+++ b/BtcVerified/Consensus/README.md
@@ -30,7 +30,7 @@ limit) are theorems only, never runtime checks.
 ## The shape of a rule
 
 `Limits.lean` holds the numeric constants (`maxMoney`, `coinbaseMaturity`,
-`maxBlockWeight`, `witnessScaleFactor`, `lockTimeThreshold`,
+`maxLegacySerializedSize`, `maxBlockWeight`, `witnessScaleFactor`, `lockTimeThreshold`,
 `sequenceFinal`), each citing its Core counterpart. `LockTime.lean` interprets
 the raw transaction lock-time field as disabled, an absolute block height, or
 an absolute time; BIP68 relative locks remain the separate sequence-field leaf
@@ -61,16 +61,20 @@ empty-input/output object Core's witness-aware decoder accepts
 220–252](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L220-L252)).
 Negative amounts remain unrepresentable, and in `Nat` one total-value bound
 subsumes Core's per-output and running-total `MoneyRange` checks. The
-stripped-size ceiling is also a transaction-local rule: although Core expresses
-it in block-weight units, it reads only the transaction. The coinbase's
+legacy one-million-byte stripped-size ceiling is also a transaction-local
+rule. Current Core expresses the equivalent predicate in block-weight units;
+`Tx.stripped_size_bound_iff_core` records that implementation correspondence
+without making the semantic rule depend on SegWit constants. The coinbase's
 positional structural checks remain block rules (#37).
 
 Checked claims:
 
+- `Tx.stripped_size_bound_iff_core`: the semantic legacy serialized-size
+  bound is exactly equivalent to Core v28's weight-unit expression.
 - `Tx.isWellFormed_iff`: the stateless checker accepts a transaction exactly
   when some input and output exist, no outpoint is spent twice, no input claims
   the null outpoint, the outputs create at most `maxMoney` satoshis, and the
-  stripped serialization fits within the per-transaction weight ceiling.
+  stripped serialization fits within the legacy one-million-byte ceiling.
 - `Tx.WellFormed.outputs_length_le`: that stripped-size rule implies every
   accepted transaction has at most `2 ^ 32` outputs, so its `UInt32` output
   indices cannot wrap.

--- a/BtcVerified/Consensus/README.md
+++ b/BtcVerified/Consensus/README.md
@@ -11,17 +11,21 @@ chain state and position). This directory currently supplies the reusable
 transaction premises and regular-transaction transition step; the block fold
 that composes them into extension validity is next (#37).
 
-Three disciplines hold everywhere. Every rule corresponds 1:1 to a check in
-Bitcoin Core's consensus module and its doc-string says which; the *checkers*
-are stated at whatever level of abstraction reads best, with equivalence to
-Core's literal control flow left to `Impl/` transcriptions if ever wanted.
-No premise embeds an activation height — premises take evaluation context (the
-admitting block's height, the time lock times are measured against), and
-"which rules are in force when" is an external mapping, a later leaf (#38).
-An enforced premise is a runnable `Bool` checker (the definition), a `Prop`
-specification record naming its structural content, and a proved equivalence
-between them; derived properties (conservation, the supply limit) are
-theorems only, never runtime checks.
+Three disciplines hold everywhere. First, this is an abstract reasoning model:
+its rules are factored to make protocol behavior and Bitcoin-level theorems
+legible, not to reproduce Core's C++ control flow definitionally. Core strongly
+influences the initial boundaries, and every claim about its behavior carries a
+release-pinned source citation. Implementation-shaped transcriptions belong in
+`Impl/`, where they can be proved equivalent to this model at the observable
+boundary — accepted block extensions and the state transitions they produce —
+and other implementations or forks can be compared against the same object.
+Second, no premise embeds an activation height: premises take evaluation
+context (the admitting block's height, the time lock times are measured
+against), and "which rules are in force when" is an external mapping, a later
+leaf (#38). Third, an enforced premise is a runnable `Bool` checker (the
+definition), a `Prop` specification record naming its structural content, and a
+proved equivalence between them; derived properties (conservation, the supply
+limit) are theorems only, never runtime checks.
 
 ## The shape of a rule
 
@@ -29,8 +33,10 @@ theorems only, never runtime checks.
 `maxBlockWeight`, `witnessScaleFactor`, `lockTimeThreshold`,
 `sequenceFinal`), each citing its Core counterpart.
 `TxContext.lean` is the evaluation context — height and measuring time;
-BIP113 changed which clock Core passes without changing any rule, so the
-clock choice belongs to the activation layer. `ScriptCheck.lean` is the
+BIP113 changed which clock Core passes without changing `IsFinalTx`
+([Bitcoin Core v28.0, `validation.cpp` lines
+4224–4238](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L4224-L4238)),
+so the clock choice belongs to the activation layer. `ScriptCheck.lean` is the
 script-validity parameter: no formal script model exists yet, so these
 premises take an abstract judgment over (all spent coins, input index,
 spending transaction) — wide in the coin list because taproot signature
@@ -43,26 +49,28 @@ indexed interface is backed by a pointwise alignment theorem.
 ## Transaction-local premises
 
 `TxStateless.lean`: what a regular transaction must satisfy before any chain
-state is consulted — Core's `CheckTransaction`. Empty inputs need no rule
-(the transaction type cannot represent them), negative amounts are
-unrepresentable, and in `Nat` one total-value bound subsumes Core's
-per-output and running-total `MoneyRange` checks. The stripped-size ceiling is
-also a transaction-local rule: although Core expresses it in block-weight
-units, it reads only the transaction. The coinbase's positional structural
-checks remain block rules (#37).
+state is consulted — Core's [`CheckTransaction`, Bitcoin Core v28.0,
+`tx_check.cpp` lines
+11–59](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L11-L59).
+Empty inputs are an explicit premise: the syntax now admits the degenerate
+empty-input/output object Core's witness-aware decoder accepts
+([`transaction.h` lines
+220–252](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L220-L252)).
+Negative amounts remain unrepresentable, and in `Nat` one total-value bound
+subsumes Core's per-output and running-total `MoneyRange` checks. The
+stripped-size ceiling is also a transaction-local rule: although Core expresses
+it in block-weight units, it reads only the transaction. The coinbase's
+positional structural checks remain block rules (#37).
 
 Checked claims:
 
 - `Tx.isWellFormed_iff`: the stateless checker accepts a transaction exactly
-  when some output exists, no outpoint is spent twice, no input claims the
-  null outpoint, the outputs create at most `maxMoney` satoshis, and the
+  when some input and output exist, no outpoint is spent twice, no input claims
+  the null outpoint, the outputs create at most `maxMoney` satoshis, and the
   stripped serialization fits within the per-transaction weight ceiling.
 - `Tx.WellFormed.outputs_length_le`: that stripped-size rule implies every
   accepted transaction has at most `2 ^ 32` outputs, so its `UInt32` output
   indices cannot wrap.
-- `Tx.body_inputs_ne_nil` (with the `Tx` type): every transaction has at
-  least one input — Core's empty-`vin` check as a type invariant.
-
 Why it matters: these are reusable premises a block validator establishes for
 every transaction before it ever reads the UTXO set, and the null-outpoint
 rule is what separates the coinbase (judged positionally, by block rules) from
@@ -71,17 +79,26 @@ the regular transactions judged here.
 ## Contextual transaction premises
 
 `TxContextual.lean`: what a regular transaction must satisfy relative to the
-UTXO set and the admitting block — Core's `Consensus::CheckTxInputs` and
-`IsFinalTx`, script validity as the parameter, plus
+UTXO set and the admitting block — Core's [`Consensus::CheckTxInputs`, Bitcoin
+Core v28.0, `tx_verify.cpp` lines
+164–204](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L164-L204)
+and [`IsFinalTx`, lines
+17–37](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L17-L37),
+script validity as the parameter, plus
 `creates_do_not_overwrite`: no created outpoint may currently hold an unspent
 coin. Input value and fee retain Core's explicit `MoneyRange` checks over
-arbitrary UTXO sets; #50
+arbitrary UTXO sets ([Bitcoin Core v28.0, `tx_verify.cpp` lines
+184–200](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L184-L200)); #50
 tracks proving them redundant on reachable states once #37 supplies the
 supply invariant. The no-overwrite rule is BIP30's content in current-state
 vocabulary — recreating a fully-spent outpoint stays legal; the two 2010
-duplicate-coinbase blocks and Core's post-BIP34 skip of the scan are
-activation history (#38/#39), not rule content. BIP68 relative lock times
-need median-time-past history no leaf provides yet and are deferred.
+duplicate-coinbase blocks and Core's post-BIP34 skip of the scan are activation
+history ([Bitcoin Core v28.0, `validation.cpp` lines
+2495–2575](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L2495-L2575))
+(#38/#39), not rule content. BIP68 relative lock times need median-time-past
+history no leaf provides yet and are deferred ([Bitcoin Core v28.0,
+`tx_verify.cpp` lines
+39–109](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L39-L109)).
 
 Checked claims:
 

--- a/BtcVerified/Consensus/README.md
+++ b/BtcVerified/Consensus/README.md
@@ -21,7 +21,7 @@ boundary — accepted block extensions and the state transitions they produce �
 and other implementations or forks can be compared against the same object.
 Second, no premise embeds an activation height: premises take evaluation
 context (the admitting block's height, block time, and median-time-past) plus
-an explicit finality-clock choice, and "which rules are in force when" is an
+an explicit lock-time-clock choice, and "which rules are in force when" is an
 external mapping, a later leaf (#38). Third, an enforced premise is a runnable `Bool` checker (the
 definition), a `Prop` specification record naming its structural content, and a
 proved equivalence between them; derived properties (conservation, the supply
@@ -35,7 +35,7 @@ limit) are theorems only, never runtime checks.
 the raw transaction lock-time field as disabled, an absolute block height, or
 an absolute time; BIP68 relative locks remain the separate sequence-field leaf
 #46. `TxContext.lean` carries the admitting height plus separately named block
-time and median-time-past values. `FinalityClock` selects which one measures
+time and median-time-past values. `LockTimeClock` selects which one measures
 absolute time locks: BIP113 changed that choice without changing `IsFinalTx`
 ([Bitcoin Core v28.0, `validation.cpp` lines
 4224–4238](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L4224-L4238)),
@@ -112,17 +112,17 @@ Checked claims:
 - `Coin.isMature_iff`: the maturity checker accepts a coin at a height
   exactly when it is non-coinbase or at least `coinbaseMaturity` blocks
   deep.
-- `TxBody.isFinal_iff`: the finality checker accepts exactly when the lock
-  time is zero, already past on the axis it selects, or overridden by every
-  input carrying the final sequence.
+- `TxBody.isLockTimeSatisfied_iff`: the absolute lock-time checker accepts
+  exactly when the lock is disabled, already past on its selected axis, or
+  overridden by every input carrying `sequenceFinal`.
 - `Tx.spentCoins_aligned`: under the existence premise, each spent coin is
   exactly the lookup of the outpoint named by the corresponding input.
 - `Tx.spentCoins_length`: the aligned input and coin lists have equal length.
 - `Tx.isAdmissible_iff`: the contextual checker accepts exactly when inputs
   exist, coinbase spends are mature, cumulative input value and fee remain
-  within `maxMoney`, inputs cover outputs, the transaction is final, no
-  created outpoint is currently unspent, and every input passes the script
-  judgment.
+  within `maxMoney`, inputs cover outputs, the absolute lock-time condition is
+  satisfied, no created outpoint is currently unspent, and every input passes
+  the script judgment.
 
 Why it matters: the specification record's fields are, by construction, the
 hypotheses of the machine's action theorems. They are the contextual premises

--- a/BtcVerified/Consensus/README.md
+++ b/BtcVerified/Consensus/README.md
@@ -22,7 +22,8 @@ theorems only, never runtime checks.
 ## The shape of a rule
 
 `Limits.lean` holds the numeric constants (`maxMoney`, `coinbaseMaturity`,
-`lockTimeThreshold`, `sequenceFinal`), each citing its Core counterpart.
+`maxBlockWeight`, `witnessScaleFactor`, `lockTimeThreshold`,
+`sequenceFinal`), each citing its Core counterpart.
 `TxContext.lean` is the evaluation context — height and measuring time;
 BIP113 changed which clock Core passes without changing any rule, so the
 clock choice belongs to the activation layer. `ScriptCheck.lean` is the
@@ -38,14 +39,20 @@ to every spent output — with widening combinators (`ofCoinFree`,
 state is consulted — Core's `CheckTransaction`. Empty inputs need no rule
 (the transaction type cannot represent them), negative amounts are
 unrepresentable, and in `Nat` one total-value bound subsumes Core's
-per-output and running-total `MoneyRange` checks; oversize and the coinbase's
-structural checks are block rules (#37).
+per-output and running-total `MoneyRange` checks. The stripped-size ceiling is
+also a transaction-local rule: although Core expresses it in block-weight
+units, it reads only the transaction. The coinbase's positional structural
+checks remain block rules (#37).
 
 Checked claims:
 
 - `Tx.isWellFormed_iff`: the stateless checker accepts a transaction exactly
   when some output exists, no outpoint is spent twice, no input claims the
-  null outpoint, and the outputs create at most `maxMoney` satoshis.
+  null outpoint, the outputs create at most `maxMoney` satoshis, and the
+  stripped serialization fits within the per-transaction weight ceiling.
+- `Tx.WellFormed.outputs_length_le`: that stripped-size rule implies every
+  accepted transaction has at most `2 ^ 32` outputs, so its `UInt32` output
+  indices cannot wrap.
 - `Tx.body_inputs_ne_nil` (with the `Tx` type): every transaction has at
   least one input — Core's empty-`vin` check as a type invariant.
 
@@ -90,10 +97,10 @@ exactly the vocabulary the ledger accounting consumes.
 `ApplyChecked.lean`: where rules meet machine. The discharge lemma converts
 a rule-passing transaction's guarantees into the action theorems'
 hypotheses, the gated conservation theorems specialize the accounting
-identity with everything discharged (the output-count bound arrives with the
-block-size rule, #37), and `applyChecked` is the strict rules-then-act
-interface. Fees are not spec objects: conservation is the accounting
-identity, and "the total drops by exactly the fee" is its English reading.
+identity with every root-level transaction property discharged, and
+`applyChecked` is the strict rules-then-act interface. Fees are not spec
+objects: conservation is the accounting identity, and "the total drops by
+exactly the fee" is its English reading.
 
 Checked claims:
 

--- a/BtcVerified/Consensus/README.md
+++ b/BtcVerified/Consensus/README.md
@@ -2,19 +2,23 @@
 
 The rules layer: the central, legible statement of what Bitcoin consensus
 demands, stated over the `Chainstate/` machine and never inside it (rules
-import the machine; the machine never imports rules). Rules separate along
-two axes — what they judge (transactions vs blocks) and what they need
-(nothing beyond the object vs chain state and position). This directory
-currently fills the two transaction buckets; block rules are next (#37).
+import the machine; the machine never imports rules). The root consensus
+judgment is whether a candidate block extends a parent-chain state under the
+active ruleset, not whether a transaction is valid in isolation. Rules
+therefore separate along two axes — their scope (transaction-local premises
+vs block-wide conditions) and what they need (nothing beyond the object vs
+chain state and position). This directory currently supplies the reusable
+transaction premises and regular-transaction transition step; the block fold
+that composes them into extension validity is next (#37).
 
 Three disciplines hold everywhere. Every rule corresponds 1:1 to a check in
 Bitcoin Core's consensus module and its doc-string says which; the *checkers*
 are stated at whatever level of abstraction reads best, with equivalence to
 Core's literal control flow left to `Impl/` transcriptions if ever wanted.
-No rule embeds an activation height — rules take evaluation context (the
+No premise embeds an activation height — premises take evaluation context (the
 admitting block's height, the time lock times are measured against), and
 "which rules are in force when" is an external mapping, a later leaf (#38).
-An enforced rule is a runnable `Bool` checker (the definition), a `Prop`
+An enforced premise is a runnable `Bool` checker (the definition), a `Prop`
 specification record naming its structural content, and a proved equivalence
 between them; derived properties (conservation, the supply limit) are
 theorems only, never runtime checks.
@@ -27,13 +31,16 @@ theorems only, never runtime checks.
 `TxContext.lean` is the evaluation context — height and measuring time;
 BIP113 changed which clock Core passes without changing any rule, so the
 clock choice belongs to the activation layer. `ScriptCheck.lean` is the
-script-validity parameter: consensus does not execute scripts yet, so the
-rules take a judgment over (all spent coins, input index, spending
-transaction) — wide in the coin list because taproot signature hashes commit
-to every spent output — with widening combinators (`ofCoinFree`,
-`ofPerInput`) so narrower judgments are stated at their natural scope.
+script-validity parameter: no formal script model exists yet, so these
+premises take an abstract judgment over (all spent coins, input index,
+spending transaction) — wide in the coin list because taproot signature
+hashes commit to every spent output — with widening combinators (`ofCoinFree`,
+`ofPerInput`) so narrower judgments are stated at their natural scope. A
+zipper or other focus-by-construction API is deliberately deferred until the
+script model can determine the interface it actually needs; the current
+indexed interface is backed by a pointwise alignment theorem.
 
-## Stateless transaction rules
+## Transaction-local premises
 
 `TxStateless.lean`: what a regular transaction must satisfy before any chain
 state is consulted — Core's `CheckTransaction`. Empty inputs need no rule
@@ -56,18 +63,19 @@ Checked claims:
 - `Tx.body_inputs_ne_nil` (with the `Tx` type): every transaction has at
   least one input — Core's empty-`vin` check as a type invariant.
 
-Why it matters: these are the rules a block validator runs on every
-transaction before it ever reads the UTXO set, and the null-outpoint rule is
-what separates the coinbase (judged positionally, by block rules) from the
-regular transactions judged here.
+Why it matters: these are reusable premises a block validator establishes for
+every transaction before it ever reads the UTXO set, and the null-outpoint
+rule is what separates the coinbase (judged positionally, by block rules) from
+the regular transactions judged here.
 
-## Contextual transaction rules
+## Contextual transaction premises
 
 `TxContextual.lean`: what a regular transaction must satisfy relative to the
 UTXO set and the admitting block — Core's `Consensus::CheckTxInputs` and
-`IsFinalTx`, script validity as the parameter, plus `creates_absent`: no
-created outpoint may currently hold an unspent coin. Input value and fee
-retain Core's explicit `MoneyRange` checks over arbitrary UTXO sets; #50
+`IsFinalTx`, script validity as the parameter, plus
+`creates_do_not_overwrite`: no created outpoint may currently hold an unspent
+coin. Input value and fee retain Core's explicit `MoneyRange` checks over
+arbitrary UTXO sets; #50
 tracks proving them redundant on reachable states once #37 supplies the
 supply invariant. The no-overwrite rule is BIP30's content in current-state
 vocabulary — recreating a fully-spent outpoint stays legal; the two 2010
@@ -83,40 +91,44 @@ Checked claims:
 - `TxBody.isFinal_iff`: the finality checker accepts exactly when the lock
   time is zero, already past on the axis it selects, or overridden by every
   input carrying the final sequence.
-- `Tx.spentCoins_length`: under the existence rule, the spent-coin list
-  aligns with the inputs — one coin per input, in order.
+- `Tx.spentCoins_aligned`: under the existence premise, each spent coin is
+  exactly the lookup of the outpoint named by the corresponding input.
+- `Tx.spentCoins_length`: the aligned input and coin lists have equal length.
 - `Tx.isAdmissible_iff`: the contextual checker accepts exactly when inputs
   exist, coinbase spends are mature, cumulative input value and fee remain
   within `maxMoney`, inputs cover outputs, the transaction is final, no
   created outpoint is currently unspent, and every input passes the script
   judgment.
 
-Why it matters: the specification record's fields are, by construction,
-the hypotheses of the machine's action theorems — the rules are stated in
-exactly the vocabulary the ledger accounting consumes.
+Why it matters: the specification record's fields are, by construction, the
+hypotheses of the machine's action theorems. They are the contextual premises
+the block fold consumes, stated in exactly the vocabulary the ledger
+accounting uses.
 
-## Guarded application
+## Guarded regular-transaction step
 
-`ApplyChecked.lean`: where rules meet machine. The discharge lemma converts
-a rule-passing transaction's guarantees into the action theorems'
+`ApplyChecked.lean`: where transaction premises meet the machine. The
+discharge lemma converts an admissible transaction's guarantees into the
+action theorems'
 hypotheses, the gated conservation theorems specialize the accounting
-identity with every root-level transaction property discharged, and
-`applyChecked` is the strict rules-then-act interface. Fees are not spec
-objects: conservation is the accounting identity, and "the total drops by
-exactly the fee" is its English reading.
+identity with every local machine obligation discharged, and `applyChecked`
+is the internal regular-transaction step that #37's block fold will iterate.
+It is not a root consensus interface: only the complete fold, coinbase
+epilogue, and block-wide premises establish a valid extension. Fees are not
+spec objects: conservation is the accounting identity, and "the total drops
+by exactly the fee" is its English reading.
 
 Checked claims:
 
-- `Tx.creates_absent_spend`: a rule-passing transaction's created outpoints
-  are absent even after its spends are erased.
-- `UtxoSet.totalValue_apply_of_admissible`: for a rule-passing transaction,
+- `Tx.creates_do_not_overwrite_after_spend`: an admissible transaction's
+  created outpoints remain fresh after its spends are erased.
+- `UtxoSet.totalValue_apply_of_admissible`: for a premise-passing transaction,
   total value after plus value spent equals total value before plus value
   created.
-- `UtxoSet.totalValue_apply_le_of_admissible`: a rule-passing transaction
+- `UtxoSet.totalValue_apply_le_of_admissible`: a premise-passing transaction
   never increases the total value the set holds.
-- `UtxoSet.applyChecked_eq_some_iff`: the strict interface succeeds on
-  exactly the rule-passing transactions and then agrees with the guard-free
-  action.
+- `UtxoSet.applyChecked_eq_some_iff`: the internal step succeeds exactly when
+  its transaction premises hold and then agrees with the guard-free action.
 
 Why it matters: this is the per-transaction step the block fold (#37)
 iterates. The delta invariant — a block grows the total by at most the

--- a/BtcVerified/Consensus/ScriptCheck.lean
+++ b/BtcVerified/Consensus/ScriptCheck.lean
@@ -11,13 +11,16 @@ import BtcVerified.Chainstate.Coin
 
   The judgment sees all the coins the transaction spends (in input order),
   the index of the input under judgment, and the spending transaction. The
-  coin list is that wide because BIP341 (taproot) signature hashes commit to
-  *every* spent output's amount and script, so a taproot-capable judgment
-  needs them all. Narrower judgments — legacy signature hashes read no coin
-  data at all; BIP143 reads only its own input's amount — are stated at
-  their natural scope and embedded here by the widening combinators, with
-  the `Tx` argument last so widening is argument-prepending, never
-  reshuffling.
+  coin list is that wide because Core's BIP341 path precomputes every spent
+  output's amount and script ([Bitcoin Core v28.0, `interpreter.cpp` lines
+  1398–1445](https://github.com/bitcoin/bitcoin/blob/v28.0/src/script/interpreter.cpp#L1398-L1445)),
+  so a taproot-capable judgment needs them all. Narrower judgments — Core's
+  legacy signature-hash branch reads no coin data, while its BIP143 branch
+  serializes only the current input's amount ([`interpreter.cpp` lines
+  1568–1607](https://github.com/bitcoin/bitcoin/blob/v28.0/src/script/interpreter.cpp#L1568-L1607))
+  — are stated at their natural scope and embedded here by the widening
+  combinators, with the `Tx` argument last so widening is argument-prepending,
+  never reshuffling.
 
   This module ships the type and the combinators only; no formal script
   judgment exists yet. A zipper or other focus-by-construction interface is
@@ -36,13 +39,17 @@ spends. -/
 abbrev ScriptCheck := List Coin → Nat → Tx → Bool
 
 /-- Widen a judgment that never reads the spent coins (a legacy signature
-hash reads no coin data) by prepending the dropped argument. -/
+hash reads no coin data; [Bitcoin Core v28.0, `interpreter.cpp` lines
+1568–1620](https://github.com/bitcoin/bitcoin/blob/v28.0/src/script/interpreter.cpp#L1568-L1620))
+by prepending the dropped argument. -/
 def ScriptCheck.ofCoinFree (f : Nat → Tx → Bool) : ScriptCheck :=
   fun _ => f
 
 /-- Widen a judgment that reads only its own input's coin (BIP143 commits to
-the input's own amount alone) by selecting coin `i` from the list; an input
-whose coin is missing fails the judgment. -/
+the input's own amount alone; [Bitcoin Core v28.0, `interpreter.cpp` lines
+1595–1607](https://github.com/bitcoin/bitcoin/blob/v28.0/src/script/interpreter.cpp#L1595-L1607))
+by selecting coin `i` from the list; an input whose coin is missing fails the
+judgment. -/
 def ScriptCheck.ofPerInput (f : Coin → Nat → Tx → Bool) : ScriptCheck :=
   fun coins i tx => ((coins[i]?).map fun coin => f coin i tx).getD false
 

--- a/BtcVerified/Consensus/ScriptCheck.lean
+++ b/BtcVerified/Consensus/ScriptCheck.lean
@@ -1,0 +1,45 @@
+import BtcVerified.Transaction.Tx
+import BtcVerified.Chainstate.Coin
+/-!
+  # The script-validity parameter
+
+  The consensus layer does not execute scripts — tokenization and execution
+  are a later layer — so the transaction rules take script validity as a
+  parameter: a judgment that decides, for one input of a spending
+  transaction, whether its unlocking data satisfies the spent output's
+  script.
+
+  The judgment sees all the coins the transaction spends (in input order),
+  the index of the input under judgment, and the spending transaction. The
+  coin list is that wide because BIP341 (taproot) signature hashes commit to
+  *every* spent output's amount and script, so a taproot-capable judgment
+  needs them all. Narrower judgments — legacy signature hashes read no coin
+  data at all; BIP143 reads only its own input's amount — are stated at
+  their natural scope and embedded here by the widening combinators, with
+  the `Tx` argument last so widening is argument-prepending, never
+  reshuffling.
+
+  This module ships the type and the combinators only; actual judgments
+  arrive with the script layer.
+-/
+
+namespace BtcVerified
+
+/-- Judge one input's unlocking data: given all coins the transaction spends
+(in input order), the index of the input under judgment, and the spending
+transaction, decide whether that input satisfies the script of the output it
+spends. -/
+abbrev ScriptCheck := List Coin → Nat → Tx → Bool
+
+/-- Widen a judgment that never reads the spent coins (a legacy signature
+hash reads no coin data) by prepending the dropped argument. -/
+def ScriptCheck.ofCoinFree (f : Nat → Tx → Bool) : ScriptCheck :=
+  fun _ => f
+
+/-- Widen a judgment that reads only its own input's coin (BIP143 commits to
+the input's own amount alone) by selecting coin `i` from the list; an input
+whose coin is missing fails the judgment. -/
+def ScriptCheck.ofPerInput (f : Coin → Nat → Tx → Bool) : ScriptCheck :=
+  fun coins i tx => ((coins[i]?).map fun coin => f coin i tx).getD false
+
+end BtcVerified

--- a/BtcVerified/Consensus/ScriptCheck.lean
+++ b/BtcVerified/Consensus/ScriptCheck.lean
@@ -19,8 +19,12 @@ import BtcVerified.Chainstate.Coin
   the `Tx` argument last so widening is argument-prepending, never
   reshuffling.
 
-  This module ships the type and the combinators only; actual judgments
-  arrive with the script layer.
+  This module ships the type and the combinators only; no formal script
+  judgment exists yet. A zipper or other focus-by-construction interface is
+  therefore deliberately deferred until the script model can determine the
+  interface it actually needs. For the present indexed parameter,
+  `Tx.spentCoins_aligned` proves that the coin at each checked index is the
+  lookup of the corresponding input's outpoint.
 -/
 
 namespace BtcVerified

--- a/BtcVerified/Consensus/TxContext.lean
+++ b/BtcVerified/Consensus/TxContext.lean
@@ -8,23 +8,23 @@
   values to decide *this* transaction *here*; "which rules are in force at
   this height" is the ruleset mapping's business (#38).
 
-  `FinalityClock` names the choice BIP113 changed: Core supplies the block's
+  `LockTimeClock` names the choice BIP113 changed: Core supplies the block's
   own timestamp before activation and the preceding block's median-time-past
   after it, without changing `IsFinalTx` itself ([Bitcoin Core v28.0,
   `validation.cpp` lines 4224–4238](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L4224-L4238)).
   Both values remain present and named in `TxContext`; the ruleset chooses a
-  `FinalityClock` explicitly instead of hiding that activation-sensitive
+  `LockTimeClock` explicitly instead of hiding that activation-sensitive
   decision in an overloaded caller-filled `time` field.
 -/
 
 namespace BtcVerified
 
-/-- Which named time in `TxContext` measures absolute transaction finality.
+/-- Which named time in `TxContext` measures an absolute transaction lock.
 The height-indexed ruleset in #38 chooses between these cases. -/
-inductive FinalityClock where
-  /-- Pre-BIP113 finality uses the admitting block's header time. -/
+inductive LockTimeClock where
+  /-- Pre-BIP113 absolute time locks use the admitting block's header time. -/
   | blockTime
-  /-- Post-BIP113 finality uses the preceding block's median-time-past. -/
+  /-- Post-BIP113 absolute time locks use the preceding block's MTP. -/
   | medianTimePast
   deriving DecidableEq
 
@@ -35,18 +35,18 @@ structure TxContext where
   [`CheckTxInputs`, Bitcoin Core v28.0, `tx_verify.cpp` lines
   164–180](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L164-L180)). -/
   height : Nat
-  /-- The admitting block header's timestamp, used for finality before BIP113
+  /-- The admitting block header's timestamp, used for time locks before BIP113
   ([Bitcoin Core v28.0, `validation.cpp` lines
   4224–4230](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L4224-L4230)). -/
   blockTime : Nat
-  /-- The preceding block's median-time-past, used for finality after BIP113
+  /-- The preceding block's median-time-past, used for time locks after BIP113
   ([Bitcoin Core v28.0, `validation.cpp` lines
   4224–4230](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L4224-L4230)). -/
   medianTimePast : Nat
   deriving DecidableEq
 
-/-- Read the named context time selected by the active finality rule. -/
-def TxContext.timeFor (ctx : TxContext) : FinalityClock → Nat
+/-- Read the named context time selected by the active absolute-lock rule. -/
+def TxContext.timeFor (ctx : TxContext) : LockTimeClock → Nat
   | .blockTime => ctx.blockTime
   | .medianTimePast => ctx.medianTimePast
 

--- a/BtcVerified/Consensus/TxContext.lean
+++ b/BtcVerified/Consensus/TxContext.lean
@@ -2,33 +2,52 @@
   # Transaction evaluation context
 
   Where and when a transaction is being admitted to the chain: the height of
-  the admitting block and the time lock times are measured against. This is
+  the admitting block, its header time, and the preceding chain's
+  median-time-past. This is
   evaluation context, never activation — the contextual rules read these
   values to decide *this* transaction *here*; "which rules are in force at
   this height" is the ruleset mapping's business (#38).
 
-  In particular, BIP113 changed which clock Core passes as the lock-time
-  measuring point (the block's own timestamp before, its median-time-past
-  after) without changing `IsFinalTx` itself ([Bitcoin Core v28.0,
+  `FinalityClock` names the choice BIP113 changed: Core supplies the block's
+  own timestamp before activation and the preceding block's median-time-past
+  after it, without changing `IsFinalTx` itself ([Bitcoin Core v28.0,
   `validation.cpp` lines 4224–4238](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L4224-L4238)).
-  The rules only compare against `time`; which clock supplies it is exactly the
-  kind of choice the activation layer owns.
+  Both values remain present and named in `TxContext`; the ruleset chooses a
+  `FinalityClock` explicitly instead of hiding that activation-sensitive
+  decision in an overloaded caller-filled `time` field.
 -/
 
 namespace BtcVerified
 
+/-- Which named time in `TxContext` measures absolute transaction finality.
+The height-indexed ruleset in #38 chooses between these cases. -/
+inductive FinalityClock where
+  /-- Pre-BIP113 finality uses the admitting block's header time. -/
+  | blockTime
+  /-- Post-BIP113 finality uses the preceding block's median-time-past. -/
+  | medianTimePast
+  deriving DecidableEq
+
 /-- The context a chain-contextual transaction rule evaluates in: the height
-of the admitting block and the time lock times are measured against. -/
+of the admitting block and both clocks consensus rules can name. -/
 structure TxContext where
   /-- Height of the block admitting the transaction (Core's `nSpendHeight` in
   [`CheckTxInputs`, Bitcoin Core v28.0, `tx_verify.cpp` lines
   164–180](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L164-L180)). -/
   height : Nat
-  /-- The time lock-time finality is measured against (Core's `nBlockTime` in
-  [`IsFinalTx`, Bitcoin Core v28.0, `tx_verify.cpp` lines
-  17–37](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L17-L37));
-  which clock supplies it is the activation layer's choice). -/
-  time : Nat
+  /-- The admitting block header's timestamp, used for finality before BIP113
+  ([Bitcoin Core v28.0, `validation.cpp` lines
+  4224–4230](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L4224-L4230)). -/
+  blockTime : Nat
+  /-- The preceding block's median-time-past, used for finality after BIP113
+  ([Bitcoin Core v28.0, `validation.cpp` lines
+  4224–4230](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L4224-L4230)). -/
+  medianTimePast : Nat
   deriving DecidableEq
+
+/-- Read the named context time selected by the active finality rule. -/
+def TxContext.timeFor (ctx : TxContext) : FinalityClock → Nat
+  | .blockTime => ctx.blockTime
+  | .medianTimePast => ctx.medianTimePast
 
 end BtcVerified

--- a/BtcVerified/Consensus/TxContext.lean
+++ b/BtcVerified/Consensus/TxContext.lean
@@ -9,9 +9,10 @@
 
   In particular, BIP113 changed which clock Core passes as the lock-time
   measuring point (the block's own timestamp before, its median-time-past
-  after) without ever changing the finality rule itself. The rules only
-  compare against `time`; which clock supplies it is exactly the kind of
-  choice the activation layer owns.
+  after) without changing `IsFinalTx` itself ([Bitcoin Core v28.0,
+  `validation.cpp` lines 4224–4238](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L4224-L4238)).
+  The rules only compare against `time`; which clock supplies it is exactly the
+  kind of choice the activation layer owns.
 -/
 
 namespace BtcVerified
@@ -19,11 +20,14 @@ namespace BtcVerified
 /-- The context a chain-contextual transaction rule evaluates in: the height
 of the admitting block and the time lock times are measured against. -/
 structure TxContext where
-  /-- Height of the block admitting the transaction (Core's `nSpendHeight`). -/
+  /-- Height of the block admitting the transaction (Core's `nSpendHeight` in
+  [`CheckTxInputs`, Bitcoin Core v28.0, `tx_verify.cpp` lines
+  164–180](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L164-L180)). -/
   height : Nat
-  /-- The time lock-time finality is measured against (Core's `nBlockTime`;
-  which clock supplies it — block time or median-time-past — is the
-  activation layer's choice). -/
+  /-- The time lock-time finality is measured against (Core's `nBlockTime` in
+  [`IsFinalTx`, Bitcoin Core v28.0, `tx_verify.cpp` lines
+  17–37](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L17-L37));
+  which clock supplies it is the activation layer's choice). -/
   time : Nat
   deriving DecidableEq
 

--- a/BtcVerified/Consensus/TxContext.lean
+++ b/BtcVerified/Consensus/TxContext.lean
@@ -1,0 +1,30 @@
+/-!
+  # Transaction evaluation context
+
+  Where and when a transaction is being admitted to the chain: the height of
+  the admitting block and the time lock times are measured against. This is
+  evaluation context, never activation — the contextual rules read these
+  values to decide *this* transaction *here*; "which rules are in force at
+  this height" is the ruleset mapping's business (#38).
+
+  In particular, BIP113 changed which clock Core passes as the lock-time
+  measuring point (the block's own timestamp before, its median-time-past
+  after) without ever changing the finality rule itself. The rules only
+  compare against `time`; which clock supplies it is exactly the kind of
+  choice the activation layer owns.
+-/
+
+namespace BtcVerified
+
+/-- The context a chain-contextual transaction rule evaluates in: the height
+of the admitting block and the time lock times are measured against. -/
+structure TxContext where
+  /-- Height of the block admitting the transaction (Core's `nSpendHeight`). -/
+  height : Nat
+  /-- The time lock-time finality is measured against (Core's `nBlockTime`;
+  which clock supplies it — block time or median-time-past — is the
+  activation layer's choice). -/
+  time : Nat
+  deriving DecidableEq
+
+end BtcVerified

--- a/BtcVerified/Consensus/TxContextual.lean
+++ b/BtcVerified/Consensus/TxContextual.lean
@@ -1,5 +1,6 @@
 import BtcVerified.Chainstate.Apply
 import BtcVerified.Consensus.Limits
+import BtcVerified.Consensus.LockTime
 import BtcVerified.Consensus.TxContext
 import BtcVerified.Consensus.ScriptCheck
 /-!
@@ -45,9 +46,9 @@ import BtcVerified.Consensus.ScriptCheck
 
   * `Coin.isMature_iff`: the maturity checker accepts a coin at a height
     exactly when the coin is non-coinbase or `coinbaseMaturity` blocks deep.
-  * `TxBody.isFinal_iff`: the finality checker accepts exactly when the lock
-    is zero, already past on the axis the lock time selects, or overridden
-    by every input carrying the final sequence.
+  * `TxBody.isFinal_iff`: for an explicitly selected finality clock, the
+    checker accepts exactly when the interpreted absolute lock is disabled or
+    past, or every input carries the final sequence.
   * `Tx.spentCoins_aligned`: under the existence rule, each spent coin is the
     lookup of the outpoint named by the corresponding input.
   * `Tx.spentCoins_length`: the aligned lists have equal length.
@@ -90,33 +91,52 @@ theorem Coin.isMature_iff {coin : Coin} {height : Nat} :
     | false => exact Or.inl rfl
     | true => exact Or.inr (h hcb)
 
-/-- Decide lock-time finality for an evaluation context (Core's `IsFinalTx`):
-the lock is disabled (zero), already past — the lock time itself selecting
-the height or time axis by `lockTimeThreshold` — or overridden by every
-input carrying the final sequence ([Bitcoin Core v28.0, `tx_verify.cpp` lines
-17–37](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L17-L37)). -/
-def TxBody.isFinal (body : TxBody) (ctx : TxContext) : Bool :=
-  body.lockTime == 0
-    || decide (body.lockTime.toNat <
-        if body.lockTime.toNat < Consensus.lockTimeThreshold
-        then ctx.height else ctx.time)
+/-- The semantic absolute lock time interpreted from the body's raw wire
+field. Relative lock times are per-input sequence semantics deferred to #46. -/
+def TxBody.interpretedLockTime (body : TxBody) : Consensus.LockTime :=
+  Consensus.LockTime.ofUInt32 body.lockTime
+
+/-- Decide lock-time finality under an explicitly selected finality clock
+(Core's `IsFinalTx`): the interpreted absolute lock is disabled or already
+past, or every input overrides it with the final sequence value ([Bitcoin Core
+v28.0, `tx_verify.cpp` lines
+17–37](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L17-L37)).
+The height-indexed ruleset in #38 selects `.blockTime` before BIP113 and
+`.medianTimePast` after it. -/
+def TxBody.isFinal (body : TxBody) (clock : FinalityClock)
+    (ctx : TxContext) : Bool :=
+  body.interpretedLockTime.isPast ctx.height (ctx.timeFor clock)
     || body.inputs.val.all (·.sequence == Consensus.sequenceFinal)
 
-/-- The specification `TxBody.isFinal` enforces: the lock time is zero, or
-strictly below the height or time the threshold axis selects, or every
-input's sequence is final. -/
-def TxBody.Final (body : TxBody) (ctx : TxContext) : Prop :=
-  body.lockTime = 0
-    ∨ body.lockTime.toNat <
-        (if body.lockTime.toNat < Consensus.lockTimeThreshold
-         then ctx.height else ctx.time)
+/-- The specification `TxBody.isFinal` enforces: the interpreted absolute
+lock has passed under the selected clock, or every input's sequence is final. -/
+def TxBody.Final (body : TxBody) (clock : FinalityClock)
+    (ctx : TxContext) : Prop :=
+  body.interpretedLockTime.Past ctx.height (ctx.timeFor clock)
     ∨ ∀ input ∈ body.inputs.val, input.sequence = Consensus.sequenceFinal
 
 /-- The finality checker enforces exactly its specification: `isFinal`
 accepts a body in a context iff the body is `Final` there. -/
-theorem TxBody.isFinal_iff {body : TxBody} {ctx : TxContext} :
-    body.isFinal ctx = true ↔ body.Final ctx := by
-  simp [isFinal, Final, Bool.or_eq_true, List.all_eq_true, or_assoc]
+theorem TxBody.isFinal_iff {body : TxBody} {clock : FinalityClock}
+    {ctx : TxContext} :
+    body.isFinal clock ctx = true ↔ body.Final clock ctx := by
+  simp [isFinal, Final, Consensus.LockTime.isPast_iff, List.all_eq_true]
+
+/-- The semantic finality specification is equivalent to Core's wire-shaped
+three-arm statement: zero lock time, raw threshold-selected comparison, or the
+all-final sequence override ([Bitcoin Core v28.0, `tx_verify.cpp` lines
+17–37](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L17-L37)). -/
+theorem TxBody.final_iff_core {body : TxBody} {clock : FinalityClock}
+    {ctx : TxContext} :
+    body.Final clock ctx ↔
+      body.lockTime = 0
+        ∨ body.lockTime.toNat <
+          (if body.lockTime.toNat < Consensus.lockTimeThreshold
+           then ctx.height else ctx.timeFor clock)
+        ∨ ∀ input ∈ body.inputs.val,
+          input.sequence = Consensus.sequenceFinal := by
+  simp only [Final, interpretedLockTime, Consensus.LockTime.ofUInt32_past_iff]
+  tauto
 
 /-- The coins a transaction's inputs consume, in input order — total via
 `filterMap`, aligned with the inputs whenever the existence rule holds
@@ -172,7 +192,7 @@ coinbase spends are mature, input value and fee stay within `maxMoney`, inputs
 cover outputs, the transaction is final, no created outpoint is currently
 overwritten, and every input passes the script judgment. -/
 def Tx.isAdmissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
-    (ctx : TxContext) (tx : Tx) : Bool :=
+    (clock : FinalityClock) (ctx : TxContext) (tx : Tx) : Bool :=
   tx.body.spends.all (fun o => (utxos.lookup o).isSome)
     && tx.body.spends.all
         (fun o => ((utxos.lookup o).map (·.isMature ctx.height)).getD true)
@@ -183,7 +203,7 @@ def Tx.isAdmissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
     && decide ((tx.body.spends.map utxos.valueAt).sum
         - (tx.body.outputs.val.map fun o => o.value.toNat).sum
         ≤ Consensus.maxMoney)
-    && tx.body.isFinal ctx
+    && tx.body.isFinal clock ctx
     && tx.body.creates.all (fun entry => (utxos.lookup entry.1).isNone)
     && (List.range tx.body.inputs.val.length).all
         (fun i => scriptOk (tx.spentCoins utxos) i tx)
@@ -194,7 +214,7 @@ fields are the facts the action theorems consume ([Bitcoin Core v28.0,
 `tx_verify.cpp` lines
 164–204](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L164-L204)). -/
 structure Tx.Admissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
-    (ctx : TxContext) (tx : Tx) : Prop where
+    (clock : FinalityClock) (ctx : TxContext) (tx : Tx) : Prop where
   /-- Every input's outpoint is an unspent coin
   (`bad-txns-inputs-missingorspent`; [Bitcoin Core v28.0, `tx_verify.cpp` lines
   164–170](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L164-L170)). -/
@@ -225,7 +245,7 @@ structure Tx.Admissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
   /-- The transaction is final for the admitting block (`bad-txns-nonfinal`;
   [Bitcoin Core v28.0, `validation.cpp` lines
   4231–4239](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L4231-L4239)). -/
-  final : tx.body.Final ctx
+  final : tx.body.Final clock ctx
   /-- Creating this transaction's outputs does not overwrite any currently
   unspent outpoint — BIP30's content; its historical carve-outs are the
   activation layer's business (#38/#39; [Bitcoin Core v28.0, `validation.cpp`
@@ -242,9 +262,9 @@ structure Tx.Admissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
 /-- The checker enforces exactly its specification: `isAdmissible` accepts a
 transaction iff it is `Admissible`. -/
 theorem Tx.isAdmissible_iff {scriptOk : ScriptCheck} {utxos : UtxoSet}
-    {ctx : TxContext} {tx : Tx} :
-    tx.isAdmissible scriptOk utxos ctx = true
-      ↔ Tx.Admissible scriptOk utxos ctx tx := by
+    {clock : FinalityClock} {ctx : TxContext} {tx : Tx} :
+    tx.isAdmissible scriptOk utxos clock ctx = true
+      ↔ Tx.Admissible scriptOk utxos clock ctx tx := by
   simp only [isAdmissible, Bool.and_eq_true, List.all_eq_true,
     decide_eq_true_eq, TxBody.isFinal_iff, List.mem_range]
   constructor
@@ -276,7 +296,8 @@ theorem Tx.isAdmissible_iff {scriptOk : ScriptCheck} {utxos : UtxoSet}
       exact habsent _ (List.mem_map_of_mem hentry)
 
 instance instDecidableAdmissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
-    (ctx : TxContext) : DecidablePred (Tx.Admissible scriptOk utxos ctx) :=
+    (clock : FinalityClock) (ctx : TxContext) :
+    DecidablePred (Tx.Admissible scriptOk utxos clock ctx) :=
   fun _ => decidable_of_iff _ Tx.isAdmissible_iff
 
 end BtcVerified

--- a/BtcVerified/Consensus/TxContextual.lean
+++ b/BtcVerified/Consensus/TxContextual.lean
@@ -3,14 +3,15 @@ import BtcVerified.Consensus.Limits
 import BtcVerified.Consensus.TxContext
 import BtcVerified.Consensus.ScriptCheck
 /-!
-  # Contextual transaction rules
+  # Contextual transaction premises
 
-  The chain-contextual bucket: what consensus demands of a regular
-  transaction relative to the UTXO set and the admitting block — Core's
+  The chain-contextual premises a regular transaction must establish while a
+  candidate block is being checked against the UTXO set — Core's
   `Consensus::CheckTxInputs` (`src/consensus/tx_verify.cpp`) and `IsFinalTx`,
   plus the rule that keeps the machine's insert-replaces path unreachable.
-  Script validity is the `ScriptCheck` parameter; every rule here is
-  script-agnostic.
+  These predicates are reusable steps inside block-extension validity, not a
+  standalone consensus verdict for a transaction. Script validity is the
+  `ScriptCheck` parameter; every rule here is script-agnostic.
 
   The enforced rule is the checker `Tx.isAdmissible`; `Tx.Admissible` is the
   specification it is proved to enforce (`Tx.isAdmissible_iff`), and its
@@ -25,7 +26,7 @@ import BtcVerified.Consensus.ScriptCheck
   One contextual Core rule remains deferred: BIP68 relative lock times need
   per-coin median-time-past history that no leaf provides yet.
 
-  `creates_absent` is BIP30's content in current-state vocabulary: a
+  `creates_do_not_overwrite` is BIP30's content in current-state vocabulary: a
   transaction may not create an outpoint that *currently* holds an unspent
   coin (recreating a fully-spent outpoint is legal — it happened before
   BIP34). The two 2010 duplicate-coinbase blocks and Core's post-BIP34 skip
@@ -39,8 +40,9 @@ import BtcVerified.Consensus.ScriptCheck
   * `TxBody.isFinal_iff`: the finality checker accepts exactly when the lock
     is zero, already past on the axis the lock time selects, or overridden
     by every input carrying the final sequence.
-  * `Tx.spentCoins_length`: under the existence rule, the spent-coin list
-    has one coin per input.
+  * `Tx.spentCoins_aligned`: under the existence rule, each spent coin is the
+    lookup of the outpoint named by the corresponding input.
+  * `Tx.spentCoins_length`: the aligned lists have equal length.
   * `Tx.isAdmissible_iff`: the checker accepts a transaction exactly when it
     satisfies the eight contextual rules — inputs exist, coinbase spends are
     mature, input value and fee stay within `maxMoney`, inputs cover outputs,
@@ -112,22 +114,53 @@ theorem TxBody.isFinal_iff {body : TxBody} {ctx : TxContext} :
 def Tx.spentCoins (tx : Tx) (utxos : UtxoSet) : List Coin :=
   tx.body.spends.filterMap fun o => utxos.lookup o
 
-/-- Under the existence rule the spent-coin list is aligned with the inputs:
-one coin per input, in order. -/
+/-- Under the existence rule, the spent-coin list is pointwise aligned with
+the inputs: each coin is exactly the lookup of the outpoint named by the
+corresponding input. -/
+theorem Tx.spentCoins_aligned {tx : Tx} {utxos : UtxoSet}
+    (h : ∀ o ∈ tx.body.spends, o ∈ utxos) :
+    List.Forall₂ (fun input coin =>
+      utxos.lookup input.prevout = some coin)
+      tx.body.inputs.val (tx.spentCoins utxos) := by
+  have aligned : ∀ inputs : List TxIn,
+      (∀ input ∈ inputs, input.prevout ∈ utxos) →
+      List.Forall₂ (fun input coin =>
+        utxos.lookup input.prevout = some coin)
+        inputs ((inputs.map fun input => input.prevout).filterMap utxos.lookup) := by
+    intro inputs
+    induction inputs with
+    | nil =>
+        intro _
+        exact .nil
+    | cons input inputs ih =>
+        intro hinputs
+        have hmem : input.prevout ∈ utxos := hinputs input (by simp)
+        have hsome := Finmap.lookup_isSome.mpr hmem
+        cases hlookup : utxos.lookup input.prevout with
+        | none => simp [hlookup] at hsome
+        | some coin =>
+            simp only [List.map_cons, List.filterMap_cons, hlookup]
+            exact .cons hlookup
+              (ih fun next hnext => hinputs next (by simp [hnext]))
+  unfold spentCoins
+  rw [TxBody.spends]
+  exact aligned tx.body.inputs.val fun input hinput =>
+    h input.prevout (by
+      rw [TxBody.spends]
+      exact List.mem_map.mpr ⟨input, hinput, rfl⟩)
+
+/-- Under the existence rule there is one spent coin per input. This is the
+length consequence of `Tx.spentCoins_aligned`. -/
 theorem Tx.spentCoins_length {tx : Tx} {utxos : UtxoSet}
     (h : ∀ o ∈ tx.body.spends, o ∈ utxos) :
-    (tx.spentCoins utxos).length = tx.body.inputs.val.length := by
-  have hlen : (tx.body.spends.filterMap fun o => utxos.lookup o).length
-      = tx.body.spends.length :=
-    List.filterMap_length_eq_length.mpr
-      fun o ho => Finmap.lookup_isSome.mpr (h o ho)
-  rw [spentCoins, hlen, TxBody.spends, List.length_map]
+    (tx.spentCoins utxos).length = tx.body.inputs.val.length :=
+  (Tx.spentCoins_aligned h).length_eq.symm
 
-/-- Decide the chain-contextual validity of a regular transaction over the
-UTXO set, script validity supplied as a parameter: inputs exist, coinbase
-spends are mature, input value and fee stay within `maxMoney`, inputs cover
-outputs, the transaction is final, no created outpoint is currently unspent,
-and every input passes the script judgment. -/
+/-- Decide the contextual admissibility premises for one regular-transaction
+step over the UTXO set, script validity supplied as a parameter: inputs exist,
+coinbase spends are mature, input value and fee stay within `maxMoney`, inputs
+cover outputs, the transaction is final, no created outpoint is currently
+overwritten, and every input passes the script judgment. -/
 def Tx.isAdmissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
     (ctx : TxContext) (tx : Tx) : Bool :=
   tx.body.spends.all (fun o => (utxos.lookup o).isSome)
@@ -175,9 +208,11 @@ structure Tx.Admissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
     ≤ Consensus.maxMoney
   /-- The transaction is final for the admitting block (`non-final`). -/
   final : tx.body.Final ctx
-  /-- No created outpoint currently holds an unspent coin — BIP30's content;
-  its historical carve-outs are the activation layer's business (#38/#39). -/
-  creates_absent : ∀ o ∈ tx.body.creates.map Prod.fst, o ∉ utxos
+  /-- Creating this transaction's outputs does not overwrite any currently
+  unspent outpoint — BIP30's content; its historical carve-outs are the
+  activation layer's business (#38/#39). -/
+  creates_do_not_overwrite :
+    ∀ o ∈ tx.body.creates.map Prod.fst, o ∉ utxos
   /-- Every input satisfies the script judgment against the coins the
   transaction spends. -/
   scripts_ok : ∀ i < tx.body.inputs.val.length,

--- a/BtcVerified/Consensus/TxContextual.lean
+++ b/BtcVerified/Consensus/TxContextual.lean
@@ -7,7 +7,10 @@ import BtcVerified.Consensus.ScriptCheck
 
   The chain-contextual premises a regular transaction must establish while a
   candidate block is being checked against the UTXO set — Core's
-  `Consensus::CheckTxInputs` (`src/consensus/tx_verify.cpp`) and `IsFinalTx`,
+  [`Consensus::CheckTxInputs`, Bitcoin Core v28.0, `tx_verify.cpp` lines
+  164–204](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L164-L204)
+  and [`IsFinalTx`, lines
+  17–37](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L17-L37),
   plus the rule that keeps the machine's insert-replaces path unreachable.
   These predicates are reusable steps inside block-extension validity, not a
   standalone consensus verdict for a transaction. Script validity is the
@@ -19,19 +22,24 @@ import BtcVerified.Consensus.ScriptCheck
 
   Core's `MoneyRange` checks on value-in and fee remain explicit here even
   though `Nat` eliminates arithmetic overflow: this checker ranges over an
-  arbitrary `UtxoSet`, not only states reachable from genesis. Issue #50
+  arbitrary `UtxoSet`, not only states reachable from genesis ([Bitcoin Core
+  v28.0, `tx_verify.cpp` lines
+  184–200](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L184-L200)). Issue #50
   tracks proving these checks redundant under the supply invariant once #37
   provides it.
 
   One contextual Core rule remains deferred: BIP68 relative lock times need
-  per-coin median-time-past history that no leaf provides yet.
+  per-coin median-time-past history that no leaf provides yet ([Bitcoin Core
+  v28.0, `tx_verify.cpp` lines
+  39–109](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L39-L109)).
 
   `creates_do_not_overwrite` is BIP30's content in current-state vocabulary: a
   transaction may not create an outpoint that *currently* holds an unspent
   coin (recreating a fully-spent outpoint is legal — it happened before
   BIP34). The two 2010 duplicate-coinbase blocks and Core's post-BIP34 skip
-  of this check are activation history, owned by the ruleset mapping
-  (#38/#39); the rule itself is height-free.
+  of this check are activation history ([Bitcoin Core v28.0, `validation.cpp`
+  lines 2495–2575](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L2495-L2575)),
+  owned by the ruleset mapping (#38/#39); the rule itself is height-free.
 
   Checked claims:
 
@@ -54,7 +62,8 @@ namespace BtcVerified
 
 /-- Decide that a coin is spendable at `height`: immediately, unless it was
 created in coinbase position — then only once `coinbaseMaturity` blocks
-deep. -/
+deep ([Bitcoin Core v28.0, `tx_verify.cpp` lines
+178–181](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L178-L181)). -/
 def Coin.isMature (coin : Coin) (height : Nat) : Bool :=
   !coin.provenance.coinbase
     || decide (coin.provenance.height + Consensus.coinbaseMaturity ≤ height)
@@ -84,7 +93,8 @@ theorem Coin.isMature_iff {coin : Coin} {height : Nat} :
 /-- Decide lock-time finality for an evaluation context (Core's `IsFinalTx`):
 the lock is disabled (zero), already past — the lock time itself selecting
 the height or time axis by `lockTimeThreshold` — or overridden by every
-input carrying the final sequence. -/
+input carrying the final sequence ([Bitcoin Core v28.0, `tx_verify.cpp` lines
+17–37](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L17-L37)). -/
 def TxBody.isFinal (body : TxBody) (ctx : TxContext) : Bool :=
   body.lockTime == 0
     || decide (body.lockTime.toNat <
@@ -178,16 +188,20 @@ def Tx.isAdmissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
     && (List.range tx.body.inputs.val.length).all
         (fun i => scriptOk (tx.spentCoins utxos) i tx)
 
-/-- The specification `Tx.isAdmissible` enforces — Core's contextual checks
-for a regular transaction, one field per rule; the fields are the facts the
-action theorems consume. -/
+/-- The specification `Tx.isAdmissible` enforces — an abstract factoring of
+Core's contextual checks for a regular transaction, one field per rule; the
+fields are the facts the action theorems consume ([Bitcoin Core v28.0,
+`tx_verify.cpp` lines
+164–204](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L164-L204)). -/
 structure Tx.Admissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
     (ctx : TxContext) (tx : Tx) : Prop where
   /-- Every input's outpoint is an unspent coin
-  (`bad-txns-inputs-missingorspent`). -/
+  (`bad-txns-inputs-missingorspent`; [Bitcoin Core v28.0, `tx_verify.cpp` lines
+  164–170](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L164-L170)). -/
   spends_mem : ∀ o ∈ tx.body.spends, o ∈ utxos
   /-- Every coinbase coin spent is at least `coinbaseMaturity` blocks deep
-  (`bad-txns-premature-spend-of-coinbase`). -/
+  (`bad-txns-premature-spend-of-coinbase`; [Bitcoin Core v28.0,
+  `tx_verify.cpp` lines 178–181](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L178-L181)). -/
   spends_mature : ∀ o ∈ tx.body.spends, ∀ coin,
     utxos.lookup o = some coin → coin.Mature ctx.height
   /-- The total input value stays within `maxMoney`; in `Nat` this one total
@@ -197,7 +211,9 @@ structure Tx.Admissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
   input_values_bounded : (tx.body.spends.map utxos.valueAt).sum
     ≤ Consensus.maxMoney
   /-- The inputs cover the outputs: value out ≤ value in, in `Nat` — fee
-  non-negativity is this same fact (`bad-txns-in-belowout`). -/
+  non-negativity is this same fact (`bad-txns-in-belowout`; [Bitcoin Core
+  v28.0, `tx_verify.cpp` lines
+  191–195](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L191-L195)). -/
   values_cover : (tx.body.outputs.val.map fun o => o.value.toNat).sum
     ≤ (tx.body.spends.map utxos.valueAt).sum
   /-- The fee — input value minus output value in `Nat` — stays within
@@ -206,15 +222,20 @@ structure Tx.Admissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
   fee_bounded : (tx.body.spends.map utxos.valueAt).sum
       - (tx.body.outputs.val.map fun o => o.value.toNat).sum
     ≤ Consensus.maxMoney
-  /-- The transaction is final for the admitting block (`non-final`). -/
+  /-- The transaction is final for the admitting block (`bad-txns-nonfinal`;
+  [Bitcoin Core v28.0, `validation.cpp` lines
+  4231–4239](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L4231-L4239)). -/
   final : tx.body.Final ctx
   /-- Creating this transaction's outputs does not overwrite any currently
   unspent outpoint — BIP30's content; its historical carve-outs are the
-  activation layer's business (#38/#39). -/
+  activation layer's business (#38/#39; [Bitcoin Core v28.0, `validation.cpp`
+  lines 2495–2575](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L2495-L2575)). -/
   creates_do_not_overwrite :
     ∀ o ∈ tx.body.creates.map Prod.fst, o ∉ utxos
   /-- Every input satisfies the script judgment against the coins the
-  transaction spends. -/
+  transaction spends; Core invokes `CheckInputScripts` for every regular
+  transaction while connecting a block ([Bitcoin Core v28.0, `validation.cpp`
+  lines 2659–2671](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L2659-L2671)). -/
   scripts_ok : ∀ i < tx.body.inputs.val.length,
     scriptOk (tx.spentCoins utxos) i tx = true
 

--- a/BtcVerified/Consensus/TxContextual.lean
+++ b/BtcVerified/Consensus/TxContextual.lean
@@ -46,17 +46,17 @@ import BtcVerified.Consensus.ScriptCheck
 
   * `Coin.isMature_iff`: the maturity checker accepts a coin at a height
     exactly when the coin is non-coinbase or `coinbaseMaturity` blocks deep.
-  * `TxBody.isFinal_iff`: for an explicitly selected finality clock, the
-    checker accepts exactly when the interpreted absolute lock is disabled or
-    past, or every input carries the final sequence.
+  * `TxBody.isLockTimeSatisfied_iff`: for an explicitly selected lock-time
+    clock, the checker accepts exactly when the interpreted absolute lock is
+    disabled or past, or every input carries the `sequenceFinal` sentinel.
   * `Tx.spentCoins_aligned`: under the existence rule, each spent coin is the
     lookup of the outpoint named by the corresponding input.
   * `Tx.spentCoins_length`: the aligned lists have equal length.
   * `Tx.isAdmissible_iff`: the checker accepts a transaction exactly when it
     satisfies the eight contextual rules — inputs exist, coinbase spends are
     mature, input value and fee stay within `maxMoney`, inputs cover outputs,
-    the transaction is final, no created outpoint is currently unspent, and
-    every input passes the script judgment.
+    the transaction's absolute lock-time condition is satisfied, no created
+    outpoint is currently unspent, and every input passes the script judgment.
 -/
 
 namespace BtcVerified
@@ -96,46 +96,53 @@ field. Relative lock times are per-input sequence semantics deferred to #46. -/
 def TxBody.interpretedLockTime (body : TxBody) : Consensus.LockTime :=
   Consensus.LockTime.ofUInt32 body.lockTime
 
-/-- Decide lock-time finality under an explicitly selected finality clock
-(Core's `IsFinalTx`): the interpreted absolute lock is disabled or already
-past, or every input overrides it with the final sequence value ([Bitcoin Core
+/-- Decide whether the transaction's absolute lock-time condition is satisfied
+under an explicitly selected clock (Core calls this `IsFinalTx`): the
+interpreted absolute lock is disabled or already
+past, or every input overrides it with the `sequenceFinal` value ([Bitcoin Core
 v28.0, `tx_verify.cpp` lines
 17–37](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L17-L37)).
 The height-indexed ruleset in #38 selects `.blockTime` before BIP113 and
 `.medianTimePast` after it. -/
-def TxBody.isFinal (body : TxBody) (clock : FinalityClock)
+def TxBody.isLockTimeSatisfied (body : TxBody) (clock : LockTimeClock)
     (ctx : TxContext) : Bool :=
   body.interpretedLockTime.isPast ctx.height (ctx.timeFor clock)
     || body.inputs.val.all (·.sequence == Consensus.sequenceFinal)
 
-/-- The specification `TxBody.isFinal` enforces: the interpreted absolute
-lock has passed under the selected clock, or every input's sequence is final. -/
-def TxBody.Final (body : TxBody) (clock : FinalityClock)
+/-- The specification `TxBody.isLockTimeSatisfied` enforces: the interpreted
+absolute lock has passed under the selected clock, or every input carries the
+`sequenceFinal` sentinel. -/
+def TxBody.LockTimeSatisfied (body : TxBody) (clock : LockTimeClock)
     (ctx : TxContext) : Prop :=
   body.interpretedLockTime.Past ctx.height (ctx.timeFor clock)
     ∨ ∀ input ∈ body.inputs.val, input.sequence = Consensus.sequenceFinal
 
-/-- The finality checker enforces exactly its specification: `isFinal`
-accepts a body in a context iff the body is `Final` there. -/
-theorem TxBody.isFinal_iff {body : TxBody} {clock : FinalityClock}
+/-- The lock-time checker enforces exactly its specification:
+`isLockTimeSatisfied` accepts a body in a context iff its `LockTimeSatisfied`
+proposition holds there. -/
+theorem TxBody.isLockTimeSatisfied_iff {body : TxBody} {clock : LockTimeClock}
     {ctx : TxContext} :
-    body.isFinal clock ctx = true ↔ body.Final clock ctx := by
-  simp [isFinal, Final, Consensus.LockTime.isPast_iff, List.all_eq_true]
+    body.isLockTimeSatisfied clock ctx = true ↔
+      body.LockTimeSatisfied clock ctx := by
+  simp [isLockTimeSatisfied, LockTimeSatisfied,
+    Consensus.LockTime.isPast_iff, List.all_eq_true]
 
-/-- The semantic finality specification is equivalent to Core's wire-shaped
-three-arm statement: zero lock time, raw threshold-selected comparison, or the
-all-final sequence override ([Bitcoin Core v28.0, `tx_verify.cpp` lines
+/-- The semantic lock-time specification is equivalent to Core's wire-shaped
+`IsFinalTx` statement: zero lock time, raw threshold-selected comparison, or
+the all-`sequenceFinal` override ([Bitcoin Core v28.0, `tx_verify.cpp` lines
 17–37](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L17-L37)). -/
-theorem TxBody.final_iff_core {body : TxBody} {clock : FinalityClock}
+theorem TxBody.lockTimeSatisfied_iff_core {body : TxBody}
+    {clock : LockTimeClock}
     {ctx : TxContext} :
-    body.Final clock ctx ↔
+    body.LockTimeSatisfied clock ctx ↔
       body.lockTime = 0
         ∨ body.lockTime.toNat <
           (if body.lockTime.toNat < Consensus.lockTimeThreshold
            then ctx.height else ctx.timeFor clock)
         ∨ ∀ input ∈ body.inputs.val,
           input.sequence = Consensus.sequenceFinal := by
-  simp only [Final, interpretedLockTime, Consensus.LockTime.ofUInt32_past_iff]
+  simp only [LockTimeSatisfied, interpretedLockTime,
+    Consensus.LockTime.ofUInt32_past_iff]
   tauto
 
 /-- The coins a transaction's inputs consume, in input order — total via
@@ -189,10 +196,10 @@ theorem Tx.spentCoins_length {tx : Tx} {utxos : UtxoSet}
 /-- Decide the contextual admissibility premises for one regular-transaction
 step over the UTXO set, script validity supplied as a parameter: inputs exist,
 coinbase spends are mature, input value and fee stay within `maxMoney`, inputs
-cover outputs, the transaction is final, no created outpoint is currently
-overwritten, and every input passes the script judgment. -/
+cover outputs, the absolute lock-time condition is satisfied, no created
+outpoint is currently overwritten, and every input passes the script judgment. -/
 def Tx.isAdmissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
-    (clock : FinalityClock) (ctx : TxContext) (tx : Tx) : Bool :=
+    (clock : LockTimeClock) (ctx : TxContext) (tx : Tx) : Bool :=
   tx.body.spends.all (fun o => (utxos.lookup o).isSome)
     && tx.body.spends.all
         (fun o => ((utxos.lookup o).map (·.isMature ctx.height)).getD true)
@@ -203,7 +210,7 @@ def Tx.isAdmissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
     && decide ((tx.body.spends.map utxos.valueAt).sum
         - (tx.body.outputs.val.map fun o => o.value.toNat).sum
         ≤ Consensus.maxMoney)
-    && tx.body.isFinal clock ctx
+    && tx.body.isLockTimeSatisfied clock ctx
     && tx.body.creates.all (fun entry => (utxos.lookup entry.1).isNone)
     && (List.range tx.body.inputs.val.length).all
         (fun i => scriptOk (tx.spentCoins utxos) i tx)
@@ -214,7 +221,7 @@ fields are the facts the action theorems consume ([Bitcoin Core v28.0,
 `tx_verify.cpp` lines
 164–204](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L164-L204)). -/
 structure Tx.Admissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
-    (clock : FinalityClock) (ctx : TxContext) (tx : Tx) : Prop where
+    (clock : LockTimeClock) (ctx : TxContext) (tx : Tx) : Prop where
   /-- Every input's outpoint is an unspent coin
   (`bad-txns-inputs-missingorspent`; [Bitcoin Core v28.0, `tx_verify.cpp` lines
   164–170](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L164-L170)). -/
@@ -242,10 +249,11 @@ structure Tx.Admissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
   fee_bounded : (tx.body.spends.map utxos.valueAt).sum
       - (tx.body.outputs.val.map fun o => o.value.toNat).sum
     ≤ Consensus.maxMoney
-  /-- The transaction is final for the admitting block (`bad-txns-nonfinal`;
+  /-- The transaction's absolute lock-time condition is satisfied for the
+  admitting block (`bad-txns-nonfinal`;
   [Bitcoin Core v28.0, `validation.cpp` lines
   4231–4239](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L4231-L4239)). -/
-  final : tx.body.Final clock ctx
+  lock_time_satisfied : tx.body.LockTimeSatisfied clock ctx
   /-- Creating this transaction's outputs does not overwrite any currently
   unspent outpoint — BIP30's content; its historical carve-outs are the
   activation layer's business (#38/#39; [Bitcoin Core v28.0, `validation.cpp`
@@ -262,16 +270,16 @@ structure Tx.Admissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
 /-- The checker enforces exactly its specification: `isAdmissible` accepts a
 transaction iff it is `Admissible`. -/
 theorem Tx.isAdmissible_iff {scriptOk : ScriptCheck} {utxos : UtxoSet}
-    {clock : FinalityClock} {ctx : TxContext} {tx : Tx} :
+    {clock : LockTimeClock} {ctx : TxContext} {tx : Tx} :
     tx.isAdmissible scriptOk utxos clock ctx = true
       ↔ Tx.Admissible scriptOk utxos clock ctx tx := by
   simp only [isAdmissible, Bool.and_eq_true, List.all_eq_true,
-    decide_eq_true_eq, TxBody.isFinal_iff, List.mem_range]
+    decide_eq_true_eq, TxBody.isLockTimeSatisfied_iff, List.mem_range]
   constructor
   · rintro ⟨⟨⟨⟨⟨⟨⟨hmem, hmature⟩, hinputBound⟩, hcover⟩, hfee⟩,
-      hfinal⟩, habsent⟩, hscripts⟩
+      hlock⟩, habsent⟩, hscripts⟩
     refine ⟨fun o ho => Finmap.lookup_isSome.mp (hmem o ho), ?_,
-      hinputBound, hcover, hfee, hfinal, ?_, fun i hi => hscripts i hi⟩
+      hinputBound, hcover, hfee, hlock, ?_, fun i hi => hscripts i hi⟩
     · intro o ho coin hcoin
       have hgetD := hmature o ho
       rw [hcoin] at hgetD
@@ -281,10 +289,10 @@ theorem Tx.isAdmissible_iff {scriptOk : ScriptCheck} {utxos : UtxoSet}
       have hnone := habsent entry hentry
       rw [Option.isNone_iff_eq_none, Finmap.lookup_eq_none] at hnone
       exact hnone
-  · rintro ⟨hmem, hmature, hinputBound, hcover, hfee, hfinal, habsent,
+  · rintro ⟨hmem, hmature, hinputBound, hcover, hfee, hlock, habsent,
       hscripts⟩
     refine ⟨⟨⟨⟨⟨⟨⟨fun o ho => Finmap.lookup_isSome.mpr (hmem o ho), ?_⟩,
-      hinputBound⟩, hcover⟩, hfee⟩, hfinal⟩, ?_⟩,
+      hinputBound⟩, hcover⟩, hfee⟩, hlock⟩, ?_⟩,
       fun i hi => hscripts i hi⟩
     · intro o ho
       cases hcoin : utxos.lookup o with
@@ -296,7 +304,7 @@ theorem Tx.isAdmissible_iff {scriptOk : ScriptCheck} {utxos : UtxoSet}
       exact habsent _ (List.mem_map_of_mem hentry)
 
 instance instDecidableAdmissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
-    (clock : FinalityClock) (ctx : TxContext) :
+    (clock : LockTimeClock) (ctx : TxContext) :
     DecidablePred (Tx.Admissible scriptOk utxos clock ctx) :=
   fun _ => decidable_of_iff _ Tx.isAdmissible_iff
 

--- a/BtcVerified/Consensus/TxContextual.lean
+++ b/BtcVerified/Consensus/TxContextual.lean
@@ -16,13 +16,14 @@ import BtcVerified.Consensus.ScriptCheck
   specification it is proved to enforce (`Tx.isAdmissible_iff`), and its
   named fields are exactly the facts the action theorems consume.
 
-  Two Core checks have no rule here, and why:
+  Core's `MoneyRange` checks on value-in and fee remain explicit here even
+  though `Nat` eliminates arithmetic overflow: this checker ranges over an
+  arbitrary `UtxoSet`, not only states reachable from genesis. Issue #50
+  tracks proving these checks redundant under the supply invariant once #37
+  provides it.
 
-  * the `MoneyRange` re-checks on value-in and fee are `int64` overflow
-    armor; in `Nat` there is no overflow, and the sub-`maxMoney` bound on
-    any honest set's values is the supply theorem's business (#37).
-  * BIP68 relative lock times need per-coin median-time-past history that
-    no leaf provides yet; deferred to its own leaf.
+  One contextual Core rule remains deferred: BIP68 relative lock times need
+  per-coin median-time-past history that no leaf provides yet.
 
   `creates_absent` is BIP30's content in current-state vocabulary: a
   transaction may not create an outpoint that *currently* holds an unspent
@@ -41,10 +42,10 @@ import BtcVerified.Consensus.ScriptCheck
   * `Tx.spentCoins_length`: under the existence rule, the spent-coin list
     has one coin per input.
   * `Tx.isAdmissible_iff`: the checker accepts a transaction exactly when it
-    satisfies the six contextual rules — inputs exist, coinbase spends are
-    mature, inputs cover outputs, the transaction is final, no created
-    outpoint is currently unspent, and every input passes the script
-    judgment.
+    satisfies the eight contextual rules — inputs exist, coinbase spends are
+    mature, input value and fee stay within `maxMoney`, inputs cover outputs,
+    the transaction is final, no created outpoint is currently unspent, and
+    every input passes the script judgment.
 -/
 
 namespace BtcVerified
@@ -124,16 +125,21 @@ theorem Tx.spentCoins_length {tx : Tx} {utxos : UtxoSet}
 
 /-- Decide the chain-contextual validity of a regular transaction over the
 UTXO set, script validity supplied as a parameter: inputs exist, coinbase
-spends are mature, inputs cover outputs, the transaction is final, no
-created outpoint is currently unspent, and every input passes the script
-judgment. -/
+spends are mature, input value and fee stay within `maxMoney`, inputs cover
+outputs, the transaction is final, no created outpoint is currently unspent,
+and every input passes the script judgment. -/
 def Tx.isAdmissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
     (ctx : TxContext) (tx : Tx) : Bool :=
   tx.body.spends.all (fun o => (utxos.lookup o).isSome)
     && tx.body.spends.all
         (fun o => ((utxos.lookup o).map (·.isMature ctx.height)).getD true)
+    && decide ((tx.body.spends.map utxos.valueAt).sum
+        ≤ Consensus.maxMoney)
     && decide ((tx.body.outputs.val.map fun o => o.value.toNat).sum
         ≤ (tx.body.spends.map utxos.valueAt).sum)
+    && decide ((tx.body.spends.map utxos.valueAt).sum
+        - (tx.body.outputs.val.map fun o => o.value.toNat).sum
+        ≤ Consensus.maxMoney)
     && tx.body.isFinal ctx
     && tx.body.creates.all (fun entry => (utxos.lookup entry.1).isNone)
     && (List.range tx.body.inputs.val.length).all
@@ -151,10 +157,22 @@ structure Tx.Admissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
   (`bad-txns-premature-spend-of-coinbase`). -/
   spends_mature : ∀ o ∈ tx.body.spends, ∀ coin,
     utxos.lookup o = some coin → coin.Mature ctx.height
+  /-- The total input value stays within `maxMoney`; in `Nat` this one total
+  bound subsumes Core's per-coin and running-total `MoneyRange` checks
+  ([Bitcoin Core v28.0, `tx_verify.cpp` lines
+  184–188](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L184-L188)). -/
+  input_values_bounded : (tx.body.spends.map utxos.valueAt).sum
+    ≤ Consensus.maxMoney
   /-- The inputs cover the outputs: value out ≤ value in, in `Nat` — fee
   non-negativity is this same fact (`bad-txns-in-belowout`). -/
   values_cover : (tx.body.outputs.val.map fun o => o.value.toNat).sum
     ≤ (tx.body.spends.map utxos.valueAt).sum
+  /-- The fee — input value minus output value in `Nat` — stays within
+  `maxMoney` ([Bitcoin Core v28.0, `tx_verify.cpp` lines
+  197–200](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L197-L200)). -/
+  fee_bounded : (tx.body.spends.map utxos.valueAt).sum
+      - (tx.body.outputs.val.map fun o => o.value.toNat).sum
+    ≤ Consensus.maxMoney
   /-- The transaction is final for the admitting block (`non-final`). -/
   final : tx.body.Final ctx
   /-- No created outpoint currently holds an unspent coin — BIP30's content;
@@ -174,9 +192,10 @@ theorem Tx.isAdmissible_iff {scriptOk : ScriptCheck} {utxos : UtxoSet}
   simp only [isAdmissible, Bool.and_eq_true, List.all_eq_true,
     decide_eq_true_eq, TxBody.isFinal_iff, List.mem_range]
   constructor
-  · rintro ⟨⟨⟨⟨⟨hmem, hmature⟩, hcover⟩, hfinal⟩, habsent⟩, hscripts⟩
-    refine ⟨fun o ho => Finmap.lookup_isSome.mp (hmem o ho), ?_, hcover,
-      hfinal, ?_, fun i hi => hscripts i hi⟩
+  · rintro ⟨⟨⟨⟨⟨⟨⟨hmem, hmature⟩, hinputBound⟩, hcover⟩, hfee⟩,
+      hfinal⟩, habsent⟩, hscripts⟩
+    refine ⟨fun o ho => Finmap.lookup_isSome.mp (hmem o ho), ?_,
+      hinputBound, hcover, hfee, hfinal, ?_, fun i hi => hscripts i hi⟩
     · intro o ho coin hcoin
       have hgetD := hmature o ho
       rw [hcoin] at hgetD
@@ -186,9 +205,11 @@ theorem Tx.isAdmissible_iff {scriptOk : ScriptCheck} {utxos : UtxoSet}
       have hnone := habsent entry hentry
       rw [Option.isNone_iff_eq_none, Finmap.lookup_eq_none] at hnone
       exact hnone
-  · rintro ⟨hmem, hmature, hcover, hfinal, habsent, hscripts⟩
-    refine ⟨⟨⟨⟨⟨fun o ho => Finmap.lookup_isSome.mpr (hmem o ho), ?_⟩,
-      hcover⟩, hfinal⟩, ?_⟩, fun i hi => hscripts i hi⟩
+  · rintro ⟨hmem, hmature, hinputBound, hcover, hfee, hfinal, habsent,
+      hscripts⟩
+    refine ⟨⟨⟨⟨⟨⟨⟨fun o ho => Finmap.lookup_isSome.mpr (hmem o ho), ?_⟩,
+      hinputBound⟩, hcover⟩, hfee⟩, hfinal⟩, ?_⟩,
+      fun i hi => hscripts i hi⟩
     · intro o ho
       cases hcoin : utxos.lookup o with
       | none => rfl

--- a/BtcVerified/Consensus/TxContextual.lean
+++ b/BtcVerified/Consensus/TxContextual.lean
@@ -1,0 +1,205 @@
+import BtcVerified.Chainstate.Apply
+import BtcVerified.Consensus.Limits
+import BtcVerified.Consensus.TxContext
+import BtcVerified.Consensus.ScriptCheck
+/-!
+  # Contextual transaction rules
+
+  The chain-contextual bucket: what consensus demands of a regular
+  transaction relative to the UTXO set and the admitting block — Core's
+  `Consensus::CheckTxInputs` (`src/consensus/tx_verify.cpp`) and `IsFinalTx`,
+  plus the rule that keeps the machine's insert-replaces path unreachable.
+  Script validity is the `ScriptCheck` parameter; every rule here is
+  script-agnostic.
+
+  The enforced rule is the checker `Tx.isAdmissible`; `Tx.Admissible` is the
+  specification it is proved to enforce (`Tx.isAdmissible_iff`), and its
+  named fields are exactly the facts the action theorems consume.
+
+  Two Core checks have no rule here, and why:
+
+  * the `MoneyRange` re-checks on value-in and fee are `int64` overflow
+    armor; in `Nat` there is no overflow, and the sub-`maxMoney` bound on
+    any honest set's values is the supply theorem's business (#37).
+  * BIP68 relative lock times need per-coin median-time-past history that
+    no leaf provides yet; deferred to its own leaf.
+
+  `creates_absent` is BIP30's content in current-state vocabulary: a
+  transaction may not create an outpoint that *currently* holds an unspent
+  coin (recreating a fully-spent outpoint is legal — it happened before
+  BIP34). The two 2010 duplicate-coinbase blocks and Core's post-BIP34 skip
+  of this check are activation history, owned by the ruleset mapping
+  (#38/#39); the rule itself is height-free.
+
+  Checked claims:
+
+  * `Coin.isMature_iff`: the maturity checker accepts a coin at a height
+    exactly when the coin is non-coinbase or `coinbaseMaturity` blocks deep.
+  * `TxBody.isFinal_iff`: the finality checker accepts exactly when the lock
+    is zero, already past on the axis the lock time selects, or overridden
+    by every input carrying the final sequence.
+  * `Tx.spentCoins_length`: under the existence rule, the spent-coin list
+    has one coin per input.
+  * `Tx.isAdmissible_iff`: the checker accepts a transaction exactly when it
+    satisfies the six contextual rules — inputs exist, coinbase spends are
+    mature, inputs cover outputs, the transaction is final, no created
+    outpoint is currently unspent, and every input passes the script
+    judgment.
+-/
+
+namespace BtcVerified
+
+/-- Decide that a coin is spendable at `height`: immediately, unless it was
+created in coinbase position — then only once `coinbaseMaturity` blocks
+deep. -/
+def Coin.isMature (coin : Coin) (height : Nat) : Bool :=
+  !coin.provenance.coinbase
+    || decide (coin.provenance.height + Consensus.coinbaseMaturity ≤ height)
+
+/-- The specification `Coin.isMature` enforces: coinbase provenance implies
+the creation height is at least `coinbaseMaturity` blocks above. -/
+def Coin.Mature (coin : Coin) (height : Nat) : Prop :=
+  coin.provenance.coinbase = true →
+    coin.provenance.height + Consensus.coinbaseMaturity ≤ height
+
+/-- The maturity checker enforces exactly its specification: `isMature`
+accepts a coin at a height iff the coin is `Mature` there. -/
+theorem Coin.isMature_iff {coin : Coin} {height : Nat} :
+    coin.isMature height = true ↔ coin.Mature height := by
+  simp only [isMature, Mature, Bool.or_eq_true, Bool.not_eq_true',
+    decide_eq_true_eq]
+  constructor
+  · rintro (hcb | hdeep) htrue
+    · rw [htrue] at hcb
+      cases hcb
+    · exact hdeep
+  · intro h
+    cases hcb : coin.provenance.coinbase with
+    | false => exact Or.inl rfl
+    | true => exact Or.inr (h hcb)
+
+/-- Decide lock-time finality for an evaluation context (Core's `IsFinalTx`):
+the lock is disabled (zero), already past — the lock time itself selecting
+the height or time axis by `lockTimeThreshold` — or overridden by every
+input carrying the final sequence. -/
+def TxBody.isFinal (body : TxBody) (ctx : TxContext) : Bool :=
+  body.lockTime == 0
+    || decide (body.lockTime.toNat <
+        if body.lockTime.toNat < Consensus.lockTimeThreshold
+        then ctx.height else ctx.time)
+    || body.inputs.val.all (·.sequence == Consensus.sequenceFinal)
+
+/-- The specification `TxBody.isFinal` enforces: the lock time is zero, or
+strictly below the height or time the threshold axis selects, or every
+input's sequence is final. -/
+def TxBody.Final (body : TxBody) (ctx : TxContext) : Prop :=
+  body.lockTime = 0
+    ∨ body.lockTime.toNat <
+        (if body.lockTime.toNat < Consensus.lockTimeThreshold
+         then ctx.height else ctx.time)
+    ∨ ∀ input ∈ body.inputs.val, input.sequence = Consensus.sequenceFinal
+
+/-- The finality checker enforces exactly its specification: `isFinal`
+accepts a body in a context iff the body is `Final` there. -/
+theorem TxBody.isFinal_iff {body : TxBody} {ctx : TxContext} :
+    body.isFinal ctx = true ↔ body.Final ctx := by
+  simp [isFinal, Final, Bool.or_eq_true, List.all_eq_true, or_assoc]
+
+/-- The coins a transaction's inputs consume, in input order — total via
+`filterMap`, aligned with the inputs whenever the existence rule holds
+(`Tx.spentCoins_length`). -/
+def Tx.spentCoins (tx : Tx) (utxos : UtxoSet) : List Coin :=
+  tx.body.spends.filterMap fun o => utxos.lookup o
+
+/-- Under the existence rule the spent-coin list is aligned with the inputs:
+one coin per input, in order. -/
+theorem Tx.spentCoins_length {tx : Tx} {utxos : UtxoSet}
+    (h : ∀ o ∈ tx.body.spends, o ∈ utxos) :
+    (tx.spentCoins utxos).length = tx.body.inputs.val.length := by
+  have hlen : (tx.body.spends.filterMap fun o => utxos.lookup o).length
+      = tx.body.spends.length :=
+    List.filterMap_length_eq_length.mpr
+      fun o ho => Finmap.lookup_isSome.mpr (h o ho)
+  rw [spentCoins, hlen, TxBody.spends, List.length_map]
+
+/-- Decide the chain-contextual validity of a regular transaction over the
+UTXO set, script validity supplied as a parameter: inputs exist, coinbase
+spends are mature, inputs cover outputs, the transaction is final, no
+created outpoint is currently unspent, and every input passes the script
+judgment. -/
+def Tx.isAdmissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
+    (ctx : TxContext) (tx : Tx) : Bool :=
+  tx.body.spends.all (fun o => (utxos.lookup o).isSome)
+    && tx.body.spends.all
+        (fun o => ((utxos.lookup o).map (·.isMature ctx.height)).getD true)
+    && decide ((tx.body.outputs.val.map fun o => o.value.toNat).sum
+        ≤ (tx.body.spends.map utxos.valueAt).sum)
+    && tx.body.isFinal ctx
+    && tx.body.creates.all (fun entry => (utxos.lookup entry.1).isNone)
+    && (List.range tx.body.inputs.val.length).all
+        (fun i => scriptOk (tx.spentCoins utxos) i tx)
+
+/-- The specification `Tx.isAdmissible` enforces — Core's contextual checks
+for a regular transaction, one field per rule; the fields are the facts the
+action theorems consume. -/
+structure Tx.Admissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
+    (ctx : TxContext) (tx : Tx) : Prop where
+  /-- Every input's outpoint is an unspent coin
+  (`bad-txns-inputs-missingorspent`). -/
+  spends_mem : ∀ o ∈ tx.body.spends, o ∈ utxos
+  /-- Every coinbase coin spent is at least `coinbaseMaturity` blocks deep
+  (`bad-txns-premature-spend-of-coinbase`). -/
+  spends_mature : ∀ o ∈ tx.body.spends, ∀ coin,
+    utxos.lookup o = some coin → coin.Mature ctx.height
+  /-- The inputs cover the outputs: value out ≤ value in, in `Nat` — fee
+  non-negativity is this same fact (`bad-txns-in-belowout`). -/
+  values_cover : (tx.body.outputs.val.map fun o => o.value.toNat).sum
+    ≤ (tx.body.spends.map utxos.valueAt).sum
+  /-- The transaction is final for the admitting block (`non-final`). -/
+  final : tx.body.Final ctx
+  /-- No created outpoint currently holds an unspent coin — BIP30's content;
+  its historical carve-outs are the activation layer's business (#38/#39). -/
+  creates_absent : ∀ o ∈ tx.body.creates.map Prod.fst, o ∉ utxos
+  /-- Every input satisfies the script judgment against the coins the
+  transaction spends. -/
+  scripts_ok : ∀ i < tx.body.inputs.val.length,
+    scriptOk (tx.spentCoins utxos) i tx = true
+
+/-- The checker enforces exactly its specification: `isAdmissible` accepts a
+transaction iff it is `Admissible`. -/
+theorem Tx.isAdmissible_iff {scriptOk : ScriptCheck} {utxos : UtxoSet}
+    {ctx : TxContext} {tx : Tx} :
+    tx.isAdmissible scriptOk utxos ctx = true
+      ↔ Tx.Admissible scriptOk utxos ctx tx := by
+  simp only [isAdmissible, Bool.and_eq_true, List.all_eq_true,
+    decide_eq_true_eq, TxBody.isFinal_iff, List.mem_range]
+  constructor
+  · rintro ⟨⟨⟨⟨⟨hmem, hmature⟩, hcover⟩, hfinal⟩, habsent⟩, hscripts⟩
+    refine ⟨fun o ho => Finmap.lookup_isSome.mp (hmem o ho), ?_, hcover,
+      hfinal, ?_, fun i hi => hscripts i hi⟩
+    · intro o ho coin hcoin
+      have hgetD := hmature o ho
+      rw [hcoin] at hgetD
+      exact Coin.isMature_iff.mp hgetD
+    · intro o ho
+      obtain ⟨entry, hentry, rfl⟩ := List.mem_map.mp ho
+      have hnone := habsent entry hentry
+      rw [Option.isNone_iff_eq_none, Finmap.lookup_eq_none] at hnone
+      exact hnone
+  · rintro ⟨hmem, hmature, hcover, hfinal, habsent, hscripts⟩
+    refine ⟨⟨⟨⟨⟨fun o ho => Finmap.lookup_isSome.mpr (hmem o ho), ?_⟩,
+      hcover⟩, hfinal⟩, ?_⟩, fun i hi => hscripts i hi⟩
+    · intro o ho
+      cases hcoin : utxos.lookup o with
+      | none => rfl
+      | some coin =>
+          exact Coin.isMature_iff.mpr (hmature o ho coin hcoin)
+    · intro entry hentry
+      rw [Option.isNone_iff_eq_none, Finmap.lookup_eq_none]
+      exact habsent _ (List.mem_map_of_mem hentry)
+
+instance instDecidableAdmissible (scriptOk : ScriptCheck) (utxos : UtxoSet)
+    (ctx : TxContext) : DecidablePred (Tx.Admissible scriptOk utxos ctx) :=
+  fun _ => decidable_of_iff _ Tx.isAdmissible_iff
+
+end BtcVerified

--- a/BtcVerified/Consensus/TxStateless.lean
+++ b/BtcVerified/Consensus/TxStateless.lean
@@ -2,14 +2,17 @@ import BtcVerified.Transaction.Tx
 import BtcVerified.Chainstate.Apply
 import BtcVerified.Consensus.Limits
 /-!
-  # Stateless transaction rules
+  # Transaction-local premises
 
-  The context-free bucket: what consensus demands of a regular transaction
-  before looking at any chain state — Core's `CheckTransaction`
+  The transaction-local premises used while checking a regular transaction
+  inside a candidate block, before looking at any chain state — Core's
+  `CheckTransaction`
   (`src/consensus/tx_check.cpp`), restricted to a transaction with real
   inputs. A transaction in coinbase position is judged by block rules (#37),
   because coinbase-ness is positional; here its null prevout simply fails
-  `spends_ne_null`.
+  `spends_ne_null`. Passing these premises is not a standalone consensus
+  verdict; block-extension validity composes them with contextual and
+  block-wide premises.
 
   The enforced rule is the checker `Tx.isWellFormed`; `Tx.WellFormed` is the
   specification it is proved to enforce (`Tx.isWellFormed_iff`). Downstream
@@ -32,8 +35,9 @@ import BtcVerified.Consensus.Limits
     spent twice, no input claims the null outpoint, the outputs create at
     most `maxMoney` satoshis in total, and the stripped serialization fits
     within the per-transaction weight ceiling.
-  * `Tx.WellFormed.outputs_length_le`: a stateless-valid transaction has at
-    most `2 ^ 32` outputs, so its `UInt32` output indices cannot wrap.
+  * `Tx.WellFormed.outputs_length_le`: a transaction satisfying the local
+    premises has at most `2 ^ 32` outputs, so its `UInt32` output indices
+    cannot wrap.
 -/
 
 namespace BtcVerified
@@ -44,10 +48,11 @@ serialization. -/
 def Tx.strippedSize (tx : Tx) : Nat :=
   (Serialize.Codec.encode tx.body).length
 
-/-- Decide the context-free validity of a regular transaction: some output
-exists, no outpoint is spent twice, no input claims the null outpoint, and
-the outputs create at most `maxMoney` satoshis in total, and the stripped
-serialization fits within Core's per-transaction weight ceiling
+/-- Decide the transaction-local admissibility premises for a regular
+transaction: some output exists, no outpoint is spent twice, no input claims
+the null outpoint, the outputs create at most `maxMoney` satoshis in total,
+and the stripped serialization fits within Core's per-transaction weight
+ceiling
 ([Bitcoin Core v28.0, `tx_check.cpp` lines 18–21](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L18-L21)). -/
 def Tx.isWellFormed (tx : Tx) : Bool :=
   decide (tx.body.outputs.val ≠ [])
@@ -108,9 +113,9 @@ private theorem TxOut.list_length_le_encodeElems_length (outputs : List TxOut) :
     have houtput := TxOut.one_le_encode_length output
     omega
 
-/-- A stateless-valid transaction has at most `2 ^ 32` outputs: Core's
-stripped-size rule is far tighter than the width of an outpoint's `vout`, so
-the `UInt32` indices used by the UTXO action cannot wrap. -/
+/-- A transaction satisfying the local premises has at most `2 ^ 32` outputs:
+Core's stripped-size rule is far tighter than the width of an outpoint's
+`vout`, so the `UInt32` indices used by the UTXO action cannot wrap. -/
 theorem Tx.WellFormed.outputs_length_le {tx : Tx} (h : tx.WellFormed) :
     tx.body.outputs.val.length ≤ 2 ^ 32 := by
   have helems := TxOut.list_length_le_encodeElems_length tx.body.outputs.val

--- a/BtcVerified/Consensus/TxStateless.lean
+++ b/BtcVerified/Consensus/TxStateless.lean
@@ -1,0 +1,80 @@
+import BtcVerified.Transaction.Tx
+import BtcVerified.Chainstate.Apply
+import BtcVerified.Consensus.Limits
+/-!
+  # Stateless transaction rules
+
+  The context-free bucket: what consensus demands of a regular transaction
+  before looking at any chain state — Core's `CheckTransaction`
+  (`src/consensus/tx_check.cpp`), restricted to a transaction with real
+  inputs. A transaction in coinbase position is judged by block rules (#37),
+  because coinbase-ness is positional; here its null prevout simply fails
+  `spends_ne_null`.
+
+  The enforced rule is the checker `Tx.isWellFormed`; `Tx.WellFormed` is the
+  specification it is proved to enforce (`Tx.isWellFormed_iff`). Downstream
+  theorems consume the specification's named fields.
+
+  Core checks with no rule here, and why:
+
+  * empty `vin` — a type invariant, not a rule: `Tx.body_inputs_ne_nil`.
+  * negative amounts — unrepresentable (`UInt64` values, `Nat` sums).
+  * per-output and running-total `MoneyRange` — in `Nat` the single sum
+    bound `values_bounded` subsumes every per-output bound; no overflow
+    exists to re-check.
+  * oversize — a block rule (#37); it is also what discharges the
+    `outputs.length ≤ 2 ^ 32` hypothesis of the action theorems.
+  * coinbase scriptSig length — a block rule (#37), with the rest of the
+    coinbase's structural checks.
+
+  Checked claims:
+
+  * `Tx.isWellFormed_iff`: the checker accepts a transaction exactly when it
+    satisfies the four stateless rules — some output exists, no outpoint is
+    spent twice, no input claims the null outpoint, and the outputs create
+    at most `maxMoney` satoshis in total.
+-/
+
+namespace BtcVerified
+
+/-- Decide the context-free validity of a regular transaction: some output
+exists, no outpoint is spent twice, no input claims the null outpoint, and
+the outputs create at most `maxMoney` satoshis in total. -/
+def Tx.isWellFormed (tx : Tx) : Bool :=
+  decide (tx.body.outputs.val ≠ [])
+    && decide tx.body.spends.Nodup
+    && tx.body.spends.all (· != OutPoint.null)
+    && decide ((tx.body.outputs.val.map fun o => o.value.toNat).sum
+        ≤ Consensus.maxMoney)
+
+/-- The specification `Tx.isWellFormed` enforces — Core's `CheckTransaction`
+for a transaction with real inputs, one field per rule. -/
+structure Tx.WellFormed (tx : Tx) : Prop where
+  /-- There is at least one output (`bad-txns-vout-empty`). -/
+  outputs_ne_nil : tx.body.outputs.val ≠ []
+  /-- No two inputs consume the same outpoint (`bad-txns-inputs-duplicate`). -/
+  spends_nodup : tx.body.spends.Nodup
+  /-- No input claims the null outpoint (`bad-txns-prevout-null`). -/
+  spends_ne_null : ∀ o ∈ tx.body.spends, o ≠ OutPoint.null
+  /-- The outputs create at most `maxMoney` satoshis in total — which in
+  `Nat` also bounds every individual output (`bad-txns-vout-toolarge`,
+  `bad-txns-txouttotal-toolarge`). -/
+  values_bounded : (tx.body.outputs.val.map fun o => o.value.toNat).sum
+    ≤ Consensus.maxMoney
+
+/-- The checker enforces exactly its specification: `isWellFormed` accepts a
+transaction iff it is `WellFormed`. -/
+theorem Tx.isWellFormed_iff {tx : Tx} :
+    tx.isWellFormed = true ↔ tx.WellFormed := by
+  simp only [isWellFormed, Bool.and_eq_true, decide_eq_true_eq,
+    List.all_eq_true, bne_iff_ne]
+  constructor
+  · rintro ⟨⟨⟨houtputs, hnodup⟩, hnull⟩, hbound⟩
+    exact ⟨houtputs, hnodup, hnull, hbound⟩
+  · rintro ⟨houtputs, hnodup, hnull, hbound⟩
+    exact ⟨⟨⟨houtputs, hnodup⟩, hnull⟩, hbound⟩
+
+instance instDecidableWellFormed : DecidablePred Tx.WellFormed :=
+  fun _ => decidable_of_iff _ Tx.isWellFormed_iff
+
+end BtcVerified

--- a/BtcVerified/Consensus/TxStateless.lean
+++ b/BtcVerified/Consensus/TxStateless.lean
@@ -6,35 +6,43 @@ import BtcVerified.Consensus.Limits
 
   The transaction-local premises used while checking a regular transaction
   inside a candidate block, before looking at any chain state — Core's
-  `CheckTransaction`
-  (`src/consensus/tx_check.cpp`), restricted to a transaction with real
-  inputs. A transaction in coinbase position is judged by block rules (#37),
-  because coinbase-ness is positional; here its null prevout simply fails
-  `spends_ne_null`. Passing these premises is not a standalone consensus
-  verdict; block-extension validity composes them with contextual and
-  block-wide premises.
+  [`CheckTransaction`, Bitcoin Core v28.0, `tx_check.cpp` lines
+  11–59](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L11-L59),
+  specialized to a transaction in regular position. A transaction in coinbase
+  position is judged by block rules (#37), because coinbase-ness is positional;
+  here its null prevout simply fails `spends_ne_null`. Passing these premises is
+  not a standalone consensus verdict; block-extension validity composes them
+  with contextual and block-wide premises.
 
   The enforced rule is the checker `Tx.isWellFormed`; `Tx.WellFormed` is the
   specification it is proved to enforce (`Tx.isWellFormed_iff`). Downstream
   theorems consume the specification's named fields.
 
-  Core checks with no rule here, and why:
+  Core checks represented differently here, and why:
 
-  * empty `vin` — a type invariant, not a rule: `Tx.body_inputs_ne_nil`.
-  * negative amounts — unrepresentable (`UInt64` values, `Nat` sums).
+  * empty `vin` — an explicit premise, because the syntax admits the degenerate
+    empty transaction Core's witness-aware decoder accepts ([Bitcoin Core
+    v28.0, `transaction.h` lines
+    220–252](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L220-L252)).
+  * negative amounts — unrepresentable (`UInt64` values, `Nat` sums), unlike
+    Core's signed `CAmount` and explicit negative-output rejection
+    ([`amount.h` lines 11–12](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/amount.h#L11-L12),
+    [`tx_check.cpp` lines 23–30](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L23-L30)).
   * per-output and running-total `MoneyRange` — in `Nat` the single sum
     bound `values_bounded` subsumes every per-output bound; no overflow
-    exists to re-check.
+    exists to re-check ([Bitcoin Core v28.0, `tx_check.cpp` lines
+    23–33](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L23-L33)).
   * coinbase scriptSig length — a block rule (#37), with the rest of the
-    coinbase's structural checks.
+    coinbase's structural checks ([Bitcoin Core v28.0, `tx_check.cpp` lines
+    47–50](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L47-L50)).
 
   Checked claims:
 
   * `Tx.isWellFormed_iff`: the checker accepts a transaction exactly when it
-    satisfies the five stateless rules — some output exists, no outpoint is
-    spent twice, no input claims the null outpoint, the outputs create at
-    most `maxMoney` satoshis in total, and the stripped serialization fits
-    within the per-transaction weight ceiling.
+    satisfies the six stateless rules — some input and output exist, no outpoint
+    is spent twice, no input claims the null outpoint, the outputs create at most
+    `maxMoney` satoshis in total, and the stripped serialization fits within the
+    per-transaction weight ceiling.
   * `Tx.WellFormed.outputs_length_le`: a transaction satisfying the local
     premises has at most `2 ^ 32` outputs, so its `UInt32` output indices
     cannot wrap.
@@ -44,18 +52,20 @@ namespace BtcVerified
 
 /-- The transaction's serialization size without witness data: exactly Core's
 `GetSerializeSize(TX_NO_WITNESS(tx))`, because `TxBody` is the stripped
-serialization. -/
+serialization ([Bitcoin Core v28.0, `tx_check.cpp` lines
+18–20](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L18-L20)). -/
 def Tx.strippedSize (tx : Tx) : Nat :=
   (Serialize.Codec.encode tx.body).length
 
 /-- Decide the transaction-local admissibility premises for a regular
-transaction: some output exists, no outpoint is spent twice, no input claims
+transaction: some input and output exist, no outpoint is spent twice, no input claims
 the null outpoint, the outputs create at most `maxMoney` satoshis in total,
 and the stripped serialization fits within Core's per-transaction weight
 ceiling
 ([Bitcoin Core v28.0, `tx_check.cpp` lines 18–21](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L18-L21)). -/
 def Tx.isWellFormed (tx : Tx) : Bool :=
-  decide (tx.body.outputs.val ≠ [])
+  decide (tx.body.inputs.val ≠ [])
+    && decide (tx.body.outputs.val ≠ [])
     && decide tx.body.spends.Nodup
     && tx.body.spends.all (· != OutPoint.null)
     && decide ((tx.body.outputs.val.map fun o => o.value.toNat).sum
@@ -63,18 +73,29 @@ def Tx.isWellFormed (tx : Tx) : Bool :=
     && decide (tx.strippedSize * Consensus.witnessScaleFactor
         ≤ Consensus.maxBlockWeight)
 
-/-- The specification `Tx.isWellFormed` enforces — Core's `CheckTransaction`
-for a transaction with real inputs, one field per rule. -/
+/-- The specification `Tx.isWellFormed` enforces — the regular-transaction
+projection of Core's `CheckTransaction`, one field per rule ([Bitcoin Core
+v28.0, `tx_check.cpp` lines
+11–59](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L11-L59)). -/
 structure Tx.WellFormed (tx : Tx) : Prop where
-  /-- There is at least one output (`bad-txns-vout-empty`). -/
+  /-- There is at least one input (`bad-txns-vin-empty`; [Bitcoin Core v28.0,
+  `tx_check.cpp` lines 14–15](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L14-L15)). -/
+  inputs_ne_nil : tx.body.inputs.val ≠ []
+  /-- There is at least one output (`bad-txns-vout-empty`; [Bitcoin Core v28.0,
+  `tx_check.cpp` lines 16–17](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L16-L17)). -/
   outputs_ne_nil : tx.body.outputs.val ≠ []
-  /-- No two inputs consume the same outpoint (`bad-txns-inputs-duplicate`). -/
+  /-- No two inputs consume the same outpoint (`bad-txns-inputs-duplicate`;
+  [Bitcoin Core v28.0, `tx_check.cpp` lines
+  36–44](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L36-L44)). -/
   spends_nodup : tx.body.spends.Nodup
-  /-- No input claims the null outpoint (`bad-txns-prevout-null`). -/
+  /-- No regular input claims the null outpoint (`bad-txns-prevout-null`;
+  [Bitcoin Core v28.0, `tx_check.cpp` lines
+  47–56](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L47-L56)). -/
   spends_ne_null : ∀ o ∈ tx.body.spends, o ≠ OutPoint.null
   /-- The outputs create at most `maxMoney` satoshis in total — which in
   `Nat` also bounds every individual output (`bad-txns-vout-toolarge`,
-  `bad-txns-txouttotal-toolarge`). -/
+  `bad-txns-txouttotal-toolarge`; [Bitcoin Core v28.0, `tx_check.cpp` lines
+  23–33](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L23-L33)). -/
   values_bounded : (tx.body.outputs.val.map fun o => o.value.toNat).sum
     ≤ Consensus.maxMoney
   /-- The stripped serialization, scaled to weight units, fits within Core's
@@ -90,10 +111,10 @@ theorem Tx.isWellFormed_iff {tx : Tx} :
   simp only [isWellFormed, Bool.and_eq_true, decide_eq_true_eq,
     List.all_eq_true, bne_iff_ne]
   constructor
-  · rintro ⟨⟨⟨⟨houtputs, hnodup⟩, hnull⟩, hbound⟩, hsize⟩
-    exact ⟨houtputs, hnodup, hnull, hbound, hsize⟩
-  · rintro ⟨houtputs, hnodup, hnull, hbound, hsize⟩
-    exact ⟨⟨⟨⟨houtputs, hnodup⟩, hnull⟩, hbound⟩, hsize⟩
+  · rintro ⟨⟨⟨⟨⟨hinputs, houtputs⟩, hnodup⟩, hnull⟩, hbound⟩, hsize⟩
+    exact ⟨hinputs, houtputs, hnodup, hnull, hbound, hsize⟩
+  · rintro ⟨hinputs, houtputs, hnodup, hnull, hbound, hsize⟩
+    exact ⟨⟨⟨⟨⟨hinputs, houtputs⟩, hnodup⟩, hnull⟩, hbound⟩, hsize⟩
 
 private theorem TxOut.one_le_encode_length (output : TxOut) :
     1 ≤ (Serialize.Codec.encode output).length := by
@@ -115,7 +136,9 @@ private theorem TxOut.list_length_le_encodeElems_length (outputs : List TxOut) :
 
 /-- A transaction satisfying the local premises has at most `2 ^ 32` outputs:
 Core's stripped-size rule is far tighter than the width of an outpoint's
-`vout`, so the `UInt32` indices used by the UTXO action cannot wrap. -/
+`vout`, so the `UInt32` indices used by the UTXO action cannot wrap
+([Bitcoin Core v28.0, `tx_check.cpp` lines
+18–21](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L18-L21)). -/
 theorem Tx.WellFormed.outputs_length_le {tx : Tx} (h : tx.WellFormed) :
     tx.body.outputs.val.length ≤ 2 ^ 32 := by
   have helems := TxOut.list_length_le_encodeElems_length tx.body.outputs.val

--- a/BtcVerified/Consensus/TxStateless.lean
+++ b/BtcVerified/Consensus/TxStateless.lean
@@ -38,11 +38,13 @@ import BtcVerified.Consensus.Limits
 
   Checked claims:
 
+  * `Tx.stripped_size_bound_iff_core`: the semantic legacy serialized-size
+    bound is equivalent to Core v28's weight-unit expression.
   * `Tx.isWellFormed_iff`: the checker accepts a transaction exactly when it
     satisfies the six stateless rules — some input and output exist, no outpoint
     is spent twice, no input claims the null outpoint, the outputs create at most
     `maxMoney` satoshis in total, and the stripped serialization fits within the
-    per-transaction weight ceiling.
+    historical one-million-byte ceiling.
   * `Tx.WellFormed.outputs_length_le`: a transaction satisfying the local
     premises has at most `2 ^ 32` outputs, so its `UInt32` output indices
     cannot wrap.
@@ -57,12 +59,26 @@ serialization ([Bitcoin Core v28.0, `tx_check.cpp` lines
 def Tx.strippedSize (tx : Tx) : Nat :=
   (Serialize.Codec.encode tx.body).length
 
+/-- The semantic legacy serialized-size bound is exactly equivalent to the
+weight-unit expression Core v28 uses in `CheckTransaction`. This theorem keeps
+the historical protocol rule primary while making the implementation
+correspondence explicit ([Bitcoin Core v28.0, `tx_check.cpp` lines
+18–21](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L18-L21)). -/
+theorem Tx.stripped_size_bound_iff_core {tx : Tx} :
+    tx.strippedSize ≤ Consensus.maxLegacySerializedSize ↔
+      tx.strippedSize * Consensus.witnessScaleFactor
+        ≤ Consensus.maxBlockWeight := by
+  unfold Consensus.maxLegacySerializedSize Consensus.witnessScaleFactor
+    Consensus.maxBlockWeight
+  omega
+
 /-- Decide the transaction-local admissibility premises for a regular
 transaction: some input and output exist, no outpoint is spent twice, no input claims
 the null outpoint, the outputs create at most `maxMoney` satoshis in total,
-and the stripped serialization fits within Core's per-transaction weight
-ceiling
-([Bitcoin Core v28.0, `tx_check.cpp` lines 18–21](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L18-L21)). -/
+and the stripped serialization fits within the historical one-million-byte
+ceiling. Core v28 expresses the equivalent check in weight units
+([Bitcoin Core v28.0, `tx_check.cpp` lines
+18–21](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L18-L21)). -/
 def Tx.isWellFormed (tx : Tx) : Bool :=
   decide (tx.body.inputs.val ≠ [])
     && decide (tx.body.outputs.val ≠ [])
@@ -70,8 +86,7 @@ def Tx.isWellFormed (tx : Tx) : Bool :=
     && tx.body.spends.all (· != OutPoint.null)
     && decide ((tx.body.outputs.val.map fun o => o.value.toNat).sum
         ≤ Consensus.maxMoney)
-    && decide (tx.strippedSize * Consensus.witnessScaleFactor
-        ≤ Consensus.maxBlockWeight)
+    && decide (tx.strippedSize ≤ Consensus.maxLegacySerializedSize)
 
 /-- The specification `Tx.isWellFormed` enforces — the regular-transaction
 projection of Core's `CheckTransaction`, one field per rule ([Bitcoin Core
@@ -98,11 +113,13 @@ structure Tx.WellFormed (tx : Tx) : Prop where
   23–33](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L23-L33)). -/
   values_bounded : (tx.body.outputs.val.map fun o => o.value.toNat).sum
     ≤ Consensus.maxMoney
-  /-- The stripped serialization, scaled to weight units, fits within Core's
-  per-transaction ceiling (`bad-txns-oversize`; [Bitcoin Core v28.0,
-  `tx_check.cpp` lines 18–21](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L18-L21)). -/
-  stripped_size_bounded : tx.strippedSize * Consensus.witnessScaleFactor
-    ≤ Consensus.maxBlockWeight
+  /-- The stripped serialization fits within the historical one-million-byte
+  ceiling (`bad-txns-oversize`). Core v28's weight-unit expression is proved
+  equivalent by `Tx.stripped_size_bound_iff_core` ([Bitcoin Core v28.0,
+  `tx_check.cpp` lines
+  18–21](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L18-L21)). -/
+  stripped_size_bounded : tx.strippedSize
+    ≤ Consensus.maxLegacySerializedSize
 
 /-- The checker enforces exactly its specification: `isWellFormed` accepts a
 transaction iff it is `WellFormed`. -/
@@ -135,7 +152,7 @@ private theorem TxOut.list_length_le_encodeElems_length (outputs : List TxOut) :
     omega
 
 /-- A transaction satisfying the local premises has at most `2 ^ 32` outputs:
-Core's stripped-size rule is far tighter than the width of an outpoint's
+the legacy serialized-size rule is far tighter than the width of an outpoint's
 `vout`, so the `UInt32` indices used by the UTXO action cannot wrap
 ([Bitcoin Core v28.0, `tx_check.cpp` lines
 18–21](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L18-L21)). -/
@@ -162,7 +179,7 @@ theorem Tx.WellFormed.outputs_length_le {tx : Tx} (h : tx.WellFormed) :
     simp only [List.length_append]
     omega
   have hsize := h.stripped_size_bounded
-  unfold Consensus.witnessScaleFactor Consensus.maxBlockWeight at hsize
+  unfold Consensus.maxLegacySerializedSize at hsize
   omega
 
 instance instDecidableWellFormed : DecidablePred Tx.WellFormed :=

--- a/BtcVerified/Consensus/TxStateless.lean
+++ b/BtcVerified/Consensus/TxStateless.lean
@@ -22,30 +22,41 @@ import BtcVerified.Consensus.Limits
   * per-output and running-total `MoneyRange` — in `Nat` the single sum
     bound `values_bounded` subsumes every per-output bound; no overflow
     exists to re-check.
-  * oversize — a block rule (#37); it is also what discharges the
-    `outputs.length ≤ 2 ^ 32` hypothesis of the action theorems.
   * coinbase scriptSig length — a block rule (#37), with the rest of the
     coinbase's structural checks.
 
   Checked claims:
 
   * `Tx.isWellFormed_iff`: the checker accepts a transaction exactly when it
-    satisfies the four stateless rules — some output exists, no outpoint is
-    spent twice, no input claims the null outpoint, and the outputs create
-    at most `maxMoney` satoshis in total.
+    satisfies the five stateless rules — some output exists, no outpoint is
+    spent twice, no input claims the null outpoint, the outputs create at
+    most `maxMoney` satoshis in total, and the stripped serialization fits
+    within the per-transaction weight ceiling.
+  * `Tx.WellFormed.outputs_length_le`: a stateless-valid transaction has at
+    most `2 ^ 32` outputs, so its `UInt32` output indices cannot wrap.
 -/
 
 namespace BtcVerified
 
+/-- The transaction's serialization size without witness data: exactly Core's
+`GetSerializeSize(TX_NO_WITNESS(tx))`, because `TxBody` is the stripped
+serialization. -/
+def Tx.strippedSize (tx : Tx) : Nat :=
+  (Serialize.Codec.encode tx.body).length
+
 /-- Decide the context-free validity of a regular transaction: some output
 exists, no outpoint is spent twice, no input claims the null outpoint, and
-the outputs create at most `maxMoney` satoshis in total. -/
+the outputs create at most `maxMoney` satoshis in total, and the stripped
+serialization fits within Core's per-transaction weight ceiling
+([Bitcoin Core v28.0, `tx_check.cpp` lines 18–21](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L18-L21)). -/
 def Tx.isWellFormed (tx : Tx) : Bool :=
   decide (tx.body.outputs.val ≠ [])
     && decide tx.body.spends.Nodup
     && tx.body.spends.all (· != OutPoint.null)
     && decide ((tx.body.outputs.val.map fun o => o.value.toNat).sum
         ≤ Consensus.maxMoney)
+    && decide (tx.strippedSize * Consensus.witnessScaleFactor
+        ≤ Consensus.maxBlockWeight)
 
 /-- The specification `Tx.isWellFormed` enforces — Core's `CheckTransaction`
 for a transaction with real inputs, one field per rule. -/
@@ -61,6 +72,11 @@ structure Tx.WellFormed (tx : Tx) : Prop where
   `bad-txns-txouttotal-toolarge`). -/
   values_bounded : (tx.body.outputs.val.map fun o => o.value.toNat).sum
     ≤ Consensus.maxMoney
+  /-- The stripped serialization, scaled to weight units, fits within Core's
+  per-transaction ceiling (`bad-txns-oversize`; [Bitcoin Core v28.0,
+  `tx_check.cpp` lines 18–21](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L18-L21)). -/
+  stripped_size_bounded : tx.strippedSize * Consensus.witnessScaleFactor
+    ≤ Consensus.maxBlockWeight
 
 /-- The checker enforces exactly its specification: `isWellFormed` accepts a
 transaction iff it is `WellFormed`. -/
@@ -69,10 +85,57 @@ theorem Tx.isWellFormed_iff {tx : Tx} :
   simp only [isWellFormed, Bool.and_eq_true, decide_eq_true_eq,
     List.all_eq_true, bne_iff_ne]
   constructor
-  · rintro ⟨⟨⟨houtputs, hnodup⟩, hnull⟩, hbound⟩
-    exact ⟨houtputs, hnodup, hnull, hbound⟩
-  · rintro ⟨houtputs, hnodup, hnull, hbound⟩
-    exact ⟨⟨⟨houtputs, hnodup⟩, hnull⟩, hbound⟩
+  · rintro ⟨⟨⟨⟨houtputs, hnodup⟩, hnull⟩, hbound⟩, hsize⟩
+    exact ⟨houtputs, hnodup, hnull, hbound, hsize⟩
+  · rintro ⟨houtputs, hnodup, hnull, hbound, hsize⟩
+    exact ⟨⟨⟨⟨houtputs, hnodup⟩, hnull⟩, hbound⟩, hsize⟩
+
+private theorem TxOut.one_le_encode_length (output : TxOut) :
+    1 ≤ (Serialize.Codec.encode output).length := by
+  change 1 ≤ (Serialize.Codec.encode output.value
+    ++ Serialize.Codec.encode output.scriptPubKey).length
+  have hvalue : (Serialize.Codec.encode output.value).length = 8 :=
+    Serialize.encodeBitVecLE_length 8 output.value.toBitVec
+  simp only [List.length_append, hvalue]
+  omega
+
+private theorem TxOut.list_length_le_encodeElems_length (outputs : List TxOut) :
+    outputs.length ≤ (Serialize.encodeElems outputs).length := by
+  induction outputs with
+  | nil => rfl
+  | cons output outputs ih =>
+    simp only [List.length_cons, Serialize.encodeElems, List.length_append]
+    have houtput := TxOut.one_le_encode_length output
+    omega
+
+/-- A stateless-valid transaction has at most `2 ^ 32` outputs: Core's
+stripped-size rule is far tighter than the width of an outpoint's `vout`, so
+the `UInt32` indices used by the UTXO action cannot wrap. -/
+theorem Tx.WellFormed.outputs_length_le {tx : Tx} (h : tx.WellFormed) :
+    tx.body.outputs.val.length ≤ 2 ^ 32 := by
+  have helems := TxOut.list_length_le_encodeElems_length tx.body.outputs.val
+  have houtputs :
+      tx.body.outputs.val.length ≤
+        (Serialize.Codec.encode tx.body.outputs).length := by
+    change tx.body.outputs.val.length ≤
+      (CompactSize.encode
+        (UInt64.ofNat tx.body.outputs.val.length)
+        ++ Serialize.encodeElems tx.body.outputs.val).length
+    simp only [List.length_append]
+    omega
+  have hbody :
+      (Serialize.Codec.encode tx.body.outputs).length ≤ tx.strippedSize := by
+    unfold Tx.strippedSize
+    change (Serialize.Codec.encode tx.body.outputs).length ≤
+      (Serialize.Codec.encode tx.body.version
+        ++ (Serialize.Codec.encode tx.body.inputs
+          ++ (Serialize.Codec.encode tx.body.outputs
+            ++ Serialize.Codec.encode tx.body.lockTime))).length
+    simp only [List.length_append]
+    omega
+  have hsize := h.stripped_size_bounded
+  unfold Consensus.witnessScaleFactor Consensus.maxBlockWeight at hsize
+  omega
 
 instance instDecidableWellFormed : DecidablePred Tx.WellFormed :=
   fun _ => decidable_of_iff _ Tx.isWellFormed_iff

--- a/BtcVerified/Impl/README.md
+++ b/BtcVerified/Impl/README.md
@@ -1,9 +1,16 @@
 # BtcVerified/Impl
 
-Implementation-facing models, checked against the platonic specs they
+Implementation-facing models, checked against the abstract consensus specs they
 realize: level-order vector layouts, transcriptions of Bitcoin Core's own
 consensus code, and (later) efficient representations the spec proofs are
-transported to.
+transported to. `Consensus/` is the reasoning substrate, chosen for clear facts
+about protocol behavior and heavily informed by Core without being
+definitionally identical to it. `Impl/BitcoinCore` models the code-shaped side;
+the intended bridge is a refinement/equivalence theorem over observable
+behavior — accepted raw block histories and resulting state transitions. That
+separation also lets forks and independent implementations be compared against
+the same consensus object instead of making Core's internal structure the
+definition of Bitcoin.
 
 ## `BtcVerified.Impl.BitcoinCore`
 

--- a/BtcVerified/Transaction/OutPoint.lean
+++ b/BtcVerified/Transaction/OutPoint.lean
@@ -36,4 +36,9 @@ def OutPoint.equivProd : OutPoint ≃ (Hash256 × UInt32) where
 instance instCodecOutPoint : Codec OutPoint :=
   Codec.ofEquiv OutPoint.equivProd inferInstance
 
+/-- The outpoint a coinbase input carries: zero txid, all-ones index. It names
+no real output — the one outpoint a regular input may never claim (Core's
+`COutPoint::IsNull`). -/
+def OutPoint.null : OutPoint := ⟨0, 0xffffffff⟩
+
 end BtcVerified

--- a/BtcVerified/Transaction/OutPoint.lean
+++ b/BtcVerified/Transaction/OutPoint.lean
@@ -38,7 +38,8 @@ instance instCodecOutPoint : Codec OutPoint :=
 
 /-- The outpoint a coinbase input carries: zero txid, all-ones index. It names
 no real output — the one outpoint a regular input may never claim (Core's
-`COutPoint::IsNull`). -/
+[`COutPoint::SetNull` / `IsNull`, Bitcoin Core v28.0, `transaction.h` lines
+31–42](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L31-L42)). -/
 def OutPoint.null : OutPoint := ⟨0, 0xffffffff⟩
 
 end BtcVerified

--- a/BtcVerified/Transaction/README.md
+++ b/BtcVerified/Transaction/README.md
@@ -10,12 +10,13 @@ The transaction substructures — `OutPoint`, `TxIn`, `TxOut`, `TxBody`,
 witness-aware from the start, and push the structural facts of the wire
 format into the types:
 
-- A transaction is an inductive with two constructors over a shared,
+- A transaction is an inductive with three constructors over a shared,
   witness-free `TxBody` (version, inputs, outputs, lock time). `legacy` is the
-  pre-SegWit form; `segwit` is the BIP144 form. The `TxBody` is at once what a
-  txid commits to, the legacy serialization, and the witness-stripped form a
-  SegWit transaction shows the pre-SegWit world; `Tx.body` recovers it from
-  either constructor.
+  ordinary pre-SegWit form, `empty` is the degenerate zero-input/zero-output
+  object Core's witness-aware decoder accepts, and `segwit` is the BIP144 form.
+  The `TxBody` is at once what a txid commits to, the legacy serialization, and
+  the witness-stripped form a SegWit transaction shows the pre-SegWit world;
+  `Tx.body` recovers it from every constructor.
 - A SegWit transaction bundles each input with the witness that unlocks it
   (`SegwitInput`), so the one-witness-per-input arity is structural rather than a
   side condition. The wire groups witnesses after inputs; that regrouping is the
@@ -23,9 +24,12 @@ format into the types:
   empty then the old serialization format must be used, so the `segwit`
   constructor also carries a proof that at least one input witness stack is
   non-empty.
-- The `legacy` constructor carries a non-empty-inputs proof, because the SegWit
-  serialization reserves a zero input count (the `0x00` marker), so a legacy
-  transaction can never encode zero inputs.
+- The ordinary `legacy` constructor carries a non-empty-inputs proof. The
+  separate `empty` constructor covers Core's accepted `version ‖ 00 ‖ 00 ‖
+  locktime` path without admitting empty-input/nonempty-output bodies that the
+  witness-aware decoder cannot round-trip ([Bitcoin Core v28.0,
+  `transaction.h` lines
+  220–282](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L220-L282)).
 - Every CompactSize-prefixed field — scripts, the input/output vectors, witness
   stacks — is a `CountedList`; witness items are opaque byte strings; scripts
   are `Script` (see `../Script/`); hash-valued fields are opaque `Hash256`
@@ -45,31 +49,36 @@ codec) with no hand-written proofs. The whole-transaction codec sits on top.
 
 Checked claims:
 
-- `decodeTx_encodeTx`: every transaction round-trips, trailing bytes preserved.
+- `decodeTx_encodeTx`: every transaction, including Core's degenerate empty
+  object, round-trips with trailing bytes preserved.
 - `decodeTx_canonical`: an accepted parse consumed exactly the canonical
-  encoding — including dispatching to the legacy or SegWit branch the value's own
-  form dictates.
+  encoding — including dispatching to the legacy, empty, or SegWit branch the
+  value's own form dictates.
 
 The transaction codec is the one place the wire format and the data model
 disagree on order: `decode` reads the inputs and witnesses from their separate
 BIP144 regions and rebundles them (`zipInputs`); `encode` unzips. The
-legacy/SegWit dispatch turns on the marker byte, and a CompactSize first byte is
-`0x00` only for a zero count — which is what makes a non-empty legacy input count
-unambiguous against the marker. The SegWit branch also enforces BIP144's
+dispatch first reads the input count. A zero count makes the following byte
+Core-style optional-data flags: `0x00` yields the empty object, `0x01` selects
+SegWit, and other flags are rejected. The SegWit branch also enforces Core's
 empty-witness rule: marker/flag serialization is rejected when every witness
-stack is empty. Packaged as `instCodecTx : Codec Tx`.
+stack is empty ([Bitcoin Core v28.0, `transaction.h` lines
+224–250](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L224-L250)).
+Packaged as `instCodecTx : Codec Tx`.
 
-Why it matters: a transaction is the unit a block commits to and the unit fork
-choice ultimately weighs. Verified round-trip and canonicality for both eras is
-the serialization backbone the block codec and the txid/merkle commitments build
-on.
+Why it matters: this is an implementation-independent syntax object, not a Lean
+copy of `CTransaction`, but its accepted domain is deliberately compatible with
+Core's witness-aware decoder. Verified round-trip and canonicality provide the
+serialization backbone; an `Impl/BitcoinCore` transcription can later prove its
+decoder and validator equivalent to this model at the accepted-block and state-
+transition boundary, while other implementations can target the same model.
 
 ## Transaction ids
 
 `Tx.txid` — the double-SHA-256 of the witness-free `TxBody` serialization, as
 its raw 32 digest bytes — and `Tx.wtxid` (BIP141), the same over the full
 serialization. Witness data never affects a txid; for a legacy transaction the
-two coincide by `rfl`.
+two coincide by `rfl`, as they do for the empty no-witness case.
 
 Checked claims:
 

--- a/BtcVerified/Transaction/Tx.lean
+++ b/BtcVerified/Transaction/Tx.lean
@@ -147,6 +147,21 @@ def Tx.body : Tx → TxBody
       outputs := outputs
       lockTime := lockTime }
 
+/-- Every transaction has at least one input: a legacy transaction carries the
+proof outright, and a SegWit transaction's witness-bearing input is in
+particular an input. Core's empty-`vin` check is a type invariant here, not a
+consensus rule. -/
+theorem Tx.body_inputs_ne_nil (tx : Tx) : tx.body.inputs.val ≠ [] := by
+  cases tx with
+  | legacy body inputsNonempty => exact inputsNonempty
+  | segwit version inputs outputs lockTime hWitness =>
+      obtain ⟨input, hmem, -⟩ := hWitness
+      simp only [Tx.body]
+      intro hnil
+      rw [List.map_eq_nil_iff] at hnil
+      rw [hnil] at hmem
+      cases hmem
+
 /-! ## Bundling and unbundling SegWit inputs -/
 
 /-- The underlying inputs of a SegWit transaction, witnesses dropped — the input

--- a/BtcVerified/Transaction/Tx.lean
+++ b/BtcVerified/Transaction/Tx.lean
@@ -5,29 +5,41 @@ import BtcVerified.Ext.List
 /-!
   # The transaction type and its codec
 
-  A transaction is era-aware from the start: an inductive with a `legacy` and a
-  `segwit` constructor over a shared, witness-free `TxBody`. SegWit is a soft
+  A transaction is era-aware from the start: an inductive with ordinary
+  `legacy`, degenerate `empty`, and `segwit` constructors over a shared,
+  witness-free `TxBody`. The `empty` case is the zero-input, zero-output object
+  Bitcoin Core's witness-aware decoder accepts when it reads a zero input count
+  followed by a zero optional-data flag ([Bitcoin Core v28.0,
+  `transaction.h` lines 220–252](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L220-L252)).
+
+  This remains an abstract syntax object rather than Core's `CTransaction`, but
+  its admitted wire domain is chosen to be compatible with that decoder instead
+  of silently moving Core's empty-input rejection into parsing. SegWit is a soft
   fork — a restriction of the legacy ruleset — so the body is exactly what a txid
   commits to, exactly the legacy serialization, and exactly the witness-stripped
   form a SegWit transaction shows the pre-SegWit world; `Tx.body` recovers it
-  from either form. A SegWit transaction bundles each input with the witness that
+  from every form. A SegWit transaction bundles each input with the witness that
   unlocks it (`SegwitInput`), so the one-witness-per-input arity is structural
   rather than a side condition.
 
   ## Serialization
 
-  A transaction serializes in one of two forms, and the decoder tells them apart
-  from the bytes alone. After the 4-byte version:
+  A transaction serializes in one of three accepted forms, and the decoder tells
+  them apart from the bytes alone. After the 4-byte version:
 
-  * the **legacy** form is its `TxBody` — input vector, output vector, lock time;
+  * the ordinary **legacy** form is its `TxBody` — a non-empty input vector,
+    output vector, lock time;
+  * the degenerate **empty** form is zero inputs, zero outputs, and lock time;
   * the **SegWit** (BIP144) form interposes the marker `0x00` and flag `0x01`,
     then serializes the inputs (scriptSigs only), the outputs, one witness stack
     per input (no separate count — the count *is* the number of inputs), and the
     lock time.
 
-  The marker `0x00` is the reserved "zero inputs" encoding, never a valid legacy
-  transaction — which is what lets the decoder dispatch on it, and why the
-  `legacy` constructor carries a non-empty-inputs proof.
+  Core first reads `0x00` as an empty input vector, then reads the next byte as
+  optional-data flags. Flag `0x00` leaves both vectors empty; flag `0x01` selects
+  the SegWit body; other flags are rejected. The ordinary `legacy` constructor
+  retains its non-empty-input proof, while `empty` names the one canonical
+  empty-input result of this witness-aware dispatch.
 
   BIP144 also says that if the witness is empty, the old serialization format
   must be used. Therefore the SegWit constructor carries the corresponding
@@ -43,12 +55,15 @@ import BtcVerified.Ext.List
 
   Checked claims:
 
-  * `decodeTx_encodeTx`: every transaction round-trips, tail preserved.
+  * `decodeTx_encodeTx`: every transaction, including Core's empty object,
+    round-trips with its tail preserved.
   * `decodeTx_canonical`: an accepted parse consumed exactly the canonical
-    encoding — including taking the legacy/SegWit branch the value's own form
-    dictates.
+    encoding — including taking the legacy, empty, or SegWit branch the value's
+    own form dictates.
 
-  Both are packaged as `instCodecTx : Codec Tx`.
+  Both are packaged as `instCodecTx : Codec Tx`. Exact equivalence to a
+  transcription of Core's decoder belongs in `Impl/`; this type supplies the
+  implementation-independent syntax and reasoning substrate it must refine to.
 -/
 
 namespace BtcVerified
@@ -61,7 +76,8 @@ namespace WitnessStack
 
 /-- A witness stack contains actual witness data exactly when it has at least
 one stack item. The item itself may be empty; Bitcoin Core's null-witness test
-is about the stack item count. -/
+is about the stack item count ([Bitcoin Core v28.0, `transaction.h` lines
+237–245](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L237-L245)). -/
 def NonEmpty (wit : WitnessStack) : Prop :=
   wit.val ≠ []
 
@@ -106,12 +122,19 @@ instance (inputs : List SegwitInput) :
               | tail _ hmemTail =>
                 exact htail ⟨found, hmemTail, hnonempty⟩)
 
-/-- A Bitcoin transaction in one of its two serialization forms.
+/-- A Bitcoin transaction in one of the serialization forms accepted by the
+witness-aware wire decoder.
 
 `legacy` is the pre-SegWit form: a witness-free `TxBody`. Its inputs are
 non-empty because the SegWit serialization reserves a zero input count (the
 `0x00` marker byte), so a legacy transaction can never encode zero inputs on the
 wire.
+
+`empty` is the degenerate no-witness result Core accepts when both the initially
+read input vector and the following optional-data flag are zero. Its derived
+body has no inputs and no outputs; the transaction-local premises reject it
+([Bitcoin Core v28.0, `transaction.h` lines
+220–252](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L220-L252)).
 
 `segwit` is the BIP144 form, where each input carries its own witness. The
 arity rule — one witness stack per input — is structural here (it *is* a list of
@@ -122,6 +145,10 @@ inductive Tx where
   /-- A legacy (pre-SegWit) transaction: a witness-free body with non-empty
   inputs. -/
   | legacy (body : TxBody) (inputsNonempty : body.inputs.val ≠ [])
+  /-- The zero-input, zero-output no-witness transaction accepted by Core's
+  witness-aware decoder ([Bitcoin Core v28.0, `transaction.h` lines
+  220–252](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L220-L252)). -/
+  | empty (version : UInt32) (lockTime : UInt32)
   /-- A BIP144 SegWit transaction: each input bundled with its witness, and at
   least one witness stack non-empty so the marker/flag serialization is
   canonical. -/
@@ -133,34 +160,26 @@ inductive Tx where
 /-- Whether a transaction is in SegWit (witnessed) serialization form. -/
 def Tx.isSegWit : Tx → Bool
   | .legacy .. => false
+  | .empty .. => false
   | .segwit .. => true
 
 /-- The witness-free body of a transaction: its txid preimage and its legacy
-interpretation. A legacy transaction *is* its body; a SegWit transaction's body
-drops each input's witness. -/
+interpretation. An ordinary legacy transaction *is* its body; an empty
+transaction derives the zero-vector body; a SegWit transaction's body drops
+each input's witness. -/
 def Tx.body : Tx → TxBody
   | .legacy body _ => body
+  | .empty version lockTime =>
+    { version := version
+      inputs := ⟨[], by simp⟩
+      outputs := ⟨[], by simp⟩
+      lockTime := lockTime }
   | .segwit version inputs outputs lockTime _ =>
     { version := version
       inputs := ⟨inputs.val.map SegwitInput.input, by
         rw [List.length_map]; exact inputs.property⟩
       outputs := outputs
       lockTime := lockTime }
-
-/-- Every transaction has at least one input: a legacy transaction carries the
-proof outright, and a SegWit transaction's witness-bearing input is in
-particular an input. Core's empty-`vin` check is a type invariant here, not a
-consensus rule. -/
-theorem Tx.body_inputs_ne_nil (tx : Tx) : tx.body.inputs.val ≠ [] := by
-  cases tx with
-  | legacy body inputsNonempty => exact inputsNonempty
-  | segwit version inputs outputs lockTime hWitness =>
-      obtain ⟨input, hmem, -⟩ := hWitness
-      simp only [Tx.body]
-      intro hnil
-      rw [List.map_eq_nil_iff] at hnil
-      rw [hnil] at hmem
-      cases hmem
 
 /-! ## Bundling and unbundling SegWit inputs -/
 
@@ -252,17 +271,22 @@ def encodeSegwitBody (ins : CountedList SegwitInput) (outs : CountedList TxOut)
   Codec.encode (segwitInputs ins) ++ Codec.encode outs
     ++ encodeElems (segwitWitnesses ins) ++ Codec.encode lockTime
 
-/-- Serialize a transaction. Legacy is its `TxBody`; SegWit is the version, the
-marker `0x00` and flag `0x01`, then the SegWit body. -/
+/-- Serialize a transaction. Ordinary legacy is its `TxBody`; empty is the two
+zero vectors; SegWit is the version, marker `0x00`, flag `0x01`, and SegWit
+body. -/
 def encodeTx : Tx → List UInt8
   | .legacy body _ => Codec.encode body
+  | .empty version lockTime =>
+    Codec.encode version ++ 0x00 :: 0x00 :: Codec.encode lockTime
   | .segwit version ins outs lockTime _ =>
     Codec.encode version ++ 0x00 :: 0x01 :: encodeSegwitBody ins outs lockTime
 
 /-- Decode the SegWit body (everything after version, marker, and flag),
 rebundling the separately-read inputs and witnesses. BIP144 requires old
 serialization when the transaction's witness is empty, so all-empty witness
-stacks are rejected instead of producing a SegWit transaction. -/
+stacks are rejected instead of producing a SegWit transaction ([Bitcoin Core
+v28.0, `transaction.h` lines
+237–245](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L237-L245)). -/
 def decodeSegwit (version : UInt32) (bs : List UInt8) : Option (Tx × List UInt8) := do
   let (txins, r1) ← Codec.decode (α := CountedList TxIn) bs
   let (outs, r2) ← Codec.decode (α := CountedList TxOut) r1
@@ -283,11 +307,20 @@ def decodeLegacy (version : UInt32) (bs : List UInt8) : Option (Tx × List UInt8
   let tx ← Tx.legacy? ⟨version, inputs, outputs, lockTime⟩
   return (tx, r3)
 
+/-- Decode Core's degenerate no-witness path after the zero input count and
+zero optional-data flag. The output vector remains empty and only lock time is
+read ([Bitcoin Core v28.0, `transaction.h` lines
+224–252](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L224-L252)). -/
+def decodeEmpty (version : UInt32) (bs : List UInt8) : Option (Tx × List UInt8) := do
+  let (lockTime, rest) ← Codec.decode (α := UInt32) bs
+  return (.empty version lockTime, rest)
+
 /-- Decode a transaction: read the version, then dispatch on the marker byte. -/
 def decodeTx (bs : List UInt8) : Option (Tx × List UInt8) := do
   let (version, rest1) ← Codec.decode (α := UInt32) bs
   match rest1 with
   | 0x00 :: 0x01 :: rest3 => decodeSegwit version rest3
+  | 0x00 :: 0x00 :: rest3 => decodeEmpty version rest3
   | 0x00 :: _ => none
   | _ => decodeLegacy version rest1
 
@@ -319,6 +352,13 @@ theorem decodeLegacy_encode (body : TxBody) (hne : body.inputs.val ≠ [])
   rw [Tx.legacy?_eq_some hne]
   rfl
 
+/-- The empty transaction encoding decodes to the corresponding `Tx.empty`,
+tail preserved. -/
+theorem decodeEmpty_encode (version lockTime : UInt32) (rest : List UInt8) :
+    decodeEmpty version (Codec.encode lockTime ++ rest)
+      = some (.empty version lockTime, rest) := by
+  simp [decodeEmpty, Codec.decode_encode]
+
 /-- When the byte after the version is not the marker `0x00`, `decodeTx`
 dispatches to the legacy decoder. -/
 theorem decodeTx_legacy_eq (version : UInt32) (inputs : CountedList TxIn)
@@ -341,6 +381,11 @@ theorem decodeTx_encodeTx (tx : Tx) (rest : List UInt8) :
     simp only [List.append_assoc, List.cons_append, Option.bind_eq_bind,
       Codec.decode_encode, Option.bind_some]
     exact decodeSegwit_encode version ins outs lockTime hWitness rest
+  | empty version lockTime =>
+    unfold encodeTx decodeTx
+    simp only [List.append_assoc, List.cons_append, Option.bind_eq_bind,
+      Codec.decode_encode, Option.bind_some]
+    exact decodeEmpty_encode version lockTime rest
   | legacy body hne =>
     obtain ⟨b, t, hbt, hb0⟩ := CompactSize.encode_head (UInt64.ofNat body.inputs.val.length)
     have hb : b ≠ 0x00 := hb0 (ofNat_length_ne_zero hne body.inputs.property)
@@ -412,8 +457,21 @@ theorem decodeLegacy_canonical (version : UInt32) (bs : List UInt8) (tx : Tx)
   rw [eti, eto, elt]
   simp only [List.append_assoc]
 
+/-- If the empty-path decoder accepts `bs`, it returns `Tx.empty` at the given
+version and `bs` is exactly the canonical lock-time encoding followed by the
+tail. -/
+theorem decodeEmpty_canonical (version : UInt32) (bs : List UInt8) (tx : Tx)
+    (rest : List UInt8) (h : decodeEmpty version bs = some (tx, rest)) :
+    ∃ lockTime, tx = .empty version lockTime ∧
+      bs = Codec.encode lockTime ++ rest := by
+  unfold decodeEmpty at h
+  simp only [Option.bind_eq_bind, Option.pure_def, Option.bind_eq_some_iff,
+    Option.some.injEq, Prod.mk.injEq] at h
+  obtain ⟨⟨lockTime, tail⟩, hlt, rfl, rfl⟩ := h
+  exact ⟨lockTime, rfl, Codec.decode_canonical bs lockTime tail hlt⟩
+
 /-- Canonicality: an accepted parse consumed exactly the canonical encoding,
-including the legacy/SegWit branch the value's own form dictates. -/
+including the legacy, empty, or SegWit branch the value's own form dictates. -/
 theorem decodeTx_canonical (bs : List UInt8) (tx : Tx) (rest : List UInt8)
     (h : decodeTx bs = some (tx, rest)) : bs = encodeTx tx ++ rest := by
   unfold decodeTx at h
@@ -427,6 +485,11 @@ theorem decodeTx_canonical (bs : List UInt8) (tx : Tx) (rest : List UInt8)
       decodeSegwit_canonical version rest3 tx rest h
     rw [ev, hbody]
     simp only [encodeTx, List.append_assoc, List.cons_append]
+  · rename_i rest3
+    obtain ⟨lockTime, rfl, hbody⟩ :=
+      decodeEmpty_canonical version rest3 tx rest h
+    rw [ev, hbody]
+    simp only [encodeTx, List.append_assoc, List.cons_append]
   · simp at h
   · obtain ⟨inputs, outputs, lockTime, hne, rfl, hbody⟩ :=
       decodeLegacy_canonical version rest1 tx rest h
@@ -437,8 +500,8 @@ theorem decodeTx_canonical (bs : List UInt8) (tx : Tx) (rest : List UInt8)
           ++ (Codec.encode outputs ++ Codec.encode lockTime)) from rfl]
     simp only [List.append_assoc]
 
-/-- The transaction codec: legacy and SegWit forms, dispatched on the BIP144
-marker byte. -/
+/-- The transaction codec: ordinary legacy, degenerate empty, and SegWit forms,
+dispatched through the BIP144 marker/flags path. -/
 instance instCodecTx : Codec Tx where
   encode := encodeTx
   decode := decodeTx

--- a/BtcVerified/Transaction/Txid.lean
+++ b/BtcVerified/Transaction/Txid.lean
@@ -53,6 +53,11 @@ body's serialization. -/
 theorem Tx.wtxid_legacy (body : TxBody) (h : body.inputs.val ≠ []) :
     (Tx.legacy body h).wtxid = (Tx.legacy body h).txid := rfl
 
+/-- The degenerate empty transaction is also witness-free, so its wtxid is
+its txid. -/
+theorem Tx.wtxid_empty (version lockTime : UInt32) :
+    (Tx.empty version lockTime).wtxid = (Tx.empty version lockTime).txid := rfl
+
 /-- Equal txids mean equal witness-free bodies — or two concrete byte strings
 witnessing a double-SHA-256 collision. -/
 theorem Tx.txid_binding {t₁ t₂ : Tx} (h : t₁.txid = t₂.txid) :

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ statement of what stands.
 - [`Chainstate/`](BtcVerified/Chainstate/README.md) — The set of spendable
   coins and the single action every transaction performs on it, with the
   accounting identity the supply-limit theorem will be built on.
+- [`Consensus/`](BtcVerified/Consensus/README.md) — The validity rules
+  Bitcoin enforces on individual transactions, stated as runnable checks
+  proved to guarantee exactly the facts the ledger accounting needs, and run
+  against the first Bitcoin payment ever made.
 - [`Impl/`](BtcVerified/Impl/README.md) — Functions transcribed from Bitcoin
   Core's own source code and proved to satisfy the specification, starting
   with its merkle-root computation.

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ statement of what stands.
 - [`Chainstate/`](BtcVerified/Chainstate/README.md) — The set of spendable
   coins and the single action every transaction performs on it, with the
   accounting identity the supply-limit theorem will be built on.
-- [`Consensus/`](BtcVerified/Consensus/README.md) — The validity rules
-  Bitcoin enforces on individual transactions, stated as runnable checks
-  proved to guarantee exactly the facts the ledger accounting needs, and run
-  against the first Bitcoin payment ever made.
+- [`Consensus/`](BtcVerified/Consensus/README.md) — The reusable transaction
+  premises and guarded transition step that block-extension validity composes,
+  stated as runnable checks proved to guarantee exactly the facts the ledger
+  accounting needs and run against the first Bitcoin payment ever made.
 - [`Impl/`](BtcVerified/Impl/README.md) — Functions transcribed from Bitcoin
   Core's own source code and proved to satisfy the specification, starting
   with its merkle-root computation.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ stay anchored to the real network — the verified decoders and computable
 hashes run against actual mainnet blocks at build time, and an axiom audit
 fails CI if any headline theorem depends on an unproved assumption.
 
+The consensus model is a separate, executable reasoning substrate: Core's
+design strongly influences its initial boundaries, but Core's C++ is not the
+definition. Implementation-shaped models live under `Impl/`; the intended
+connection is a proved equivalence over accepted raw block extensions and their
+state transitions. This keeps the model useful to Bitcoin Core and its forks
+while giving other implementations one common protocol object to compare
+against.
+
 The ambition, laid out in the roadmap below, is machine-checked proofs of
 the guarantees Bitcoin is valued for: that its rules cap issuance below 21
 million coins, and that the fork-choice rule selects the valid chain backed
@@ -40,8 +48,9 @@ statement of what stands.
   exactly what a merkle root does and does not commit to, including the
   defense against the CVE-2012-2459 duplication attack.
 - [`Transaction/`](BtcVerified/Transaction/README.md) — Bitcoin transactions,
-  legacy and SegWit, with verified serialization in both directions and
-  proofs that transaction ids are binding commitments to the transaction.
+  including the degenerate empty object Core decodes plus ordinary legacy and
+  SegWit forms, with verified serialization in both directions and proofs that
+  transaction ids are binding commitments to the transaction.
 - [`Block/`](BtcVerified/Block/README.md) — Every byte of a block parses
   through a verified codec (checked against real mainnet blocks), block
   hashes are proved binding, and a chain's tip hash provably commits to the

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -145,8 +145,8 @@ elab "#assert_axioms " id:ident : command => do
 #assert_axioms BtcVerified.Coin.isMature_iff
 #assert_axioms BtcVerified.Consensus.LockTime.isPast_iff
 #assert_axioms BtcVerified.Consensus.LockTime.ofUInt32_past_iff
-#assert_axioms BtcVerified.TxBody.isFinal_iff
-#assert_axioms BtcVerified.TxBody.final_iff_core
+#assert_axioms BtcVerified.TxBody.isLockTimeSatisfied_iff
+#assert_axioms BtcVerified.TxBody.lockTimeSatisfied_iff_core
 #assert_axioms BtcVerified.Tx.spentCoins_aligned
 #assert_axioms BtcVerified.Tx.spentCoins_length
 #assert_axioms BtcVerified.Tx.isAdmissible_iff

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -136,6 +136,19 @@ elab "#assert_axioms " id:ident : command => do
 #assert_axioms BtcVerified.Chain.tip_commits_prefix
 #assert_axioms BtcVerified.Chain.tip_commits
 
+/-! ## Consensus: transaction rules -/
+
+#assert_axioms BtcVerified.Tx.body_inputs_ne_nil
+#assert_axioms BtcVerified.Tx.isWellFormed_iff
+#assert_axioms BtcVerified.Coin.isMature_iff
+#assert_axioms BtcVerified.TxBody.isFinal_iff
+#assert_axioms BtcVerified.Tx.spentCoins_length
+#assert_axioms BtcVerified.Tx.isAdmissible_iff
+#assert_axioms BtcVerified.Tx.creates_absent_spend
+#assert_axioms BtcVerified.UtxoSet.totalValue_apply_of_admissible
+#assert_axioms BtcVerified.UtxoSet.totalValue_apply_le_of_admissible
+#assert_axioms BtcVerified.UtxoSet.applyChecked_eq_some_iff
+
 /-! ## The merkle tree -/
 
 #assert_axioms BtcVerified.Merkle.combine_binding

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -140,6 +140,7 @@ elab "#assert_axioms " id:ident : command => do
 /-! ## Consensus: transaction premises -/
 
 #assert_axioms BtcVerified.Tx.isWellFormed_iff
+#assert_axioms BtcVerified.Tx.stripped_size_bound_iff_core
 #assert_axioms BtcVerified.Tx.WellFormed.outputs_length_le
 #assert_axioms BtcVerified.Coin.isMature_iff
 #assert_axioms BtcVerified.Consensus.LockTime.isPast_iff

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -142,7 +142,10 @@ elab "#assert_axioms " id:ident : command => do
 #assert_axioms BtcVerified.Tx.isWellFormed_iff
 #assert_axioms BtcVerified.Tx.WellFormed.outputs_length_le
 #assert_axioms BtcVerified.Coin.isMature_iff
+#assert_axioms BtcVerified.Consensus.LockTime.isPast_iff
+#assert_axioms BtcVerified.Consensus.LockTime.ofUInt32_past_iff
 #assert_axioms BtcVerified.TxBody.isFinal_iff
+#assert_axioms BtcVerified.TxBody.final_iff_core
 #assert_axioms BtcVerified.Tx.spentCoins_aligned
 #assert_axioms BtcVerified.Tx.spentCoins_length
 #assert_axioms BtcVerified.Tx.isAdmissible_iff

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -104,6 +104,7 @@ elab "#assert_axioms " id:ident : command => do
 #assert_axioms BtcVerified.Tx.txid_binding
 #assert_axioms BtcVerified.Tx.wtxid_binding
 #assert_axioms BtcVerified.Tx.wtxid_legacy
+#assert_axioms BtcVerified.Tx.wtxid_empty
 
 /-! ## The chainstate -/
 
@@ -138,7 +139,6 @@ elab "#assert_axioms " id:ident : command => do
 
 /-! ## Consensus: transaction premises -/
 
-#assert_axioms BtcVerified.Tx.body_inputs_ne_nil
 #assert_axioms BtcVerified.Tx.isWellFormed_iff
 #assert_axioms BtcVerified.Tx.WellFormed.outputs_length_le
 #assert_axioms BtcVerified.Coin.isMature_iff

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -140,6 +140,7 @@ elab "#assert_axioms " id:ident : command => do
 
 #assert_axioms BtcVerified.Tx.body_inputs_ne_nil
 #assert_axioms BtcVerified.Tx.isWellFormed_iff
+#assert_axioms BtcVerified.Tx.WellFormed.outputs_length_le
 #assert_axioms BtcVerified.Coin.isMature_iff
 #assert_axioms BtcVerified.TxBody.isFinal_iff
 #assert_axioms BtcVerified.Tx.spentCoins_length

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -136,16 +136,17 @@ elab "#assert_axioms " id:ident : command => do
 #assert_axioms BtcVerified.Chain.tip_commits_prefix
 #assert_axioms BtcVerified.Chain.tip_commits
 
-/-! ## Consensus: transaction rules -/
+/-! ## Consensus: transaction premises -/
 
 #assert_axioms BtcVerified.Tx.body_inputs_ne_nil
 #assert_axioms BtcVerified.Tx.isWellFormed_iff
 #assert_axioms BtcVerified.Tx.WellFormed.outputs_length_le
 #assert_axioms BtcVerified.Coin.isMature_iff
 #assert_axioms BtcVerified.TxBody.isFinal_iff
+#assert_axioms BtcVerified.Tx.spentCoins_aligned
 #assert_axioms BtcVerified.Tx.spentCoins_length
 #assert_axioms BtcVerified.Tx.isAdmissible_iff
-#assert_axioms BtcVerified.Tx.creates_absent_spend
+#assert_axioms BtcVerified.Tx.creates_do_not_overwrite_after_spend
 #assert_axioms BtcVerified.UtxoSet.totalValue_apply_of_admissible
 #assert_axioms BtcVerified.UtxoSet.totalValue_apply_le_of_admissible
 #assert_axioms BtcVerified.UtxoSet.applyChecked_eq_some_iff

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -516,7 +516,7 @@ def block170Context : TxContext :=
     medianTimePast := 1231715347 }
 
 -- The semantic lock-time interpretation exposes the selected axis, and the
--- two named clocks can produce different finality results.
+-- two named clocks can produce different lock-time satisfaction results.
 #guard Consensus.LockTime.ofUInt32 0 == .disabled
 #guard Consensus.LockTime.ofUInt32 499_999_999 == .blockHeight 499_999_999
 #guard Consensus.LockTime.ofUInt32 500_000_000 == .blockTime 500_000_000

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -507,8 +507,23 @@ def block9CoinbaseHex : String :=
    a3ac00000000"
 
 /-- The context block 170 admits its transactions in: height 170, header
-timestamp `1231731025`. -/
-def block170Context : TxContext := ⟨170, 1231731025⟩
+timestamp `1231731025`, and preceding-block MTP `1231715347`. The MTP is the
+median timestamp of blocks 159–169; both values can be checked from the exact
+preceding [block 169 on mempool.space](https://mempool.space/block/000000002a22cfee1f2c846adbd12b3e183d4f97683f85dad08a79780a84bd55). -/
+def block170Context : TxContext :=
+  { height := 170
+    blockTime := 1231731025
+    medianTimePast := 1231715347 }
+
+-- The semantic lock-time interpretation exposes the selected axis, and the
+-- two named clocks can produce different finality results.
+#guard Consensus.LockTime.ofUInt32 0 == .disabled
+#guard Consensus.LockTime.ofUInt32 499_999_999 == .blockHeight 499_999_999
+#guard Consensus.LockTime.ofUInt32 500_000_000 == .blockTime 500_000_000
+#guard (Consensus.LockTime.ofUInt32 1_231_716_000).isPast
+  block170Context.height (block170Context.timeFor .blockTime)
+#guard !(Consensus.LockTime.ofUInt32 1_231_716_000).isPast
+  block170Context.height (block170Context.timeFor .medianTimePast)
 
 #guard checksOut block9CoinbaseHex fun coinbase =>
   -- The computed txid is exactly the prevout the first-payment vector pins.
@@ -537,20 +552,23 @@ def block170Context : TxContext := ⟨170, 1231731025⟩
     payment.isWellFormed
     -- Admissible at block 170 under the always-true script judgment: the
     -- coinbase matured at height 109, and 50 BTC in covers 10 + 40 out.
-    && payment.isAdmissible (fun _ _ _ => true) utxos block170Context
+    && payment.isAdmissible (fun _ _ _ => true) utxos .blockTime
+      block170Context
     -- Not at height 105: the coinbase is four blocks short of maturity.
-    && !payment.isAdmissible (fun _ _ _ => true) utxos ⟨105, 1231731025⟩
+    && !payment.isAdmissible (fun _ _ _ => true) utxos .blockTime
+      { block170Context with height := 105 }
     -- A rejecting script judgment fails the bundle.
-    && !payment.isAdmissible (fun _ _ _ => false) utxos block170Context
+    && !payment.isAdmissible (fun _ _ _ => false) utxos .blockTime
+      block170Context
     -- Input-value and fee MoneyRange checks reject the otherwise admissible
     -- transaction over the deliberately impossible abstract state.
-    && !payment.isAdmissible (fun _ _ _ => true) outOfRangeUtxos
+    && !payment.isAdmissible (fun _ _ _ => true) outOfRangeUtxos .blockTime
       block170Context
     -- The guarded regular-transaction step applies it: the spent outpoint is
     -- gone, the two created outpoints carry 10 and 40 BTC stamped
     -- ⟨170, regular⟩, and the zero-fee total is conserved.
-    && (match UtxoSet.applyChecked (fun _ _ _ => true) utxos block170Context
-          payment with
+    && (match UtxoSet.applyChecked (fun _ _ _ => true) utxos .blockTime
+          block170Context payment with
         | some next =>
           (next.lookup ⟨coinbase.txid, 0⟩).isNone
           && ((next.lookup ⟨payment.txid, 0⟩).map fun coin =>

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -462,4 +462,85 @@ def block1HeaderHex : String :=
   | some (b, _) => decide b.merkleCommits
   | none => false
 
+/-! ## The transaction rules on the first payment
+
+  The block-9 coinbase funds the set, and the first Bitcoin payment spends
+  it at height 170 — the transaction rules and the strict interface run on
+  real mainnet data end to end. The setup authenticates itself: the
+  coinbase's *computed* txid must equal the prevout the first-payment
+  vector already pins byte-for-byte.
+-/
+
+/-- Raw wire bytes of the block-9 coinbase `0437cd…97c9` (2009-01-09), the
+transaction the first Bitcoin payment spends, fetched from
+blockstream.info. -/
+def block9CoinbaseHex : String :=
+  "0100000001000000000000000000000000000000000000000000000000000000\
+   0000000000ffffffff0704ffff001d0134ffffffff0100f2052a010000004341\
+   0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a\
+   5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412\
+   a3ac00000000"
+
+/-- The context block 170 admits its transactions in: height 170, header
+timestamp `1231731025`. -/
+def block170Context : TxContext := ⟨170, 1231731025⟩
+
+#guard checksOut block9CoinbaseHex fun coinbase =>
+  -- The computed txid is exactly the prevout the first-payment vector pins.
+  coinbase.txid
+    == hashOfDisplay "0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9"
+  -- One 50 BTC output.
+  && (coinbase.body.outputs.val.map (·.value)) == [5_000_000_000]
+  -- A coinbase fails the regular-transaction rules by design: its input
+  -- claims the null outpoint. Coinbase structure is a block rule (#37).
+  && !coinbase.isWellFormed
+
+#guard match hexBytes? block9CoinbaseHex >>= Codec.decode (α := Tx),
+    hexBytes? firstBitcoinPaymentHex >>= Codec.decode (α := Tx) with
+  | some (coinbase, _), some (payment, _) =>
+    -- The block-9 coinbase's output as the whole UTXO set: created at
+    -- height 9, in coinbase position.
+    let utxos : UtxoSet := UtxoSet.create ∅
+      (coinbase.body.creates.map fun entry => (entry.1, ⟨entry.2, ⟨9, true⟩⟩))
+    payment.isWellFormed
+    -- Admissible at block 170 under the always-true script judgment: the
+    -- coinbase matured at height 109, and 50 BTC in covers 10 + 40 out.
+    && payment.isAdmissible (fun _ _ _ => true) utxos block170Context
+    -- Not at height 105: the coinbase is four blocks short of maturity.
+    && !payment.isAdmissible (fun _ _ _ => true) utxos ⟨105, 1231731025⟩
+    -- A rejecting script judgment fails the bundle.
+    && !payment.isAdmissible (fun _ _ _ => false) utxos block170Context
+    -- The strict interface applies it: the spent outpoint is gone, the two
+    -- created outpoints carry 10 and 40 BTC stamped ⟨170, regular⟩, and
+    -- the zero-fee total is conserved.
+    && (match UtxoSet.applyChecked (fun _ _ _ => true) utxos block170Context
+          payment with
+        | some next =>
+          (next.lookup ⟨coinbase.txid, 0⟩).isNone
+          && ((next.lookup ⟨payment.txid, 0⟩).map fun coin =>
+              (coin.output.value, coin.provenance))
+            == some (1_000_000_000, ⟨170, false⟩)
+          && ((next.lookup ⟨payment.txid, 1⟩).map fun coin =>
+              (coin.output.value, coin.provenance))
+            == some (4_000_000_000, ⟨170, false⟩)
+          && next.totalValue == 5_000_000_000
+        | none => false)
+  | _, _ => false
+
+-- Duplicating the payment's input trips the duplicate-spends rule — the
+-- stateless negative real history cannot exhibit.
+#guard match hexBytes? firstBitcoinPaymentHex >>= Codec.decode (α := Tx) with
+  | some (payment, _) =>
+    (match payment.body.inputs.val with
+     | [input] =>
+       let doubled : TxBody := { payment.body with
+         inputs := ⟨[input, input], by simp⟩ }
+       !(Tx.legacy doubled (List.cons_ne_nil input [input])).isWellFormed
+     | _ => false)
+  | none => false
+
+-- The SegWit arm of the stateless checker: the first SegWit spend is
+-- well-formed.
+#guard checksOut firstSegwitSpendHex fun tx => tx.isWellFormed
+
 end Tests.GoldenVectors

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -462,11 +462,11 @@ def block1HeaderHex : String :=
   | some (b, _) => decide b.merkleCommits
   | none => false
 
-/-! ## The transaction rules on the first payment
+/-! ## The transaction premises on the first payment
 
   The block-9 coinbase funds the set, and the first Bitcoin payment spends
-  it at height 170 — the transaction rules and the strict interface run on
-  real mainnet data end to end. The setup authenticates itself: the
+  it at height 170 — the transaction premises and guarded block-fold step run
+  on real mainnet data end to end. The setup authenticates itself: the
   coinbase's *computed* txid must equal the prevout the first-payment
   vector already pins byte-for-byte.
 -/
@@ -521,9 +521,9 @@ def block170Context : TxContext := ⟨170, 1231731025⟩
     -- transaction over the deliberately impossible abstract state.
     && !payment.isAdmissible (fun _ _ _ => true) outOfRangeUtxos
       block170Context
-    -- The strict interface applies it: the spent outpoint is gone, the two
-    -- created outpoints carry 10 and 40 BTC stamped ⟨170, regular⟩, and
-    -- the zero-fee total is conserved.
+    -- The guarded regular-transaction step applies it: the spent outpoint is
+    -- gone, the two created outpoints carry 10 and 40 BTC stamped
+    -- ⟨170, regular⟩, and the zero-fee total is conserved.
     && (match UtxoSet.applyChecked (fun _ _ _ => true) utxos block170Context
           payment with
         | some next =>

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -139,7 +139,8 @@ def segwitCoinbaseHex : String :=
                   | [item] => item.val == List.replicate 32 (0 : UInt8)
                   | _ => false)
             | _ => false)
-      | .legacy .. => false)
+      | .legacy .. => false
+      | .empty .. => false)
 
 /-! ## The first SegWit spend
 
@@ -176,14 +177,16 @@ def firstSegwitSpendHex : String :=
                | [sig, pubkey] => sig.val.length == 72 && pubkey.val.length == 33
                | _ => false)
          | _ => false)
-      | .legacy .. => false)
+      | .legacy .. => false
+      | .empty .. => false)
 
 /-! ## BIP144 superfluous-witness regression
 
   BIP144's serialization section requires the old transaction serialization
   when the witness is empty. Bitcoin Core enforces the same rule by rejecting a
   marker/flag transaction whose witness stacks are all empty with
-  "Superfluous witness record".
+  "Superfluous witness record" ([Bitcoin Core v28.0, `transaction.h` lines
+  237–245](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L237-L245)).
 
   This synthetic vector is otherwise a parseable marker/flag transaction with
   one input, one output, and the single per-input witness field encoded as
@@ -202,6 +205,28 @@ def superfluousWitnessHex : String :=
     match Codec.decode (α := Tx) bytes with
     | none => true
     | some _ => false
+
+/-! ## Core-compatible empty transaction
+
+  Core's witness-aware decoder accepts the ten-byte sequence `version ‖ 00 ‖
+  00 ‖ locktime`: the first zero produces an empty input vector, the second is
+  an empty optional-data flag, the output vector remains empty, and the decoder
+  reads lock time next ([Bitcoin Core v28.0, `transaction.h` lines
+  220–252](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L220-L252)).
+  `CheckTransaction` then rejects the decoded object for empty inputs and
+  outputs ([`tx_check.cpp` lines
+  14–17](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L14-L17)).
+-/
+
+/-- Core's minimal decoded transaction: version 1, empty inputs and outputs,
+lock time zero. -/
+def coreEmptyTxHex : String := "01000000000000000000"
+
+#guard checksOut coreEmptyTxHex fun tx =>
+  tx == Tx.empty 1 0
+    && tx.body.inputs.val == []
+    && tx.body.outputs.val == []
+    && !tx.isWellFormed
 
 /-! ## Blocks -/
 

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -502,6 +502,13 @@ def block170Context : TxContext := ⟨170, 1231731025⟩
     -- height 9, in coinbase position.
     let utxos : UtxoSet := UtxoSet.create ∅
       (coinbase.body.creates.map fun entry => (entry.1, ⟨entry.2, ⟨9, true⟩⟩))
+    -- The machine admits arbitrary states, including an impossible coin over
+    -- MAX_MONEY; the contextual rules must reject a spend from such a state.
+    let outOfRangeUtxos : UtxoSet := UtxoSet.create ∅
+      (coinbase.body.creates.map fun entry =>
+        (entry.1, ⟨{ entry.2 with
+          value := UInt64.ofNat
+            (Consensus.maxMoney + 5_000_000_001) }, ⟨9, true⟩⟩))
     payment.isWellFormed
     -- Admissible at block 170 under the always-true script judgment: the
     -- coinbase matured at height 109, and 50 BTC in covers 10 + 40 out.
@@ -510,6 +517,10 @@ def block170Context : TxContext := ⟨170, 1231731025⟩
     && !payment.isAdmissible (fun _ _ _ => true) utxos ⟨105, 1231731025⟩
     -- A rejecting script judgment fails the bundle.
     && !payment.isAdmissible (fun _ _ _ => false) utxos block170Context
+    -- Input-value and fee MoneyRange checks reject the otherwise admissible
+    -- transaction over the deliberately impossible abstract state.
+    && !payment.isAdmissible (fun _ _ _ => true) outOfRangeUtxos
+      block170Context
     -- The strict interface applies it: the spent outpoint is gone, the two
     -- created outpoints carry 10 and 40 BTC stamped ⟨170, regular⟩, and
     -- the zero-fee total is conserved.


### PR DESCRIPTION
Closes #36 — the first `Consensus/` leaf beneath the block-extension judgment: reusable transaction-local and contextual premises, stated over the `Chainstate/` machine, plus the guarded regular-transaction step that #37's block fold will iterate.

## Architecture

- **Block extension is the root judgment**: consensus validity belongs to a candidate block extending a parent-chain state under the active ruleset. This PR does not define a standalone transaction-validity verdict; it factors the transaction premises and transition step that block validation composes.
- **Abstract model, implementation refinements**: `Consensus/` is an executable reasoning substrate chosen to make protocol behavior and Bitcoin-level facts legible. Core strongly influences its boundaries, but its C++ is not the definition. Core-shaped transcriptions belong in `Impl/`, with equivalence stated over accepted raw block extensions and resulting state transitions; forks and independent implementations can target the same abstract object.
- **Core-compatible parser boundary**: `Tx.empty` represents the ten-byte zero-input/zero-output object Core v28.0's witness-aware decoder accepts. Nonempty inputs are therefore an explicit `WellFormed.inputs_ne_nil` premise rather than a parser/type invariant. Ordinary legacy and SegWit cases retain the invariants needed by the canonical codec.
- **Two transaction buckets**: transaction-local premises read only the transaction; contextual premises read the evolving UTXO set and admitting-block context. Block-wide and positional premises, including the coinbase epilogue, remain #37.
- **Enforced vs derived**: an enforced premise is a runnable `Bool` checker, a `Prop` specification record, and an audited `_iff` proving the checker enforces exactly that record. Conservation and other derived properties are theorems, never runtime checks.
- **No activation heights inside premises**: premises take a context containing height, block time, and median-time-past plus an explicit `LockTimeClock`; the ruleset mapping in #38 owns the clock choice and which premises are active.
- **Script validity remains abstract**: `ScriptCheck := List Coin → Nat → Tx → Bool` is a parameter because no formal script model exists yet. A zipper or other focus-by-construction API is deliberately deferred until that model can determine the interface it actually needs. `Tx.spentCoins_aligned` proves the current indexed interface is pointwise aligned.

## Core correspondence

Every Core-behavior claim introduced by this PR now has an exact, release-pinned source link in the relevant source doc-string or README.

| Core check | Here |
|---|---|
| [`UnserializeTransaction`: zero vin + zero flags](https://github.com/bitcoin/bitcoin/blob/v28.0/src/primitives/transaction.h#L220-L252) | `Tx.empty`; codec round-trip/canonicality and a ten-byte golden vector |
| [`CheckTransaction`: empty vin](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L11-L15) | `WellFormed.inputs_ne_nil` |
| [empty vout](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L16-L17) | `WellFormed.outputs_ne_nil` |
| [`MoneyRange` per-output + running total](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L23-L33) | `WellFormed.values_bounded` (one `Nat` sum bound subsumes both) |
| [duplicate inputs](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L36-L44) | `WellFormed.spends_nodup` |
| [null prevout](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L47-L56) | `WellFormed.spends_ne_null` |
| [negative amounts](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L23-L30) | unrepresentable (`UInt64` values, `Nat` sums) |
| [oversize](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L18-L21) | semantic 1 MB `WellFormed.stripped_size_bounded`; `stripped_size_bound_iff_core` proves Core-expression equivalence; implies `outputs_length_le` |
| [coinbase scriptSig 2..100](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L47-L50) | positional block premise → #37 |
| [`CheckTxInputs`: inputs available](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L164-L170) | `Admissible.spends_mem` |
| [coinbase maturity](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L178-L181) | `Admissible.spends_mature` |
| [input `MoneyRange`](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L184-L188) | `Admissible.input_values_bounded`; redundancy on reachable states → #50 |
| [value in ≥ value out](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L191-L195) | `Admissible.values_cover` |
| [fee `MoneyRange`](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L197-L200) | `Admissible.fee_bounded`; redundancy on reachable states → #50 |
| [`IsFinalTx`](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L17-L37) | semantic `LockTime`, explicit `LockTimeClock`, `isLockTimeSatisfied`, and `Admissible.lock_time_satisfied` |
| [`CheckInputScripts` during block connection](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L2659-L2671) | abstract `Admissible.scripts_ok` parameter |
| [BIP30 scan](https://github.com/bitcoin/bitcoin/blob/v28.0/src/validation.cpp#L2495-L2575) | `Admissible.creates_do_not_overwrite` (activation history → #38/#39) |
| [BIP68 calculation and evaluation](https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_verify.cpp#L39-L109) | deferred → #46 (needs median-time-past history) |

## Where premises meet the machine

The `Admissible` fields are the hypotheses of the action theorems. `creates_do_not_overwrite_after_spend` discharges freshness after spends are erased. `UtxoSet.totalValue_apply_of_admissible` and `_le_of_admissible` establish the per-step accounting facts. The checked stripped-size premise internally supplies the output-index-width bound.

`UtxoSet.applyChecked` is the guarded regular-transaction step that #37's block fold will iterate. It is not a root consensus interface: only the complete fold, coinbase epilogue, and block-wide premises establish a valid extension. `applyChecked_eq_some_iff` characterizes the step exactly.

## Verification

- Signed head `8b82835` passes `lake build`, `lake lint`, and `lake test`.
- The axiom audit covers the transaction codec, checker/specification equivalences, semantic-to-wire lock-time equivalence, legacy-size/Core equivalence, pointwise spent-coin alignment, guarded accounting theorems, and checked-step characterization.
- Golden vectors include Core's ten-byte empty transaction (decode, byte-for-byte re-encode, then premise rejection) and real mainnet data that funds the UTXO set from the block-9 coinbase and runs the first Bitcoin payment through both premise bundles and the guarded transition. Negative vectors cover immaturity, script rejection, duplicate inputs, contextual `MoneyRange`, coinbase-as-regular rejection, and the SegWit arm.


