### PR TITLE
Add the BIP141 witness commitment leaf

### DIFF
--- a/BtcVerified.lean
+++ b/BtcVerified.lean
@@ -25,6 +25,7 @@ import BtcVerified.Chainstate.Apply
 import BtcVerified.Block.BlockHeader
 import BtcVerified.Block.Block
 import BtcVerified.Block.Commitment
+import BtcVerified.Block.WitnessCommitment
 import BtcVerified.Block.BlockHash
 import BtcVerified.Block.Chain
 import BtcVerified.Consensus.Limits

--- a/BtcVerified/Block/Commitment.lean
+++ b/BtcVerified/Block/Commitment.lean
@@ -11,7 +11,8 @@ import BtcVerified.Crypto.Merkle
   demands canonicality of the list itself.
 
   The SegWit witness commitment — the wtxid merkle root committed in the
-  coinbase — is the next leaf, not this one.
+  coinbase — is `WitnessCommitment.lean`, the sibling leaf built on the
+  same pattern.
 
   Checked claims:
 

--- a/BtcVerified/Block/README.md
+++ b/BtcVerified/Block/README.md
@@ -44,6 +44,43 @@ block's body to its header: a canonical txid list whose merkle root is the
 header's. The tree spec it is stated over, and its binding theorems, live in
 `../Crypto/` (see that README's `BtcVerified.Merkle` section).
 
+## The witness commitment
+
+SegWit moves witness data outside the txid preimage, so the txid tree no
+longer covers it; BIP141 restores the commitment through the coinbase.
+`Block.witnessCommits` (`WitnessCommitment.lean`) is the condition: the
+wtxids form a second merkle tree — the coinbase's leaf zeroed, since its own
+witness sits beneath the commitment it carries — and the coinbase records
+the double-SHA-256 of that root and the 32-byte witness reserved value (its
+input's single witness item) in the last output opening `6a24aa21a9ed`.
+Unlike the txid tree, no canonicality condition is needed: the transaction
+count is already pinned by the txid tree, and between equal-length lists the
+merkle root binds outright.
+
+Checked claims:
+
+- `witnessCommitment_binding`: equal commitments imply equal witness roots
+  and equal reserved values — or a concrete double-SHA-256 collision.
+- `Block.witnessRoot_binding`: between blocks with equally many
+  transactions, equal witness roots imply equal transactions beyond the
+  coinbase, witnesses included — or a concrete collision.
+- `Block.witnessCommits_binding`: two blocks satisfying the condition that
+  record the same commitment and have equally many transactions agree on
+  every transaction beyond the coinbase — or a concrete collision.
+- Golden vectors: the SegWit activation coinbase's real commitment output
+  and reserved value, the recognition rules (minimum length, exact header,
+  trailing bytes, last-match-wins), and `witnessCommits` itself over all
+  1866 transactions of block 481824 in the `lake test` fixture — which now
+  authenticates every byte of the fixture download, up to double-SHA-256
+  collisions.
+
+Why it matters: the txid tree binds every transaction body and misses
+exactly the witnesses; the witness tree binds every witness and misses
+exactly the coinbase's own — the reserved value, which sits in the
+commitment preimage. Together the two commitments make a block's header
+(plus its coinbase) a binding commitment to every byte of the block, which
+is what block validity will demand of witness-carrying blocks.
+
 ## Block hashes and the chain
 
 `BlockHeader.hash` — the double-SHA-256 of a header's 80-byte encoding, the

--- a/BtcVerified/Block/README.md
+++ b/BtcVerified/Block/README.md
@@ -52,15 +52,18 @@ longer covers it; BIP141 restores the commitment through the coinbase.
 wtxids form a second merkle tree — the coinbase's leaf zeroed, since its own
 witness sits beneath the commitment it carries — and the coinbase records
 the double-SHA-256 of that root and the 32-byte witness reserved value (its
-input's single witness item) in the last output opening `6a24aa21a9ed`.
-Unlike the txid tree, no canonicality condition is needed: the transaction
-count is already pinned by the txid tree, and between equal-length lists the
-merkle root binds outright.
+input's single witness item) in the last output opening `6a24aa21a9ed` with
+32 bytes behind the header. Both 32-byte values are typed `Hash256`, so the
+commitment preimage is exactly a merkle node's and the commitment *is*
+`Merkle.combine`. Unlike the txid tree, no canonicality condition is needed:
+the transaction count is already pinned by the txid tree, and between
+equal-length lists the merkle root binds outright.
 
 Checked claims:
 
 - `witnessCommitment_binding`: equal commitments imply equal witness roots
-  and equal reserved values — or a concrete double-SHA-256 collision.
+  and equal reserved values — or a concrete double-SHA-256 collision;
+  definitionally `Merkle.combine_binding`.
 - `Block.witnessRoot_binding`: between blocks with equally many
   transactions, equal witness roots imply equal transactions beyond the
   coinbase, witnesses included — or a concrete collision.

--- a/BtcVerified/Block/README.md
+++ b/BtcVerified/Block/README.md
@@ -53,9 +53,11 @@ wtxids form a second merkle tree — the coinbase's leaf zeroed, since its own
 witness sits beneath the commitment it carries — and the coinbase records
 the double-SHA-256 of that root and the 32-byte witness reserved value (its
 input's single witness item) in the last output opening `6a24aa21a9ed` with
-32 bytes behind the header. Both 32-byte values are typed `Hash256`, so the
-commitment preimage is exactly a merkle node's and the commitment *is*
-`Merkle.combine`. Unlike the txid tree, no canonicality condition is needed:
+32 bytes behind the header. The extracted values are typed `Bytes 32` — 32
+raw bytes, with no hash semantics claimed — while the witness root and the
+computed commitment are digests; `Hash256` being definitionally `Bytes 32`
+makes the commitment preimage exactly a merkle node's, so the commitment
+*is* `Merkle.combine`. Unlike the txid tree, no canonicality condition is needed:
 the transaction count is already pinned by the txid tree, and between
 equal-length lists the merkle root binds outright.
 

--- a/BtcVerified/Block/WitnessCommitment.lean
+++ b/BtcVerified/Block/WitnessCommitment.lean
@@ -115,6 +115,9 @@ def Block.witnessCommits (b : Block) : Prop :=
     ∧ b.recordedWitnessCommitment?
       = some (witnessCommitment b.witnessRoot reserved).1
 
+/-- The commitment condition is checked by computation — extract, hash,
+compare — which is what lets the golden vectors and the `lake test` fixture
+run it on real blocks. -/
 instance : DecidablePred Block.witnessCommits := fun b =>
   match hv : b.witnessReservedValue? with
   | some reserved =>

--- a/BtcVerified/Block/WitnessCommitment.lean
+++ b/BtcVerified/Block/WitnessCommitment.lean
@@ -9,11 +9,21 @@ import BtcVerified.Crypto.Merkle
   commitment through the coinbase. The wtxids form a second merkle tree —
   the coinbase's leaf taken as the zero hash, since its own witness sits
   beneath the commitment it carries — and the coinbase records
-  `sha256d(witnessRoot ‖ witnessReservedValue)` in an output whose
-  scriptPubKey is at least 38 bytes opening `6a24aa21a9ed`; when several
-  outputs match, the last one is the commitment (Bitcoin Core's
-  `GetWitnessCommitmentIndex`). The reserved value is the single 32-byte
-  item of the coinbase input's witness stack.
+  `sha256d(witnessRoot ‖ witnessReservedValue)` in the last output whose
+  scriptPubKey opens `6a24aa21a9ed` with 32 commitment bytes behind the
+  header (when several outputs match, the last one is the commitment —
+  Bitcoin Core's `GetWitnessCommitmentIndex`). The reserved value is the
+  single 32-byte item of the coinbase input's witness stack.
+
+  Both 32-byte values are typed as such: the reserved value and the
+  recorded commitment are `Hash256` — the library's 32-raw-bytes type —
+  never bare byte lists, so a commitment over an ill-sized reserved value
+  is unrepresentable rather than merely unchecked. The commitment preimage
+  `root ‖ reserved` is then exactly a merkle node's, so `witnessCommitment`
+  *is* `Merkle.combine`, and its binding theorem is `Merkle.combine_binding`
+  re-read at this leaf. Recognition and extraction of the commitment output
+  are one function: an output records a commitment exactly when the 32
+  bytes are there to extract.
 
   Unlike the txid tree, no canonicality condition is demanded of the
   witness tree, and none is needed: the padding ambiguity (CVE-2012-2459)
@@ -37,7 +47,8 @@ import BtcVerified.Crypto.Merkle
 
   * `witnessCommitment_binding`: equal commitments imply equal witness
     roots and equal reserved values — or two concrete byte strings
-    witnessing a double-SHA-256 collision.
+    witnessing a double-SHA-256 collision; definitionally
+    `Merkle.combine_binding`.
   * `Block.witnessRoot_binding`: between blocks with equally many
     transactions, equal witness roots imply equal transactions beyond the
     coinbase, witnesses included — or a concrete collision.
@@ -52,9 +63,11 @@ import BtcVerified.Crypto.Merkle
 namespace BtcVerified
 
 /-- The BIP141 witness commitment: the double-SHA-256 of the witness merkle
-root followed by the 32-byte witness reserved value. -/
-def witnessCommitment (root : Hash256) (reserved : List UInt8) : Hash256 :=
-  ⟨Sha256.sha256d (root.1 ++ reserved), Sha256.sha256d_length _⟩
+root followed by the 32-byte witness reserved value. The preimage is two
+32-byte values concatenated — exactly a merkle node's — so the commitment
+*is* a `Merkle.combine` step over the root and the reserved value. -/
+def witnessCommitment (root reserved : Hash256) : Hash256 :=
+  Merkle.combine root reserved
 
 /-- The witness merkle root of a block: the merkle root over wtxids, the
 coinbase's leaf taken as the zero hash — its witness sits beneath the
@@ -64,28 +77,30 @@ real block has at least its coinbase). -/
 def Block.witnessRoot (b : Block) : Hash256 :=
   Merkle.root (0 :: (b.txs.val.drop 1).map Tx.wtxid)
 
-/-- Whether an output records a witness commitment: at least 38 script
-bytes opening `OP_RETURN`, a 36-byte push, and the BIP141 header
-`aa21a9ed`. The 32 bytes after the header are the commitment; bytes past 38
-carry no consensus meaning and do not disqualify. -/
-def TxOut.isWitnessCommitment (o : TxOut) : Bool :=
-  o.scriptPubKey.code.val.take 6 == [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed]
-    && decide (38 ≤ o.scriptPubKey.code.val.length)
+/-- The witness commitment an output records: when its scriptPubKey opens
+`OP_RETURN`, a 36-byte push, and the BIP141 header `aa21a9ed`, the 32 bytes
+after the header. `none` when the header is absent or fewer than 32 bytes
+follow it; bytes past the commitment carry no consensus meaning and do not
+disqualify. Recognition is extraction succeeding — the boolean shape of
+Core's `GetWitnessCommitmentIndex` scan is `.isSome` of this. -/
+def TxOut.witnessCommitment? (o : TxOut) : Option Hash256 :=
+  if o.scriptPubKey.code.val.take 6 = [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed] then
+    Hash256.ofBytes? ((o.scriptPubKey.code.val.drop 6).take 32)
+  else none
 
-/-- The commitment a coinbase records: the 32 bytes after the BIP141 header
-in its *last* commitment-shaped output — BIP141 takes the highest output
-index when several match, as does Bitcoin Core's
-`GetWitnessCommitmentIndex`. `none` when no output matches. -/
-def Tx.recordedWitnessCommitment? (coinbase : Tx) : Option (List UInt8) :=
-  (coinbase.body.outputs.val.reverse.find? TxOut.isWitnessCommitment).map
-    fun o => (o.scriptPubKey.code.val.drop 6).take 32
+/-- The commitment a coinbase records: the one in its *last*
+commitment-shaped output — BIP141 takes the highest output index when
+several match, as does Bitcoin Core's `GetWitnessCommitmentIndex`. `none`
+when no output records one. -/
+def Tx.recordedWitnessCommitment? (coinbase : Tx) : Option Hash256 :=
+  coinbase.body.outputs.val.reverse.findSome? TxOut.witnessCommitment?
 
 /-- The witness reserved value a coinbase carries: the single 32-byte item
 BIP141 requires as its input's witness stack. Read from the first input —
 the coinbase's only one under consensus, though this layer does not enforce
 the single-input rule. `none` when the transaction is not
 witness-serialized or the stack is not one 32-byte item. -/
-def Tx.witnessReservedValue? : Tx → Option (List UInt8)
+def Tx.witnessReservedValue? : Tx → Option Hash256
   | .legacy .. => none
   | .empty .. => none
   | .segwit _ ins _ _ _ =>
@@ -93,16 +108,16 @@ def Tx.witnessReservedValue? : Tx → Option (List UInt8)
     | [] => none
     | input :: _ =>
       match input.witness.val with
-      | [item] => if item.val.length = 32 then some item.val else none
+      | [item] => Hash256.ofBytes? item.val
       | _ => none
 
 /-- The commitment a block records: its coinbase's, when it has one. -/
-def Block.recordedWitnessCommitment? (b : Block) : Option (List UInt8) :=
+def Block.recordedWitnessCommitment? (b : Block) : Option Hash256 :=
   b.txs.val.head?.bind Tx.recordedWitnessCommitment?
 
 /-- The witness reserved value a block carries: its coinbase's, when it has
 one. -/
-def Block.witnessReservedValue? (b : Block) : Option (List UInt8) :=
+def Block.witnessReservedValue? (b : Block) : Option Hash256 :=
   b.txs.val.head?.bind Tx.witnessReservedValue?
 
 /-- The BIP141 witness commitment condition: the coinbase carries the
@@ -113,7 +128,7 @@ witness data is) is a consensus guard at the validity layer. -/
 def Block.witnessCommits (b : Block) : Prop :=
   ∃ reserved, b.witnessReservedValue? = some reserved
     ∧ b.recordedWitnessCommitment?
-      = some (witnessCommitment b.witnessRoot reserved).1
+      = some (witnessCommitment b.witnessRoot reserved)
 
 /-- The commitment condition is checked by computation — extract, hash,
 compare — which is what lets the golden vectors and the `lake test` fixture
@@ -123,23 +138,18 @@ instance : DecidablePred Block.witnessCommits := fun b =>
   | some reserved =>
     decidable_of_iff
       (b.recordedWitnessCommitment?
-        = some (witnessCommitment b.witnessRoot reserved).1)
+        = some (witnessCommitment b.witnessRoot reserved))
       (by simp [Block.witnessCommits, hv])
   | none => isFalse (by rintro ⟨r, hr, -⟩; rw [hv] at hr; cases hr)
 
 /-- Equal witness commitments mean equal witness roots and equal reserved
 values — or two concrete byte strings witnessing a double-SHA-256
-collision. The commitment preimage splits unambiguously because a root is
-exactly 32 bytes, the same shape as `Merkle.combine_binding`. -/
-theorem witnessCommitment_binding {r₁ r₂ : Hash256} {v₁ v₂ : List UInt8}
+collision. The commitment is definitionally a merkle node over the root
+and the reserved value, so this is `Merkle.combine_binding` re-read. -/
+theorem witnessCommitment_binding {r₁ r₂ v₁ v₂ : Hash256}
     (h : witnessCommitment r₁ v₁ = witnessCommitment r₂ v₂) :
-    (r₁ = r₂ ∧ v₁ = v₂) ∨ Sha256.Collision := by
-  have hd : Sha256.sha256d (r₁.1 ++ v₁) = Sha256.sha256d (r₂.1 ++ v₂) :=
-    congrArg Subtype.val h
-  by_cases hm : r₁.1 ++ v₁ = r₂.1 ++ v₂
-  · obtain ⟨h₁, h₂⟩ := List.append_inj hm (by rw [r₁.2, r₂.2])
-    exact Or.inl ⟨Subtype.ext h₁, h₂⟩
-  · exact Or.inr ⟨_, _, hm, hd⟩
+    (r₁ = r₂ ∧ v₁ = v₂) ∨ Sha256.Collision :=
+  Merkle.combine_binding h
 
 /-- Between blocks with equally many transactions, equal witness roots mean
 equal transactions beyond the coinbase, witnesses included — or two
@@ -175,7 +185,7 @@ theorem Block.witnessCommits_binding {b₁ b₂ : Block}
   obtain ⟨v₁, -, hr₁⟩ := hc₁
   obtain ⟨v₂, -, hr₂⟩ := hc₂
   rw [hr₁, hr₂, Option.some.injEq] at hrec
-  rcases witnessCommitment_binding (Subtype.ext hrec) with ⟨hroot, -⟩ | c
+  rcases witnessCommitment_binding hrec with ⟨hroot, -⟩ | c
   · exact Block.witnessRoot_binding hlen hroot
   · exact Or.inr c
 

--- a/BtcVerified/Block/WitnessCommitment.lean
+++ b/BtcVerified/Block/WitnessCommitment.lean
@@ -1,0 +1,179 @@
+import BtcVerified.Block.Block
+import BtcVerified.Transaction.Txid
+import BtcVerified.Crypto.Merkle
+/-!
+  # The block's witness commitment
+
+  SegWit moves witness data outside the txid preimage, so the txid merkle
+  root (`Commitment.lean`) no longer covers it; BIP141 restores the
+  commitment through the coinbase. The wtxids form a second merkle tree —
+  the coinbase's leaf taken as the zero hash, since its own witness sits
+  beneath the commitment it carries — and the coinbase records
+  `sha256d(witnessRoot ‖ witnessReservedValue)` in an output whose
+  scriptPubKey is at least 38 bytes opening `6a24aa21a9ed`; when several
+  outputs match, the last one is the commitment (Bitcoin Core's
+  `GetWitnessCommitmentIndex`). The reserved value is the single 32-byte
+  item of the coinbase input's witness stack.
+
+  Unlike the txid tree, no canonicality condition is demanded of the
+  witness tree, and none is needed: the padding ambiguity (CVE-2012-2459)
+  needs room to change the leaf count, and in consensus use the
+  transaction count is already pinned by the txid tree — between
+  equal-length lists the root binds outright
+  (`Merkle.root_binding_of_length_eq`). `Block.witnessRoot_binding` is
+  that folklore argument made precise.
+
+  Division of labor between the two commitments: the txid tree binds every
+  body — including the coinbase's, and through it the recorded commitment
+  itself — and misses exactly the witnesses; the witness tree binds every
+  transaction beyond the coinbase, witnesses included, and misses exactly
+  the coinbase's own witness — which is the reserved value, sitting in the
+  commitment preimage. Together they cover every byte of a block. When a
+  commitment is *required* (any block carrying witness data must have one)
+  is a consensus guard at the validity layer, exactly as `merkleCommits`
+  states the condition and not the rule.
+
+  Checked claims:
+
+  * `witnessCommitment_binding`: equal commitments imply equal witness
+    roots and equal reserved values — or two concrete byte strings
+    witnessing a double-SHA-256 collision.
+  * `Block.witnessRoot_binding`: between blocks with equally many
+    transactions, equal witness roots imply equal transactions beyond the
+    coinbase, witnesses included — or a concrete collision.
+  * `Block.witnessCommits_binding`: two blocks satisfying `witnessCommits`
+    that record the same commitment and have equally many transactions
+    agree on every transaction beyond the coinbase — or a concrete
+    collision.
+  * `Block.witnessCommits` is decidable, so real blocks are checked
+    against it in the golden vectors and the `lake test` fixture.
+-/
+
+namespace BtcVerified
+
+/-- The BIP141 witness commitment: the double-SHA-256 of the witness merkle
+root followed by the 32-byte witness reserved value. -/
+def witnessCommitment (root : Hash256) (reserved : List UInt8) : Hash256 :=
+  ⟨Sha256.sha256d (root.1 ++ reserved), Sha256.sha256d_length _⟩
+
+/-- The witness merkle root of a block: the merkle root over wtxids, the
+coinbase's leaf taken as the zero hash — its witness sits beneath the
+commitment it carries, so BIP141 zeroes its slot and the coinbase stays
+bound by the txid tree instead. Degenerate on an empty transaction list (a
+real block has at least its coinbase). -/
+def Block.witnessRoot (b : Block) : Hash256 :=
+  Merkle.root (0 :: (b.txs.val.drop 1).map Tx.wtxid)
+
+/-- Whether an output records a witness commitment: at least 38 script
+bytes opening `OP_RETURN`, a 36-byte push, and the BIP141 header
+`aa21a9ed`. The 32 bytes after the header are the commitment; bytes past 38
+carry no consensus meaning and do not disqualify. -/
+def TxOut.isWitnessCommitment (o : TxOut) : Bool :=
+  o.scriptPubKey.code.val.take 6 == [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed]
+    && decide (38 ≤ o.scriptPubKey.code.val.length)
+
+/-- The commitment a coinbase records: the 32 bytes after the BIP141 header
+in its *last* commitment-shaped output — BIP141 takes the highest output
+index when several match, as does Bitcoin Core's
+`GetWitnessCommitmentIndex`. `none` when no output matches. -/
+def Tx.recordedWitnessCommitment? (coinbase : Tx) : Option (List UInt8) :=
+  (coinbase.body.outputs.val.reverse.find? TxOut.isWitnessCommitment).map
+    fun o => (o.scriptPubKey.code.val.drop 6).take 32
+
+/-- The witness reserved value a coinbase carries: the single 32-byte item
+BIP141 requires as its input's witness stack. Read from the first input —
+the coinbase's only one under consensus, though this layer does not enforce
+the single-input rule. `none` when the transaction is not
+witness-serialized or the stack is not one 32-byte item. -/
+def Tx.witnessReservedValue? : Tx → Option (List UInt8)
+  | .legacy .. => none
+  | .empty .. => none
+  | .segwit _ ins _ _ _ =>
+    match ins.val with
+    | [] => none
+    | input :: _ =>
+      match input.witness.val with
+      | [item] => if item.val.length = 32 then some item.val else none
+      | _ => none
+
+/-- The commitment a block records: its coinbase's, when it has one. -/
+def Block.recordedWitnessCommitment? (b : Block) : Option (List UInt8) :=
+  b.txs.val.head?.bind Tx.recordedWitnessCommitment?
+
+/-- The witness reserved value a block carries: its coinbase's, when it has
+one. -/
+def Block.witnessReservedValue? (b : Block) : Option (List UInt8) :=
+  b.txs.val.head?.bind Tx.witnessReservedValue?
+
+/-- The BIP141 witness commitment condition: the coinbase carries the
+32-byte reserved value as its witness, and the commitment it records is
+exactly the double-SHA-256 of this block's witness root followed by that
+value. Whether a block is *required* to satisfy this (any block carrying
+witness data is) is a consensus guard at the validity layer. -/
+def Block.witnessCommits (b : Block) : Prop :=
+  ∃ reserved, b.witnessReservedValue? = some reserved
+    ∧ b.recordedWitnessCommitment?
+      = some (witnessCommitment b.witnessRoot reserved).1
+
+instance : DecidablePred Block.witnessCommits := fun b =>
+  match hv : b.witnessReservedValue? with
+  | some reserved =>
+    decidable_of_iff
+      (b.recordedWitnessCommitment?
+        = some (witnessCommitment b.witnessRoot reserved).1)
+      (by simp [Block.witnessCommits, hv])
+  | none => isFalse (by rintro ⟨r, hr, -⟩; rw [hv] at hr; cases hr)
+
+/-- Equal witness commitments mean equal witness roots and equal reserved
+values — or two concrete byte strings witnessing a double-SHA-256
+collision. The commitment preimage splits unambiguously because a root is
+exactly 32 bytes, the same shape as `Merkle.combine_binding`. -/
+theorem witnessCommitment_binding {r₁ r₂ : Hash256} {v₁ v₂ : List UInt8}
+    (h : witnessCommitment r₁ v₁ = witnessCommitment r₂ v₂) :
+    (r₁ = r₂ ∧ v₁ = v₂) ∨ Sha256.Collision := by
+  have hd : Sha256.sha256d (r₁.1 ++ v₁) = Sha256.sha256d (r₂.1 ++ v₂) :=
+    congrArg Subtype.val h
+  by_cases hm : r₁.1 ++ v₁ = r₂.1 ++ v₂
+  · obtain ⟨h₁, h₂⟩ := List.append_inj hm (by rw [r₁.2, r₂.2])
+    exact Or.inl ⟨Subtype.ext h₁, h₂⟩
+  · exact Or.inr ⟨_, _, hm, hd⟩
+
+/-- Between blocks with equally many transactions, equal witness roots mean
+equal transactions beyond the coinbase, witnesses included — or two
+concrete byte strings witnessing a double-SHA-256 collision. No
+canonicality condition: with the length pinned (by the txid tree, in
+consensus use), the root binds outright — the CVE-2012-2459 ambiguity
+needs room to change the leaf count. -/
+theorem Block.witnessRoot_binding {b₁ b₂ : Block}
+    (hlen : b₁.txs.val.length = b₂.txs.val.length)
+    (hroot : b₁.witnessRoot = b₂.witnessRoot) :
+    b₁.txs.val.drop 1 = b₂.txs.val.drop 1 ∨ Sha256.Collision := by
+  unfold Block.witnessRoot at hroot
+  have hlen' : ((0 : Hash256) :: (b₁.txs.val.drop 1).map Tx.wtxid).length
+      = ((0 : Hash256) :: (b₂.txs.val.drop 1).map Tx.wtxid).length := by
+    simp only [List.length_cons, List.length_map, List.length_drop, hlen]
+  rcases Merkle.root_binding_of_length_eq hlen' hroot with heq | c
+  · simp only [List.cons.injEq, true_and] at heq
+    exact Tx.map_wtxid_binding heq
+  · exact Or.inr c
+
+/-- Two blocks satisfying the witness-commitment condition that record the
+same commitment and have equally many transactions agree on every
+transaction beyond the coinbase, witnesses included — or two concrete byte
+strings witnessing a double-SHA-256 collision. In consensus use both
+side conditions come from the txid tree: `merkleCommits` binding pins the
+transaction count and the coinbase body, and the recorded commitment is
+part of that body. -/
+theorem Block.witnessCommits_binding {b₁ b₂ : Block}
+    (hc₁ : b₁.witnessCommits) (hc₂ : b₂.witnessCommits)
+    (hrec : b₁.recordedWitnessCommitment? = b₂.recordedWitnessCommitment?)
+    (hlen : b₁.txs.val.length = b₂.txs.val.length) :
+    b₁.txs.val.drop 1 = b₂.txs.val.drop 1 ∨ Sha256.Collision := by
+  obtain ⟨v₁, -, hr₁⟩ := hc₁
+  obtain ⟨v₂, -, hr₂⟩ := hc₂
+  rw [hr₁, hr₂, Option.some.injEq] at hrec
+  rcases witnessCommitment_binding (Subtype.ext hrec) with ⟨hroot, -⟩ | c
+  · exact Block.witnessRoot_binding hlen hroot
+  · exact Or.inr c
+
+end BtcVerified

--- a/BtcVerified/Block/WitnessCommitment.lean
+++ b/BtcVerified/Block/WitnessCommitment.lean
@@ -15,15 +15,17 @@ import BtcVerified.Crypto.Merkle
   Bitcoin Core's `GetWitnessCommitmentIndex`). The reserved value is the
   single 32-byte item of the coinbase input's witness stack.
 
-  Both 32-byte values are typed as such: the reserved value and the
-  recorded commitment are `Hash256` — the library's 32-raw-bytes type —
-  never bare byte lists, so a commitment over an ill-sized reserved value
-  is unrepresentable rather than merely unchecked. The commitment preimage
-  `root ‖ reserved` is then exactly a merkle node's, so `witnessCommitment`
-  *is* `Merkle.combine`, and its binding theorem is `Merkle.combine_binding`
-  re-read at this leaf. Recognition and extraction of the commitment output
-  are one function: an output records a commitment exactly when the 32
-  bytes are there to extract.
+  Both extracted values are typed fixed-width, and only that: the reserved
+  value and the recorded commitment are `Bytes 32` — 32 raw bytes with no
+  hash semantics claimed, because the protocol today gives them none; only
+  the witness root and the computed commitment are digests (`Hash256`). A
+  commitment over an ill-sized reserved value is thus unrepresentable
+  rather than merely unchecked. `Hash256` is definitionally `Bytes 32`, so
+  the commitment preimage `root ‖ reserved` is exactly a merkle node's:
+  `witnessCommitment` *is* `Merkle.combine`, and its binding theorem is
+  `Merkle.combine_binding` re-read at this leaf. Recognition and extraction
+  of the commitment output are one function: an output records a commitment
+  exactly when the 32 bytes are there to extract.
 
   Unlike the txid tree, no canonicality condition is demanded of the
   witness tree, and none is needed: the padding ambiguity (CVE-2012-2459)
@@ -63,10 +65,11 @@ import BtcVerified.Crypto.Merkle
 namespace BtcVerified
 
 /-- The BIP141 witness commitment: the double-SHA-256 of the witness merkle
-root followed by the 32-byte witness reserved value. The preimage is two
-32-byte values concatenated — exactly a merkle node's — so the commitment
-*is* a `Merkle.combine` step over the root and the reserved value. -/
-def witnessCommitment (root reserved : Hash256) : Hash256 :=
+root followed by the 32-byte witness reserved value. The reserved value is
+bare bytes, not a digest — but a `Hash256` is definitionally a `Bytes 32`,
+so the preimage is two 32-byte values concatenated, exactly a merkle
+node's, and the commitment *is* a `Merkle.combine` step. -/
+def witnessCommitment (root : Hash256) (reserved : Bytes 32) : Hash256 :=
   Merkle.combine root reserved
 
 /-- The witness merkle root of a block: the merkle root over wtxids, the
@@ -83,16 +86,16 @@ after the header. `none` when the header is absent or fewer than 32 bytes
 follow it; bytes past the commitment carry no consensus meaning and do not
 disqualify. Recognition is extraction succeeding — the boolean shape of
 Core's `GetWitnessCommitmentIndex` scan is `.isSome` of this. -/
-def TxOut.witnessCommitment? (o : TxOut) : Option Hash256 :=
+def TxOut.witnessCommitment? (o : TxOut) : Option (Bytes 32) :=
   if o.scriptPubKey.code.val.take 6 = [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed] then
-    Hash256.ofBytes? ((o.scriptPubKey.code.val.drop 6).take 32)
+    Bytes.ofListExact? ((o.scriptPubKey.code.val.drop 6).take 32)
   else none
 
 /-- The commitment a coinbase records: the one in its *last*
 commitment-shaped output — BIP141 takes the highest output index when
 several match, as does Bitcoin Core's `GetWitnessCommitmentIndex`. `none`
 when no output records one. -/
-def Tx.recordedWitnessCommitment? (coinbase : Tx) : Option Hash256 :=
+def Tx.recordedWitnessCommitment? (coinbase : Tx) : Option (Bytes 32) :=
   coinbase.body.outputs.val.reverse.findSome? TxOut.witnessCommitment?
 
 /-- The witness reserved value a coinbase carries: the single 32-byte item
@@ -100,7 +103,7 @@ BIP141 requires as its input's witness stack. Read from the first input —
 the coinbase's only one under consensus, though this layer does not enforce
 the single-input rule. `none` when the transaction is not
 witness-serialized or the stack is not one 32-byte item. -/
-def Tx.witnessReservedValue? : Tx → Option Hash256
+def Tx.witnessReservedValue? : Tx → Option (Bytes 32)
   | .legacy .. => none
   | .empty .. => none
   | .segwit _ ins _ _ _ =>
@@ -108,16 +111,16 @@ def Tx.witnessReservedValue? : Tx → Option Hash256
     | [] => none
     | input :: _ =>
       match input.witness.val with
-      | [item] => Hash256.ofBytes? item.val
+      | [item] => Bytes.ofListExact? item.val
       | _ => none
 
 /-- The commitment a block records: its coinbase's, when it has one. -/
-def Block.recordedWitnessCommitment? (b : Block) : Option Hash256 :=
+def Block.recordedWitnessCommitment? (b : Block) : Option (Bytes 32) :=
   b.txs.val.head?.bind Tx.recordedWitnessCommitment?
 
 /-- The witness reserved value a block carries: its coinbase's, when it has
 one. -/
-def Block.witnessReservedValue? (b : Block) : Option Hash256 :=
+def Block.witnessReservedValue? (b : Block) : Option (Bytes 32) :=
   b.txs.val.head?.bind Tx.witnessReservedValue?
 
 /-- The BIP141 witness commitment condition: the coinbase carries the
@@ -146,7 +149,7 @@ instance : DecidablePred Block.witnessCommits := fun b =>
 values — or two concrete byte strings witnessing a double-SHA-256
 collision. The commitment is definitionally a merkle node over the root
 and the reserved value, so this is `Merkle.combine_binding` re-read. -/
-theorem witnessCommitment_binding {r₁ r₂ v₁ v₂ : Hash256}
+theorem witnessCommitment_binding {r₁ r₂ : Hash256} {v₁ v₂ : Bytes 32}
     (h : witnessCommitment r₁ v₁ = witnessCommitment r₂ v₂) :
     (r₁ = r₂ ∧ v₁ = v₂) ∨ Sha256.Collision :=
   Merkle.combine_binding h

--- a/BtcVerified/Transaction/README.md
+++ b/BtcVerified/Transaction/README.md
@@ -89,6 +89,9 @@ Checked claims:
   injectivity.
 - `Tx.wtxid_binding`: equal wtxids imply equal transactions, witnesses
   included — or a concrete collision.
+- `Tx.map_wtxid_binding`: equal wtxid *lists* imply equal transaction lists,
+  witnesses included — or a concrete collision; the form the witness
+  commitment (`../Block/`) lifts through the merkle layer.
 - Golden vectors: the first Bitcoin payment's txid, the genesis coinbase txid
   (which is the genesis merkle root), and the SegWit coinbase's txid with
   `wtxid ≠ txid`.

--- a/BtcVerified/Transaction/SegwitInput.lean
+++ b/BtcVerified/Transaction/SegwitInput.lean
@@ -7,7 +7,7 @@ import BtcVerified.Transaction.WitnessStack
   the pair together makes the one-witness-per-input arity structural — a list
   of `SegwitInput` cannot express a count mismatch — while the BIP144 wire
   format's regrouping (all inputs, then all witnesses) is left to the codec
-  (`Transaction.TxCodec`). No codec lives here for exactly that reason.
+  (`Transaction.Tx`). No codec lives here for exactly that reason.
 -/
 
 namespace BtcVerified

--- a/BtcVerified/Transaction/Txid.lean
+++ b/BtcVerified/Transaction/Txid.lean
@@ -24,6 +24,8 @@ import BtcVerified.Crypto.Hash256
     concrete `sha256d` collision.
   * `Tx.wtxid_binding`: equal wtxids imply equal transactions (witnesses
     included), or a concrete `sha256d` collision.
+  * `Tx.map_wtxid_binding`: equal wtxid *lists* imply equal transaction
+    lists — the form the witness commitment lifts through the merkle layer.
   * `Tx.wtxid_legacy`: a legacy transaction's wtxid is its txid.
 -/
 
@@ -75,5 +77,27 @@ theorem Tx.wtxid_binding {t₁ t₂ : Tx} (h : t₁.wtxid = t₂.wtxid) :
   · exact Or.inl ht
   · exact Or.inr ⟨Codec.encode t₁, Codec.encode t₂,
       fun he => ht (encode_injective he), congrArg Subtype.val h⟩
+
+/-- Equal wtxid lists mean equal transaction lists, witnesses included — or
+two concrete byte strings witnessing a double-SHA-256 collision.
+`Tx.wtxid_binding` lifted pointwise, in the form the witness commitment's
+binding theorem carries through the merkle layer. -/
+theorem Tx.map_wtxid_binding {l₁ l₂ : List Tx}
+    (h : l₁.map Tx.wtxid = l₂.map Tx.wtxid) : l₁ = l₂ ∨ Sha256.Collision := by
+  induction l₁ generalizing l₂ with
+  | nil =>
+    cases l₂ with
+    | nil => exact Or.inl rfl
+    | cons t r => exact absurd h (by simp)
+  | cons t₁ r₁ ih =>
+    cases l₂ with
+    | nil => exact absurd h (by simp)
+    | cons t₂ r₂ =>
+      simp only [List.map_cons, List.cons.injEq] at h
+      rcases Tx.wtxid_binding h.1 with ht | c
+      · rcases ih h.2 with hr | c
+        · exact Or.inl (by rw [ht, hr])
+        · exact Or.inr c
+      · exact Or.inr c
 
 end BtcVerified

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ statement of what stands.
   transaction ids are binding commitments to the transaction.
 - [`Block/`](BtcVerified/Block/README.md) — Every byte of a block parses
   through a verified codec (checked against real mainnet blocks), block
-  hashes are proved binding, and a chain's tip hash provably commits to the
-  entire history behind it.
+  hashes are proved binding, the coinbase's SegWit witness commitment
+  provably binds every witness in the block, and a chain's tip hash provably
+  commits to the entire history behind it.
 - [`Script/`](BtcVerified/Script/README.md) — Bitcoin Script programs
   modeled as the raw bytes consensus actually validates, with the boundary
   between parsing and execution drawn where the protocol draws it.

--- a/Tests/AxiomAudit.lean
+++ b/Tests/AxiomAudit.lean
@@ -135,6 +135,7 @@ elab "#assert_axioms " id:ident : command => do
 
 #assert_axioms BtcVerified.Tx.txid_binding
 #assert_axioms BtcVerified.Tx.wtxid_binding
+#assert_axioms BtcVerified.Tx.map_wtxid_binding
 #assert_axioms BtcVerified.Tx.wtxid_legacy
 #assert_axioms BtcVerified.Tx.wtxid_empty
 
@@ -193,6 +194,13 @@ elab "#assert_axioms " id:ident : command => do
 #assert_axioms BtcVerified.Merkle.root_binding_of_length_eq
 #assert_axioms BtcVerified.Merkle.root_binding_of_canonical
 #assert_axioms BtcVerified.Block.merkleCommits
+
+/-! ## The witness commitment -/
+
+#assert_axioms BtcVerified.witnessCommitment_binding
+#assert_axioms BtcVerified.Block.witnessRoot_binding
+#assert_axioms BtcVerified.Block.witnessCommits_binding
+#assert_axioms BtcVerified.Block.witnessCommits
 
 /-! ## Bitcoin Core's ComputeMerkleRoot -/
 

--- a/Tests/BlockFixtures.lean
+++ b/Tests/BlockFixtures.lean
@@ -9,15 +9,14 @@ import Tests.GoldenVectors
   A block is public chain data, reconstructible from any Bitcoin node, so
   fixtures are not committed: the test driver fetches each one on first run
   (from an esplora HTTP endpoint, by block hash) and caches it under
-  `Tests/fixtures/`, which is gitignored. The download is authenticated as
-  far as the current leaves allow: the decoded header must double-SHA-256 to
-  the requested block hash (so the 80 header bytes carry their proof of
-  work), the merkle commitment pins every transaction's txid to that header,
-  and the spot-checks pin the embedded transactions they name byte-for-byte.
-  Txids exclude witness data (BIP141), so the SegWit witness bytes of
-  transactions not byte-pinned by a spot-check are the one region a
-  corrupted download could alter undetected; closing it is the
-  witness-commitment leaf's job, once it lands.
+  `Tests/fixtures/`, which is gitignored. The download is authenticated end
+  to end: the decoded header must double-SHA-256 to the requested block
+  hash (so the 80 header bytes carry their proof of work), the merkle
+  commitment pins every transaction's txid to that header, the BIP141
+  witness commitment pins every witness byte to the coinbase the txid tree
+  covers, and the spot-checks additionally pin the embedded transactions
+  they name byte-for-byte. Up to double-SHA-256 collisions, no byte of a
+  fixture can differ from the mainnet block.
 
   The one fixture so far is block 481824, the SegWit activation block: 1866
   transactions mixing the legacy and SegWit serializations, the SegWit
@@ -86,14 +85,17 @@ def block481824Checks (b : Block) : Bool :=
   -- The header commits to all 1866 transaction ids through the merkle root,
   -- and the txid list is canonical. With the header-hash check above, every
   -- non-witness transaction byte is pinned: txids → merkle root → header →
-  -- proof-of-work hash. Witness bytes are outside the txid preimage (BIP141),
-  -- so only the two byte-pinned transactions above have theirs checked,
-  -- until the witness-commitment leaf lands.
+  -- proof-of-work hash.
   && decide b.merkleCommits
   -- Bitcoin Core's own algorithm accepts the block: run on the real txid list,
   -- its `mutated` flag is clear — the model agrees with Core, which accepted
   -- block 481824 into the chain.
   && !(Impl.BitcoinCore.computeMerkleRoot (b.txs.val.map Tx.txid)).2
+  -- The BIP141 witness commitment: wtxids → witness root → commitment
+  -- output in the coinbase, whose bytes the txid tree pins. Witness bytes
+  -- are all the txid tree misses, so with `merkleCommits` above every byte
+  -- of the block is now authenticated, up to double-SHA-256 collisions.
+  && decide b.witnessCommits
 
 /-- Where a fixture block is cached locally, by display hash. Gitignored. -/
 def fixturePath (blockHash : String) : System.FilePath :=

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -630,8 +630,8 @@ def block170Context : TxContext :=
   | some (tx, _) =>
     tx.recordedWitnessCommitment?
       == (hexBytes? "6c3c4dff76b5760d58694147264d208689ee07823e5694c4872f856eacf5a5d8"
-        >>= Hash256.ofBytes?)
-    && tx.witnessReservedValue? == Hash256.ofBytes? (List.replicate 32 0)
+        >>= Bytes.ofListExact?)
+    && tx.witnessReservedValue? == Bytes.ofListExact? (List.replicate 32 0)
   | none => false
 
 /-- The six bytes every commitment output opens with: `OP_RETURN`, a
@@ -659,7 +659,7 @@ def txWithOutputs (outs : List TxOut) (h : outs.length < 2 ^ 64 := by decide) :
 
 -- A commitment output yields exactly the 32 bytes after the header.
 #guard (outWithScript (commitmentHeader ++ List.replicate 32 0x11)).witnessCommitment?
-  == Hash256.ofBytes? (List.replicate 32 0x11)
+  == Bytes.ofListExact? (List.replicate 32 0x11)
 -- 37 bytes is one short of a full commitment.
 #guard (outWithScript
     (commitmentHeader ++ List.replicate 31 0x11)).witnessCommitment? == none
@@ -670,18 +670,18 @@ def txWithOutputs (outs : List TxOut) (h : outs.length < 2 ^ 64 := by decide) :
 -- Bytes past the commitment carry no consensus meaning: they do not
 -- disqualify and do not enter the extracted value.
 #guard (outWithScript (commitmentHeader ++ List.replicate 40 0x11)).witnessCommitment?
-  == Hash256.ofBytes? (List.replicate 32 0x11)
+  == Bytes.ofListExact? (List.replicate 32 0x11)
 -- Several matching outputs: the last one wins (BIP141's highest index, as
 -- in Core's GetWitnessCommitmentIndex).
 #guard (txWithOutputs
     [outWithScript (commitmentHeader ++ List.replicate 32 0x11),
      outWithScript (commitmentHeader ++ List.replicate 32 0x22)]).recordedWitnessCommitment?
-  == Hash256.ofBytes? (List.replicate 32 0x22)
+  == Bytes.ofListExact? (List.replicate 32 0x22)
 -- A non-commitment output after the commitment does not displace it.
 #guard (txWithOutputs
     [outWithScript (commitmentHeader ++ List.replicate 32 0x11),
      outWithScript []]).recordedWitnessCommitment?
-  == Hash256.ofBytes? (List.replicate 32 0x11)
+  == Bytes.ofListExact? (List.replicate 32 0x11)
 -- Pre-SegWit blocks record no commitment, carry no reserved value, and do
 -- not satisfy the commitment condition.
 #guard match hexBytes? genesisBlockHex >>= Codec.decode (α := Block) with

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -675,10 +675,12 @@ def txWithOutputs (outs : List TxOut) (h : outs.length < 2 ^ 64 := by decide) :
     [outWithScript (commitmentHeader ++ List.replicate 32 0x11),
      outWithScript []]).recordedWitnessCommitment?
   == some (List.replicate 32 0x11)
--- Pre-SegWit blocks record no commitment and carry no reserved value.
+-- Pre-SegWit blocks record no commitment, carry no reserved value, and do
+-- not satisfy the commitment condition.
 #guard match hexBytes? genesisBlockHex >>= Codec.decode (α := Block) with
   | some (b, _) =>
     b.recordedWitnessCommitment? == none && b.witnessReservedValue? == none
+    && !decide b.witnessCommits
   | none => false
 
 end Tests.GoldenVectors

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -614,4 +614,71 @@ def block170Context : TxContext :=
 -- well-formed.
 #guard checksOut firstSegwitSpendHex fun tx => tx.isWellFormed
 
+/-! ## The witness commitment
+
+  Output recognition and extraction on the real SegWit activation coinbase
+  (the commitment bytes are read straight out of `segwitCoinbaseHex`), plus
+  synthetic vectors for the recognition rules: minimum length, the exact
+  header, trailing bytes, and BIP141's last-match-wins. The full
+  `Block.witnessCommits` check over all 1866 wtxids runs in the `lake test`
+  fixture, where the whole block is in hand. -/
+
+-- The activation coinbase records the commitment visible in its own hex —
+-- the 32 bytes after the 6a24aa21a9ed header — and carries the 32-zero-byte
+-- reserved value as its witness.
+#guard match hexBytes? segwitCoinbaseHex >>= Codec.decode (α := Tx) with
+  | some (tx, _) =>
+    tx.recordedWitnessCommitment?
+      == hexBytes? "6c3c4dff76b5760d58694147264d208689ee07823e5694c4872f856eacf5a5d8"
+    && tx.witnessReservedValue? == some (List.replicate 32 0)
+  | none => false
+
+/-- The six bytes every commitment output opens with: `OP_RETURN`, a
+36-byte push, and the BIP141 header `aa21a9ed`. -/
+def commitmentHeader : List UInt8 := [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed]
+
+/-- A `TxOut` with the given script bytes and a zero amount, for the
+commitment-recognition vectors. -/
+def outWithScript (bytes : List UInt8) (h : bytes.length < 2 ^ 64 := by decide) :
+    TxOut :=
+  { value := 0, scriptPubKey := ⟨⟨bytes, h⟩⟩ }
+
+/-- A minimal legacy transaction around the given outputs — just enough
+coinbase shape for the commitment-recognition vectors. -/
+def txWithOutputs (outs : List TxOut) (h : outs.length < 2 ^ 64 := by decide) :
+    Tx :=
+  .legacy
+    { version := 1
+      inputs := ⟨[{ prevout := { txid := 0, vout := 0xffffffff }
+                    scriptSig := ⟨⟨[], by decide⟩⟩
+                    sequence := 0xffffffff }], by decide⟩
+      outputs := ⟨outs, h⟩
+      lockTime := 0 }
+    (by simp)
+
+#guard (outWithScript (commitmentHeader ++ List.replicate 32 0x11)).isWitnessCommitment
+-- 37 bytes is one short of a full commitment.
+#guard !(outWithScript (commitmentHeader ++ List.replicate 31 0x11)).isWitnessCommitment
+-- A wrong header byte disqualifies.
+#guard !(outWithScript
+    ([0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xee] ++ List.replicate 32 0x11)).isWitnessCommitment
+-- Bytes past 38 carry no consensus meaning but do not disqualify.
+#guard (outWithScript (commitmentHeader ++ List.replicate 40 0x11)).isWitnessCommitment
+-- Several matching outputs: the last one wins (BIP141's highest index, as
+-- in Core's GetWitnessCommitmentIndex).
+#guard (txWithOutputs
+    [outWithScript (commitmentHeader ++ List.replicate 32 0x11),
+     outWithScript (commitmentHeader ++ List.replicate 32 0x22)]).recordedWitnessCommitment?
+  == some (List.replicate 32 0x22)
+-- A non-commitment output after the commitment does not displace it.
+#guard (txWithOutputs
+    [outWithScript (commitmentHeader ++ List.replicate 32 0x11),
+     outWithScript []]).recordedWitnessCommitment?
+  == some (List.replicate 32 0x11)
+-- Pre-SegWit blocks record no commitment and carry no reserved value.
+#guard match hexBytes? genesisBlockHex >>= Codec.decode (α := Block) with
+  | some (b, _) =>
+    b.recordedWitnessCommitment? == none && b.witnessReservedValue? == none
+  | none => false
+
 end Tests.GoldenVectors

--- a/Tests/GoldenVectors.lean
+++ b/Tests/GoldenVectors.lean
@@ -629,8 +629,9 @@ def block170Context : TxContext :=
 #guard match hexBytes? segwitCoinbaseHex >>= Codec.decode (α := Tx) with
   | some (tx, _) =>
     tx.recordedWitnessCommitment?
-      == hexBytes? "6c3c4dff76b5760d58694147264d208689ee07823e5694c4872f856eacf5a5d8"
-    && tx.witnessReservedValue? == some (List.replicate 32 0)
+      == (hexBytes? "6c3c4dff76b5760d58694147264d208689ee07823e5694c4872f856eacf5a5d8"
+        >>= Hash256.ofBytes?)
+    && tx.witnessReservedValue? == Hash256.ofBytes? (List.replicate 32 0)
   | none => false
 
 /-- The six bytes every commitment output opens with: `OP_RETURN`, a
@@ -656,25 +657,31 @@ def txWithOutputs (outs : List TxOut) (h : outs.length < 2 ^ 64 := by decide) :
       lockTime := 0 }
     (by simp)
 
-#guard (outWithScript (commitmentHeader ++ List.replicate 32 0x11)).isWitnessCommitment
+-- A commitment output yields exactly the 32 bytes after the header.
+#guard (outWithScript (commitmentHeader ++ List.replicate 32 0x11)).witnessCommitment?
+  == Hash256.ofBytes? (List.replicate 32 0x11)
 -- 37 bytes is one short of a full commitment.
-#guard !(outWithScript (commitmentHeader ++ List.replicate 31 0x11)).isWitnessCommitment
+#guard (outWithScript
+    (commitmentHeader ++ List.replicate 31 0x11)).witnessCommitment? == none
 -- A wrong header byte disqualifies.
-#guard !(outWithScript
-    ([0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xee] ++ List.replicate 32 0x11)).isWitnessCommitment
--- Bytes past 38 carry no consensus meaning but do not disqualify.
-#guard (outWithScript (commitmentHeader ++ List.replicate 40 0x11)).isWitnessCommitment
+#guard (outWithScript
+    ([0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xee]
+      ++ List.replicate 32 0x11)).witnessCommitment? == none
+-- Bytes past the commitment carry no consensus meaning: they do not
+-- disqualify and do not enter the extracted value.
+#guard (outWithScript (commitmentHeader ++ List.replicate 40 0x11)).witnessCommitment?
+  == Hash256.ofBytes? (List.replicate 32 0x11)
 -- Several matching outputs: the last one wins (BIP141's highest index, as
 -- in Core's GetWitnessCommitmentIndex).
 #guard (txWithOutputs
     [outWithScript (commitmentHeader ++ List.replicate 32 0x11),
      outWithScript (commitmentHeader ++ List.replicate 32 0x22)]).recordedWitnessCommitment?
-  == some (List.replicate 32 0x22)
+  == Hash256.ofBytes? (List.replicate 32 0x22)
 -- A non-commitment output after the commitment does not displace it.
 #guard (txWithOutputs
     [outWithScript (commitmentHeader ++ List.replicate 32 0x11),
      outWithScript []]).recordedWitnessCommitment?
-  == some (List.replicate 32 0x11)
+  == Hash256.ofBytes? (List.replicate 32 0x11)
 -- Pre-SegWit blocks record no commitment, carry no reserved value, and do
 -- not satisfy the commitment condition.
 #guard match hexBytes? genesisBlockHex >>= Codec.decode (α := Block) with


### PR DESCRIPTION
Implements #44: the SegWit witness commitment, the leaf `Block/Commitment.lean` deferred and the gap #43 documented in the fixture's authentication story.

## The leaf (`BtcVerified/Block/WitnessCommitment.lean`)

- `Block.witnessRoot` — the wtxid merkle root with the coinbase's leaf as the zero hash (its own witness sits beneath the commitment it carries, so BIP141 zeroes its slot; the coinbase stays bound by the txid tree).
- `witnessCommitment root reserved` — `sha256d(root ‖ reserved)`.
- `TxOut.isWitnessCommitment` / `Tx.recordedWitnessCommitment?` — output recognition (≥ 38 script bytes opening `6a24aa21a9ed`; bytes past 38 don't disqualify) and extraction, last match winning as in Core's `GetWitnessCommitmentIndex`.
- `Tx.witnessReservedValue?` — the single 32-byte item of the coinbase input's witness stack.
- `Block.witnessCommits` — the commitment condition, decidable so real blocks are checked against it. When a block is *required* to satisfy it is a consensus guard at the validity layer, exactly as `merkleCommits` states the condition and not the rule.

## Checked claims (all registered in the axiom audit)

- `witnessCommitment_binding`: equal commitments imply equal witness roots and equal reserved values — or two concrete byte strings witnessing a double-SHA-256 collision.
- `Block.witnessRoot_binding`: between blocks with equally many transactions, equal witness roots imply equal transactions beyond the coinbase, *witnesses included* — or a concrete collision. No canonicality condition is needed on the witness tree: the txid tree pins the transaction count, and at equal lengths `root_binding_of_length_eq` binds outright — the CVE-2012-2459 ambiguity needs room to change the leaf count. This makes the folklore argument for why Core never needed a witness-tree `mutated` check precise.
- `Block.witnessCommits_binding`: the composite — two blocks satisfying the condition that record the same commitment and have equally many transactions agree on every transaction beyond the coinbase, or exhibit a concrete collision. In consensus use both side conditions come from the txid tree via `merkleCommits`.
- `Tx.map_wtxid_binding` (in `Txid.lean`): the pointwise lift of `wtxid_binding` the merkle layer carries.

Division of labor, now theorem-shaped: the txid tree binds every body and misses exactly the witnesses; the witness tree binds every witness except the coinbase's own — which is the reserved value, sitting in the commitment preimage. Together the two commitments cover every byte of a block.

## Vectors

- Inline `#guard`s: the activation coinbase's real commitment output and reserved value (the 32 bytes after `6a24aa21a9ed`, read straight out of the existing `segwitCoinbaseHex`), plus synthetic recognition vectors — minimum length (37 bytes fails), exact header, trailing bytes allowed, last-match-wins, and none-on-pre-SegWit-blocks.
- The block 481824 fixture now runs `decide b.witnessCommits` over all 1866 transactions, upgrading `lake test` to authenticating **every byte** of the download up to double-SHA-256 collisions — the fixture header and comments now state that as fact rather than as the deferred gap #43 documented.

## Verification

`lake build` (824 jobs, includes the new `#guard`s and audit lines), `lake lint`, and `lake test` (block 481824: decoded, header hash verified, spot-checked — including the new witness-commitment check — re-encoded byte-for-byte) all pass.

Closes #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)